### PR TITLE
Add new itertool: `side_effect()`

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -18,6 +18,7 @@ New Routines
 .. autofunction:: iterate
 .. autofunction:: one
 .. autoclass:: peekable
+.. autofunction:: side_effect
 .. autofunction:: with_iter
 
 

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -350,19 +350,19 @@ def side_effect(fn, iterable):
     Examples:
 
         >>> from more_itertools import take, consume, side_effect
-        >>> iterable = take(3, range(10))
+        >>> iterable = range(10)
         >>> iterable = side_effect(print, iterable)
-        >>> consume(iterable)
+        >>> consume(take(3, iterable))
         0
         1
         2
 
     Example for collecting data as it streams through:
 
-        >>> iterable = take(3, range(10))
+        >>> iterable = range(10)
         >>> c = []
         >>> iterable = side_effect(c.append, iterable)
-        >>> consume(iterable)
+        >>> consume(take(3, iterable))
         >>> c
         [0, 1, 2]
 

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -6,7 +6,7 @@ from recipes import *
 
 __all__ = ['chunked', 'first', 'peekable', 'collate', 'consumer', 'ilen',
            'iterate', 'with_iter', 'one', 'distinct_permutations',
-           'intersperse']
+           'intersperse', 'side_effect']
 
 
 _marker = object()
@@ -241,6 +241,7 @@ def with_iter(context_manager):
         for item in iterable:
             yield item
 
+
 def one(iterable):
     """Return the only element from the iterable.
 
@@ -333,3 +334,39 @@ def intersperse(e, iterable):
             yield e
             yield item
     raise StopIteration
+
+
+def side_effect(fn, iterable):
+    """
+    Passes through the iterable, but invokes a function for each item
+    iterated over.
+
+    Can be useful for lazy counting, logging, collecting data, or updating
+    progress bars, anything un-pure.
+
+    `fn` must be a function that takes a single argument.  Its return value
+    will be discarded.
+
+    Examples:
+
+        >>> from more_itertools import take, consume, side_effect
+        >>> iterable = take(3, range(10))
+        >>> iterable = side_effect(print, iterable)
+        >>> consume(iterable)
+        0
+        1
+        2
+
+    Example for collecting data as it streams through:
+
+        >>> iterable = take(3, range(10))
+        >>> c = set()
+        >>> iterable = side_effect(c.add, iterable)
+        >>> consume(iterable)
+        >>> sorted(c)
+        [0, 1, 2]
+
+    """
+    for item in iterable:
+        fn(item)
+        yield item

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -360,10 +360,10 @@ def side_effect(fn, iterable):
     Example for collecting data as it streams through:
 
         >>> iterable = take(3, range(10))
-        >>> c = set()
-        >>> iterable = side_effect(c.add, iterable)
+        >>> c = []
+        >>> iterable = side_effect(c.append, iterable)
         >>> consume(iterable)
-        >>> sorted(c)
+        >>> c
         [0, 1, 2]
 
     """


### PR DESCRIPTION
Passes through the iterable, but invokes a function for each item iterated over.

Can be useful for lazy counting, logging, collecting data, or updating progress bars, anything un-pure.

`fn` must be a function that takes a single argument.  Its return value will be discarded.

Examples:

```
>>> from more_itertools import take, consume, side_effect
>>> iterable = range(10)
>>> iterable = side_effect(print, iterable)
>>> consume(take(3, iterable))
0
1
2
```

Example for collecting data as it streams through:

```
>>> iterable = range(10)
>>> c = set()
>>> iterable = side_effect(c.add, iterable)
>>> consume(take(3, iterable))
>>> sorted(c)
[0, 1, 2]
```

**EDIT:** I've updated the function to support emitting side effects for chunks. This is useful because you can still process the result as a continuous stream, making chaining much easier.  It basically saves you from the ceremony of otherwise having to do this:

```
>>> iterable = range(100)
>>> iterable = chunked(iterable, 30)
>>> iterable = side_effect(do_something_with_chunk, iterable)
>>> iterable = flatten(iterable)
>>> list(iterable)
[0, 1, 2, 3, ..., 99, 100]
```
