### PR TITLE
Add iter_chunked(iterable, n) function.

### DIFF
--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -46,14 +46,21 @@ def iter_chunked(iterable, n):
         >>> list(next(chunk) for chunk in iter_chunked((xrange(1, 8)), 3))
         [1, 4, 7]
 
+        >>> list(iter_chunked([1, 2, 3], 0))
+        []
+
     If the length of ``iterable`` is not evenly divisible by ``n``, the last
     returned list will be shorter.
+    If ``n`` <= 0, no chunk will be generated.
 
     It is not necessary to retrieve all the items from the chunk. If the chunk
     is advanced and there are unfetched items in the last chunk, these will be
     automatically consumed.
 
     """
+    if n <= 0:
+        raise StopIteration
+
     iterable_peekable = peekable(iterable)
     while iterable_peekable:
         chunk = islice(iterable_peekable, n)

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -1,12 +1,12 @@
 from __future__ import print_function
 
 from functools import partial, wraps
-from itertools import izip_longest
+from itertools import izip_longest, islice
 from recipes import *
 
-__all__ = ['chunked', 'first', 'peekable', 'collate', 'consumer', 'ilen',
-           'iterate', 'with_iter', 'one', 'distinct_permutations',
-           'intersperse']
+__all__ = ['chunked', 'iter_chunked', 'first', 'peekable', 'collate',
+           'consumer', 'ilen', 'iterate', 'with_iter', 'one',
+           'distinct_permutations', 'intersperse']
 
 
 _marker = object()
@@ -35,6 +35,31 @@ def chunked(iterable, n):
             # If this is the last group, shuck off the padding:
             del group[group.index(_marker):]
         yield group
+
+
+def iter_chunked(iterable, n):
+    """Break an iterable into iterable chunks of a given length::
+
+        >>> list(map(list, iter_chunked([1, 2, 3, 4, 5, 6, 7], 3)))
+        [[1, 2, 3], [4, 5, 6], [7]]
+
+        >>> list(next(chunk) for chunk in iter_chunked((xrange(1, 8)), 3))
+        [1, 4, 7]
+
+    If the length of ``iterable`` is not evenly divisible by ``n``, the last
+    returned list will be shorter.
+
+    It is not necessary to retrieve all the items from the chunk. If the chunk
+    is advanced and there are unfetched items in the last chunk, these will be
+    automatically consumed.
+
+    """
+    iterable_peekable = peekable(iterable)
+    while iterable_peekable:
+        chunk = islice(iterable_peekable, n)
+        yield chunk
+
+        consume(chunk)
 
 
 def first(iterable, default=_marker):

--- a/more_itertools/tests/test_more.py
+++ b/more_itertools/tests/test_more.py
@@ -91,6 +91,12 @@ class IterChunkedTests(TestCase):
             [[0, 1], [3, 4], [6, 7], [9]]
         )
 
+    def test_invalid_n(self):
+        """It shouldn't generate anything for ``n`` <= 0."""
+        eq_(list(iter_chunked([1, 2, 3], 0)), [])
+
+        eq_(list(iter_chunked([1, 2, 3], -1)), [])
+
 
 class FirstTests(TestCase):
     """Tests for ``first()``"""

--- a/more_itertools/tests/test_more.py
+++ b/more_itertools/tests/test_more.py
@@ -57,6 +57,41 @@ class ChunkedTests(TestCase):
         eq_(list(chunked('ABCDE', 3)), [['A', 'B', 'C'], ['D', 'E']])
 
 
+class IterChunkedTests(TestCase):
+    """Tests for ``iter_chunked()``"""
+
+    def test_even(self):
+        """Test when ``n`` divides evenly into the length of the iterable."""
+        eq_(
+            list(list(chunk) for chunk in iter_chunked('ABCDEF', 3)),
+            [['A', 'B', 'C'], ['D', 'E', 'F']]
+        )
+
+    def test_odd(self):
+        """Test when ``n`` does not divide evenly into the length of the
+        iterable.
+
+        """
+        eq_(
+            list(list(chunk) for chunk in iter_chunked('ABCDE', 3)),
+            [['A', 'B', 'C'], ['D', 'E']]
+        )
+
+    def test_consume_unfetched_items(self):
+        """Test that remaining items of a chunk are correctly consumed
+        when a new chunk is fetched.
+
+        """
+        generator = (i for i in xrange(10))
+
+        chunks = iter_chunked(generator, 3)
+
+        eq_(
+            list(take(2, chunk) for chunk in chunks),
+            [[0, 1], [3, 4], [6, 7], [9]]
+        )
+
+
 class FirstTests(TestCase):
     """Tests for ``first()``"""
 


### PR DESCRIPTION
This is an iterable version of `chunked`. It automatically discards items of a chunk if a new one is fetched.

This function is particularly useful when the `n` parameter is large, since it does not need to store the elements in a list, like `chunked` does.
