### PR TITLE
Add collapse, interleave/interleave_longest, append/prepend.

### DIFF
--- a/more_itertools/tests/test_more.py
+++ b/more_itertools/tests/test_more.py
@@ -124,3 +124,46 @@ class ConsumerTests(TestCase):
 def test_ilen():
     """Sanity-check ``ilen()``."""
     eq_(ilen(ifilter(lambda x: x % 10 == 0, range(101))), 11)
+
+class TestAppendPrepend(TestCase):
+    """Tests for ``append()`` and ``prepend()``"""
+    def test_append(self):
+        eq_(list(append(range(5), 5)), list(range(6)))
+    def test_prepend(self):
+        eq_(list(prepend(range(5), -1)), list(range(-1, 5)))
+
+class TestInterleave(TestCase):
+    """Tests for ``interleave()`` and ``interleave_longest()``"""
+    def test_interleave(self):
+        l = [[1, 2, 3], [4, 5], [6, 7, 8]]
+        eq_(list(interleave(*l)), [1, 4, 6, 2, 5, 7])
+        l = [[1, 2], [3, 4, 5], [6, 7, 8]]
+        eq_(list(interleave(*l)), [1, 3, 6, 2, 4, 7])
+        l = [[1, 2, 3], [4, 5, 6], [7, 8]]
+        eq_(list(interleave(*l)), [1, 4, 7, 2, 5, 8])
+    def test_interleave_longest(self):
+        l = [[1, 2, 3], [4, 5], [6, 7, 8]]
+        eq_(list(interleave_longest(*l)), [1, 4, 6, 2, 5, 7, 3, 8])
+        l = [[1, 2], [3, 4, 5], [6, 7, 8]]
+        eq_(list(interleave_longest(*l)), [1, 3, 6, 2, 4, 7, 5, 8])
+        l = [[1, 2, 3], [4, 5, 6], [7, 8]]
+        eq_(list(interleave_longest(*l)), [1, 4, 7, 2, 5, 8, 3, 6])
+
+class TestCollapse(TestCase):
+    def test_collapse(self):
+        l = [[1], 2, [[3], 4], [[[5]]]]
+        eq_(list(collapse(l)), [1, 2, 3, 4, 5])
+    def test_collapse_to_string(self):
+        l = [["s1"], "s2", [["s3"], "s4"], [[["s5"]]]] 
+        eq_(list(collapse(l)), ["s1", "s2", "s3", "s4", "s5"])
+    def test_collapse_flatten(self):
+        l = [[1], [2], [[3], 4], [[[5]]]]
+        eq_(list(collapse(l, levels=1)), list(flatten(l)))
+    def test_collapse_to_level(self):
+        l = [[1], 2, [[3], 4], [[[5]]]]
+        eq_(list(collapse(l, levels=2)), [1, 2, 3, 4, [5]])
+        eq_(list(collapse(collapse(l, levels=1), levels=1)),
+            list(collapse(l, levels=2)))
+    def test_collapse_to_list(self):
+        l = (1, [2], (3, [4, (5,)]))
+        eq_(list(collapse(l, basetype=list)), [1, [2], 3, [4, (5,)]])


### PR DESCRIPTION
Five new functions, all inspired by StackOverflow questions.

`collapse(iterable, basetype=None, levels=None)`

A multi-level `flatten`. Collapse a hierarchical iterator all the way down to strings and non-iterables (and instances of `basetype`, if given, which can be a type or a tuple), or down `levels` levels. People on SO keep asking "how do I flatten up to N levels instead of exactly N", or "how do I flatten iterators but not lists", or "why does my flatten screw up my strings". Rather than writing separate solutions for each, this is an all-singing-all-dancing-flatten-everything implementation.

`interleave(*iterables)` and `interleave_longest(*iterables)`

Like `flatten(zip(*iterables))` and `flatten(zip_longest(*iterables))`, except that `iterate_longest` skips missing entries instead of filling with None.

`append(iterable, value)` and `prepend(iterable, value)`

Yields from iterable, then yields value, or vice-versa. Only worth including because I tested every way I could think of to implement this, and using `chain(iterable, [value])` is by far the most efficient, which surprised someone on SO who kept arguing that it was a huge waste to build a length-1 list.

Unlike my previous pull requests, this time I found your unit tests and added tests for them. (But the "python3 setup.py test" doesn't work, because it tries to test the non-2to3 version.) I didn't go back and write tests for my other patches, because I'd have to cancel my pull requests, patch up each branch separately, submit new pull requests, and re-merge my fork's master, but if you want me to, I can.
