### PR TITLE
Fix "F812 list comprehension redefines 'p' from line 168"

### DIFF
--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -167,7 +167,7 @@ def collate(*iterables, **kwargs):
     while peekables:
         _, p = min_or_max((key(p.peek()), p) for p in peekables)
         yield p.next()
-        peekables = [p for p in peekables if p]
+        peekables = list(p for p in peekables if p)
 
 
 def consumer(func):

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -167,7 +167,7 @@ def collate(*iterables, **kwargs):
     while peekables:
         _, p = min_or_max((key(p.peek()), p) for p in peekables)
         yield p.next()
-        peekables = list(p for p in peekables if p)
+        peekables = [x for x in peekables if x]
 
 
 def consumer(func):


### PR DESCRIPTION
@nvie points out in PR #49 that there's a redefinition of a variable in the `first` recipe. This PR builds on that one to fix the issue (which is detected by, e.g. flake8).