### PR TITLE
3.5 friendliness

### DIFF
--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -1,7 +1,8 @@
 from __future__ import print_function
 
 from functools import partial, wraps
-from recipes import take
+
+from .recipes import take
 
 __all__ = ['chunked', 'first', 'peekable', 'collate', 'consumer', 'ilen',
            'iterate', 'with_iter', 'one', 'distinct_permutations',

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -266,8 +266,16 @@ def one(iterable):
     iterable longer than 1 item is, in fact, an error.
 
     """
-    result, = iterable
-    return result
+    it = iter(iterable)
+    first = next(it, _marker)
+    if first is _marker:
+        raise ValueError('need more than 0 values to unpack')
+
+    second = next(it, _marker)
+    if second is not _marker:
+        raise ValueError('too many values to unpack (expected 1)')
+
+    return first
 
 
 def distinct_permutations(iterable):

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 # Python 3.1 and 3.0 might work as well
 [tox]
-envlist = py26, py27, py32
+envlist = py26, py27, py32, py34, py35
 
 [testenv]
 commands = nosetests more_itertools --with-doctest


### PR DESCRIPTION
This PR fixes two Python 3 compatibility items to fix tests on master.
* An old-style import in `more`
* An outdated iterable unpacking method in `more.one`

I'll be switching away from 2to3 in another PR.