### PR TITLE
Fix: variable `p` overrides previous definition

### DIFF
--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -167,7 +167,7 @@ def collate(*iterables, **kwargs):
     while peekables:
         _, p = min_or_max((key(p.peek()), p) for p in peekables)
         yield p.next()
-        peekables = [p for p in peekables if p]
+        peekables = list(p for p in peekables if p)
 
 
 def consumer(func):


### PR DESCRIPTION
In Python 2.x, the loop variable from a list comprehension bleeds into the calling context, overriding local `p` in this case.
