### PR TITLE
new function - always iterable

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -8,6 +8,7 @@ API Reference
 New Routines
 ============
 
+.. autofunction:: always_iterable
 .. autofunction:: chunked
 .. autofunction:: collate(*iterables, key=lambda a: a, reverse=False)
 .. autofunction:: consumer

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -252,8 +252,8 @@ def always_iterable(item):
     >>> always_iterable(None)
     ()
 
-    >>> always_iterable(range(10))
-    range(0, 10)
+    >>> always_iterable(xrange(10))
+    xrange(10)
 
     >>> def _test_func(): yield "I'm iterable"
     >>> print(next(always_iterable(_test_func())))

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -249,6 +249,9 @@ def always_iterable(item):
     >>> always_iterable('foo')
     ('foo',)
 
+    >>> always_iterable(b'foo') == (b'foo',)
+    True
+
     >>> always_iterable(None)
     ()
 

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -269,6 +269,7 @@ def always_iterable(item):
     """
     if item is None:
         item = ()
-    if isinstance(item, six.string_types) or not hasattr(item, '__iter__'):
+    string_types = unicode, str
+    if isinstance(item, string_types) or not hasattr(item, '__iter__'):
         item = item,
     return item

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -3,7 +3,7 @@ from itertools import izip_longest
 from recipes import *
 
 __all__ = ['chunked', 'first', 'peekable', 'collate', 'consumer', 'ilen',
-           'iterate', 'with_iter']
+           'iterate', 'with_iter', 'always_iterable']
 
 
 _marker = object()
@@ -235,3 +235,40 @@ def with_iter(context_manager):
     with context_manager as iterable:
         for item in iterable:
             yield item
+
+
+def always_iterable(item):
+    """
+    Given an object, always return an iterable. If the item is not
+    already iterable, return a tuple containing only the item. If item is
+    None, an empty iterable is returned. Strings are not considered iterable.
+
+    >>> always_iterable([1,2,3])
+    [1, 2, 3]
+
+    >>> always_iterable('foo')
+    ('foo',)
+
+    >>> always_iterable(None)
+    ()
+
+    >>> always_iterable(range(10))
+    range(0, 10)
+
+    >>> def _test_func(): yield "I'm iterable"
+    >>> print(next(always_iterable(_test_func())))
+    I'm iterable
+
+    This function is particularly useful in simplifying the case where a
+    parameter could be iterable but may be None or a single value:
+
+        def process_codes(code):
+            "code may be None, str, or list of strings"
+            for item in always_iterable(code):
+                process(item)
+    """
+    if item is None:
+        item = ()
+    if isinstance(item, six.string_types) or not hasattr(item, '__iter__'):
+        item = item,
+    return item

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -272,7 +272,7 @@ def always_iterable(item):
     """
     if item is None:
         item = ()
-    string_types = unicode, str
+    string_types = unicode, bytes
     if isinstance(item, string_types) or not hasattr(item, '__iter__'):
         item = item,
     return item


### PR DESCRIPTION
The `always_iterable` function is one of my favorite functions. I use it time and time again in unexpected scenarios.

Often, when a parameter is allowed to be a string or None, but also an iterable, one has to set up a series of tests and transformation. Using always_iterable means the logic can be greatly simplified and more intuitive, simply iterating over the (possibly empty) result.

I've tried to communicate this value in the docstring.

I've also back-ported it to support Python 2.7 first without six.
