### PR TITLE
Replace tox with Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,20 @@
+sudo: false
+
+language: "python"
+
+python:
+    - "2.7"
+    - "3.3"
+    - "3.4"
+    - "3.5"
+
+install:
+    - "pip install -U nose"
+    - "pip install -e ."
+
+script:
+    - "mkdir -p build && cd build"
+    - "nosetests more_itertools --with-doctest"
+
+notifications:
+  email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,12 +9,10 @@ python:
     - "3.5"
 
 install:
-    - "pip install -U nose"
-    - "pip install -e ."
+    - "pip install -U nose tox tox-travis"
 
 script:
-    - "mkdir -p build && cd build"
-    - "nosetests more_itertools --with-doctest"
+    - "tox"
 
 notifications:
   email: false

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -5,3 +5,4 @@ include docs/Makefile
 include docs/make.bat
 include docs/conf.py
 include fabfile.py
+include tox.ini

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -5,4 +5,3 @@ include docs/Makefile
 include docs/make.bat
 include docs/conf.py
 include fabfile.py
-include tox.ini

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,8 @@
+# Python 3.1 and 3.0 might work as well
+[tox]
+envlist = py26, py27, py32, py34, py35
+
+[testenv]
+commands = nosetests more_itertools --with-doctest
+deps = nose
+changedir = .tox  # So Python 3 runs don't pick up incompatible, un-2to3'd source from the cwd

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,6 @@
 envlist = py27, py32, py34, py35
 
 [tox:travis]
-2.6 = py26
 2.7 = py27
 3.3 = py33
 3.4 = py34

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,0 @@
-# Python 3.1 and 3.0 might work as well
-[tox]
-envlist = py26, py27, py32, py34, py35
-
-[testenv]
-commands = nosetests more_itertools --with-doctest
-deps = nose
-changedir = .tox  # So Python 3 runs don't pick up incompatible, un-2to3'd source from the cwd

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,12 @@
-# Python 3.1 and 3.0 might work as well
 [tox]
-envlist = py26, py27, py32, py34, py35
+envlist = py27, py32, py34, py35
+
+[tox:travis]
+2.6 = py26
+2.7 = py27
+3.3 = py33
+3.4 = py34
+3.5 = py35
 
 [testenv]
 commands = nosetests more_itertools --with-doctest


### PR DESCRIPTION
This PR replaces tox with Travis. Travis will do automatic testing against Python 2.7, 3.3, 3.4, and 3.5.

I didn't add Python 2.6 to the test list, since I'll be dropping Python 2.6 from `setup.py` [soon](https://twitter.com/ErikRose/status/794369557934866433).