### PR TITLE
Add unique_from_each() function

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -18,7 +18,7 @@ New Routines
 .. autofunction:: iterate
 .. autofunction:: one
 .. autoclass:: peekable
-.. autofunction:: unique_from_each
+.. autofunction:: unique_to_each
 .. autofunction:: with_iter
 
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -18,6 +18,7 @@ New Routines
 .. autofunction:: iterate
 .. autofunction:: one
 .. autoclass:: peekable
+.. autofunction:: unique_from_each
 .. autofunction:: with_iter
 
 

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -6,7 +6,7 @@ from recipes import *
 
 __all__ = ['chunked', 'first', 'peekable', 'collate', 'consumer', 'ilen',
            'iterate', 'with_iter', 'one', 'distinct_permutations',
-           'intersperse', 'unique_from_each']
+           'intersperse', 'unique_to_each']
 
 
 _marker = object()
@@ -335,18 +335,28 @@ def intersperse(e, iterable):
     raise StopIteration
 
 
-def unique_from_each(*iterables):
+def unique_to_each(*iterables):
     """
     Return the elements from each of the input iterables that aren't in the
     other input iterables.
-    
+
+    For example, suppose packages 1, 2, and 3 have these dependencies:
+    pkg_1: (A, B), pkg_2: (B, C), pkg_3: (B, D)
+
+    If you remove one package, which dependencies can also be removed?
+
+    If pkg_1 is removed, then A is no longer necessary - it is not associated
+    with pkg_2 or pkg_3. Similarly, C is only needed for pkg_2, and D is
+    only needed for pkg_3:
+    >>> unique_to_each("AB", "BC", "BD")
+    [['A'], ['C'], ['D']]
+
     If there are duplicates in one input iterable that aren't in the others
-    they will be duplicated in the output. Input order is preserved.
-    
-    >>> unique_from_each("hello", "world")
-    [['h', 'e'], ['w', 'r', 'd']]
-    >>> unique_from_each("mississippi", "missouri")
+    they will be duplicated in the output. Input order is preserved:
+    >>> unique_to_each("mississippi", "missouri")
     [['p', 'p'], ['o', 'u', 'r']]
+    
+    It is assumed that the elements of each iterable are hashable.
     """
     ret = []
     pool = [tuple(it) for it in iterables]
@@ -354,7 +364,8 @@ def unique_from_each(*iterables):
         super_list = list(chain(*pool))
         for element in it:
             super_list.remove(element)
-        uniques = [element for element in it if element not in super_list]
+        super_set = set(super_list)
+        uniques = [element for element in it if element not in super_set]
         ret.append(uniques)
     
     return ret

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -1,12 +1,12 @@
 from __future__ import print_function
 
 from functools import partial, wraps
-from itertools import izip_longest
+from itertools import chain, izip_longest
 from recipes import *
 
 __all__ = ['chunked', 'first', 'peekable', 'collate', 'consumer', 'ilen',
            'iterate', 'with_iter', 'one', 'distinct_permutations',
-           'intersperse']
+           'intersperse', 'unique_from_each']
 
 
 _marker = object()
@@ -333,3 +333,28 @@ def intersperse(e, iterable):
             yield e
             yield item
     raise StopIteration
+
+
+def unique_from_each(*iterables):
+    """
+    Return the elements from each of the input iterables that aren't in the
+    other input iterables.
+    
+    If there are duplicates in one input iterable that aren't in the others
+    they will be duplicated in the output. Input order is preserved.
+    
+    >>> unique_from_each("hello", "world")
+    [['h', 'e'], ['w', 'r', 'd']]
+    >>> unique_from_each("mississippi", "missouri")
+    [['p', 'p'], ['o', 'u', 'r']]
+    """
+    ret = []
+    pool = [tuple(it) for it in iterables]
+    for it in pool:
+        super_list = list(chain(*pool))
+        for element in it:
+            super_list.remove(element)
+        uniques = [element for element in it if element not in super_list]
+        ret.append(uniques)
+    
+    return ret

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -1,7 +1,7 @@
 from __future__ import print_function
 
 from functools import partial, wraps
-from itertools import chain, izip_longest
+from itertools import izip_longest
 from recipes import *
 
 __all__ = ['chunked', 'first', 'peekable', 'collate', 'consumer', 'ilen',
@@ -358,14 +358,16 @@ def unique_to_each(*iterables):
     
     It is assumed that the elements of each iterable are hashable.
     """
-    ret = []
-    pool = [tuple(it) for it in iterables]
-    for it in pool:
-        super_list = list(chain(*pool))
+    elements_to_indices = {}
+    pool = [list(it) for it in iterables]
+    for i, it in enumerate(pool):
         for element in it:
-            super_list.remove(element)
-        super_set = set(super_list)
-        uniques = [element for element in it if element not in super_set]
-        ret.append(uniques)
+            elements_to_indices.setdefault(element, set()).add(i)
     
-    return ret
+    for element, indices in elements_to_indices.iteritems():
+        if len(indices) != 1:
+            for i in indices:
+                while element in pool[i]:
+                    pool[i].remove(element)
+
+    return pool

--- a/more_itertools/tests/test_more.py
+++ b/more_itertools/tests/test_more.py
@@ -162,7 +162,6 @@ def test_one():
     eq_(next(numbers), 2)
 
 
-
 class IntersperseTest(TestCase):
     """ Tests for intersperse() """
 
@@ -192,3 +191,25 @@ class IntersperseTest(TestCase):
         assert next(itp) == 0
         assert next(itp) == 'x'
         assert next(itp) == 1
+
+
+class UniqueFromEachTests(TestCase):
+    """Tests for ``unique_from_each()``"""
+    
+    def test_all_unique(self):
+        """When all the input iterables are unique the output should match
+        the input."""
+        iterables = [[1, 2], [3, 4, 5], [6, 7, 8]]
+        eq_(unique_from_each(*iterables), iterables)
+    
+    def test_duplicates(self):
+        """When there are duplicates in any of the input iterables that aren't
+        in the rest, those duplicates should be emitted."""
+        iterables = ["mississippi", "missouri"]
+        eq_(unique_from_each(*iterables), [['p', 'p'], ['o', 'u', 'r']])
+    
+    def test_mixed(self):
+        """When the input iterables contain different types the function should
+        still behave properly"""
+        iterables = ['x', (i for i in range(3)), [1, 2, 3], tuple()]
+        eq_(unique_from_each(*iterables), [['x'], [0], [3], []])

--- a/more_itertools/tests/test_more.py
+++ b/more_itertools/tests/test_more.py
@@ -193,23 +193,23 @@ class IntersperseTest(TestCase):
         assert next(itp) == 1
 
 
-class UniqueFromEachTests(TestCase):
-    """Tests for ``unique_from_each()``"""
+class UniqueToEachTests(TestCase):
+    """Tests for ``unique_to_each()``"""
     
     def test_all_unique(self):
         """When all the input iterables are unique the output should match
         the input."""
         iterables = [[1, 2], [3, 4, 5], [6, 7, 8]]
-        eq_(unique_from_each(*iterables), iterables)
+        eq_(unique_to_each(*iterables), iterables)
     
     def test_duplicates(self):
         """When there are duplicates in any of the input iterables that aren't
         in the rest, those duplicates should be emitted."""
         iterables = ["mississippi", "missouri"]
-        eq_(unique_from_each(*iterables), [['p', 'p'], ['o', 'u', 'r']])
+        eq_(unique_to_each(*iterables), [['p', 'p'], ['o', 'u', 'r']])
     
     def test_mixed(self):
         """When the input iterables contain different types the function should
         still behave properly"""
         iterables = ['x', (i for i in range(3)), [1, 2, 3], tuple()]
-        eq_(unique_from_each(*iterables), [['x'], [0], [3], []])
+        eq_(unique_to_each(*iterables), [['x'], [0], [3], []])


### PR DESCRIPTION
Some months after answering [this](http://stackoverflow.com/questions/17035577/unique-features-between-multiple-lists/17035741#17035741) question at StackOverflow, I had a need for a function that would give me the unique items from a list of lists.

Here are some examples:

``` python
>>> unique_from_each("mississippi", "missouri")
[['p', 'p'], ['o', 'u', 'r']]
>>> unique_from_each("mississippi", "missouri", "russian")
[['p', 'p'], ['o'], ['a', 'n']]
```

`mississippi` and `missouri` both have an `m`, some instances of `i`, and some instances of `s`. The former doesn't have an `o`, a `u`, or an `r`, though. And the latter doesn't have a `p`, let alone two.

If we add `russian` to the mix, there's no additional overlap with `mississippi`, but it shares `r` and `u` with `missouri`. It's the only one with an `n`.

Other notes:
- For my application I needed order and duplicates to be preserved
- This will exhaust any iterators given to it, but that's typical in itertools
- This does a linear search of the concatenation of all the input iterables; could make that a set to speed up searching for long inputs if desired

It seems itertools-y, so I'd like to submit it to be considered for more-itertools.
