### PR TITLE
Switch to pytest (because nose hides problems)

### DIFF
--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -2,23 +2,15 @@
 Testing
 =======
 
-more-itertools uses nose for its tests. First, install nose::
-
-    pip install nose
-
-Then, run the tests like this::
-
-    nosetests --with-doctest
-
-
-Multiple Python Versions
-========================
-
-To run the tests on all the versions of Python more-itertools supports, install
-tox::
+To run the tests on all the versions of Python more-itertools supports,
+install tox::
 
     pip install tox
 
 Then, run the tests::
 
     tox
+
+To run it on a single env, use::
+
+    tox -e py27

--- a/more_itertools/tests/test_more.py
+++ b/more_itertools/tests/test_more.py
@@ -1,11 +1,19 @@
 from contextlib import closing
-from itertools import count, islice, ifilter, permutations
+from itertools import count, ifilter, islice, permutations
 from StringIO import StringIO
 from unittest import TestCase
 
-from nose.tools import eq_, assert_raises
-
+import pytest
 from more_itertools import *  # Test all the symbols are in __all__.
+
+
+def eq_(lhs, rhs):
+    assert lhs == rhs
+
+
+def assert_raises(exc_class, f, *args, **kwargs):
+    with pytest.raises(exc_class):
+        f(*args, **kwargs)
 
 
 class CollateTests(TestCase):

--- a/more_itertools/tests/test_recipes.py
+++ b/more_itertools/tests/test_recipes.py
@@ -1,13 +1,25 @@
 from random import seed
 from unittest import TestCase
 
-from nose.tools import eq_, assert_raises, ok_
-
+import pytest
 from more_itertools import *
 
 
 def setup_module():
     seed(1337)
+
+
+def eq_(lhs, rhs):
+    assert lhs == rhs
+
+
+def ok_(expr):
+    assert expr
+
+
+def assert_raises(exc_class, f, *args, **kwargs):
+    with pytest.raises(exc_class):
+        f(*args, **kwargs)
 
 
 class TakeTests(TestCase):

--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,3 @@
-# Hack to prevent stupid error on exit of `python setup.py test`. (See
-# http://www.eby-sarna.com/pipermail/peak/2010-May/003357.html.)
-try:
-    import multiprocessing
-except ImportError:
-    pass
-
 import sys
 
 from setuptools import setup, find_packages
@@ -26,8 +19,6 @@ setup(
     author_email='erikrose@grinchcentral.com',
     license='MIT',
     packages=find_packages(exclude=['ez_setup']),
-    tests_require=['nose'],
-    test_suite='nose.collector',
     url='https://github.com/erikrose/more-itertools',
     include_package_data=True,
     classifiers=[

--- a/tox.ini
+++ b/tox.ini
@@ -2,6 +2,9 @@
 [tox]
 envlist = py26, py27, py33, py34, pypy
 
+[pytest]
+addopts = --doctest-modules
+
 [testenv]
-commands = py.test more_itertools --doctest-modules
+commands = py.test more_itertools {posargs}
 deps = pytest

--- a/tox.ini
+++ b/tox.ini
@@ -3,6 +3,5 @@
 envlist = py26, py27, py33, py34, pypy
 
 [testenv]
-commands = nosetests more_itertools --with-doctest
-deps = nose
-changedir = .tox  # So Python 3 runs don't pick up incompatible, un-2to3'd source from the cwd
+commands = py.test more_itertools --doctest-modules
+deps = pytest

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 # Python 3.1 and 3.0 might work as well
 [tox]
-envlist = py26, py27, py32
+envlist = py26, py27, py33, py34, pypy
 
 [testenv]
 commands = nosetests more_itertools --with-doctest


### PR DESCRIPTION
Disclaimer: there is a reason, other than personal taste, for this change.
#### The problem with nose

When I was running the test suite on Python 3 (using the tox + nose setup), I was quite puzzled why the tests were passing even though [this line is present in `more.py`](https://github.com/erikrose/more-itertools/blob/master/more_itertools/more.py#L4), and `izip_longest` isn't in the `itertools` package anymore in Python 3.

After diving into it a bit more, I found that adding this line _would_ break the tests.

```
from itertools import izip_longest
print(izip_longest)  # use the imported function to expose the problem
```

Strangest, the tests don't fail with an `ImportError`, but instead with an `NameError` on the `print(izip_longest)` line. Following the stack trace, nose seems to be doing some import magic which I haven't fully grasped yet. Strangely enough, the `chunked` tests (which depend on `izip_longest`) _don't_ fail: o_O ?
#### Using pytest instead

This patch changes the test runner to `py.test` instead, which does not showcase said behaviour and fails for Python 3 in the expected way:

```
more_itertools/more.py:4: in <module>
    from itertools import izip_longest
E   ImportError: cannot import name 'izip_longest'
```

Note that I've simply wrapped the `eq_`, `ok_`, and `assert_raises` helpers for now. If you agree with this patch, I'll make sure to rewrite all the invocations directly, replacing them by plain `assert`s, and get rid of the wrapper functions.

Also, I would love to fix the now-exposed Python 3 errors, but I'll wait until after we've decided on this pull request.

@erikrose What do you think?
