### PR TITLE
Drop 2to3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,28 @@
+*.py[co]
+
+# Packages
+*.egg
+*.egg-info
+dist
+build
+eggs
+parts
+bin
+var
+sdist
+develop-eggs
+.installed.cfg
+
+# Installer logs
+pip-log.txt
+
+# Unit test / coverage reports
+.coverage
 .tox
-*.pyc
+.noseids
+
+# Docs by Sphinx
+_build
+
+# Environment
+.env

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -248,6 +248,7 @@ def with_iter(context_manager):
         for item in iterable:
             yield item
 
+
 def one(iterable):
     """Return the only element from the iterable.
 

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -74,11 +74,11 @@ class peekable(object):
         >>> p = peekable(xrange(2))
         >>> p.peek()
         0
-        >>> p.next()
+        >>> next(p)
         0
         >>> p.peek()
         1
-        >>> p.next()
+        >>> next(p)
         1
 
     Pass ``peek()`` a default value, and it will be returned in the case where
@@ -123,17 +123,21 @@ class peekable(object):
         """
         if not hasattr(self, '_peek'):
             try:
-                self._peek = self._it.next()
+                self._peek = next(self._it)
             except StopIteration:
                 if default is _marker:
                     raise
                 return default
         return self._peek
 
-    def next(self):
+    def __next__(self):
         ret = self.peek()
         del self._peek
         return ret
+
+    def next(self):
+        # For Python 2 compatibility
+        return self.__next__()
 
 
 def collate(*iterables, **kwargs):
@@ -165,7 +169,7 @@ def collate(*iterables, **kwargs):
     peekables = [p for p in peekables if p]  # Kill empties.
     while peekables:
         _, p = min_or_max((key(p.peek()), p) for p in peekables)
-        yield p.next()
+        yield next(p)
         peekables = [x for x in peekables if x]
 
 
@@ -187,14 +191,14 @@ def consumer(func):
     >>> t.send('fish')
     Thing number 1 is fish.
 
-    Without the decorator, you would have to call ``t.next()`` before
+    Without the decorator, you would have to call ``next(t)`` before
     ``t.send()`` could be used.
 
     """
     @wraps(func)
     def wrapper(*args, **kwargs):
         gen = func(*args, **kwargs)
-        gen.next()
+        next(gen)
         return gen
     return wrapper
 

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -39,9 +39,9 @@ def chunked(iterable, n):
 def first(iterable, default=_marker):
     """Return the first item of an iterable, ``default`` if there is none.
 
-        >>> first(xrange(4))
+        >>> first([0, 1, 2, 3])
         0
-        >>> first(xrange(0), 'some default')
+        >>> first([], 'some default')
         'some default'
 
     If ``default`` is not provided and there are no items in the iterable,
@@ -71,7 +71,7 @@ class peekable(object):
     Call ``peek()`` on the result to get the value that will next pop out of
     ``next()``, without advancing the iterator:
 
-        >>> p = peekable(xrange(2))
+        >>> p = peekable([0, 1])
         >>> p.peek()
         0
         >>> next(p)
@@ -94,7 +94,7 @@ class peekable(object):
     To test whether there are more items in the iterator, examine the
     peekable's truth value. If it is truthy, there are more items.
 
-        >>> assert peekable(xrange(1))
+        >>> assert peekable([1])
         >>> assert not peekable([])
 
     """
@@ -209,8 +209,7 @@ def consumer(func):
 def ilen(iterable):
     """Return the number of items in ``iterable``.
 
-    >>> from itertools import ifilter
-    >>> ilen(ifilter(lambda x: x % 3 == 0, xrange(1000000)))
+    >>> ilen(x for x in range(1000000) if x % 3 == 0)
     333334
 
     This does, of course, consume the iterable, so handle it with care.

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -107,12 +107,15 @@ class peekable(object):
     def __iter__(self):
         return self
 
-    def __nonzero__(self):
+    def __bool__(self):
         try:
             self.peek()
         except StopIteration:
             return False
         return True
+
+    def __nonzero__(self):
+        return self.__bool__()
 
     def peek(self, default=_marker):
         """Return the item that will be next returned from ``next()``.

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -2,6 +2,8 @@ from __future__ import print_function
 
 from functools import partial, wraps
 
+from six import iteritems
+
 from .recipes import take
 
 __all__ = ['chunked', 'first', 'peekable', 'collate', 'consumer', 'ilen',
@@ -368,7 +370,7 @@ def unique_to_each(*iterables):
     they will be duplicated in the output. Input order is preserved:
     >>> unique_to_each("mississippi", "missouri")
     [['p', 'p'], ['o', 'u', 'r']]
-    
+
     It is assumed that the elements of each iterable are hashable.
     """
     elements_to_indices = {}
@@ -376,8 +378,8 @@ def unique_to_each(*iterables):
     for i, it in enumerate(pool):
         for element in it:
             elements_to_indices.setdefault(element, set()).add(i)
-    
-    for element, indices in elements_to_indices.iteritems():
+
+    for element, indices in iteritems(elements_to_indices):
         if len(indices) != 1:
             for i in indices:
                 while element in pool[i]:

--- a/more_itertools/recipes.py
+++ b/more_itertools/recipes.py
@@ -13,7 +13,7 @@ import operator
 from random import randrange, sample, choice
 
 from six import PY2
-from six.moves import filterfalse, map, zip, zip_longest
+from six.moves import filterfalse, map, range, zip, zip_longest
 
 __all__ = ['take', 'tabulate', 'consume', 'nth', 'quantify', 'padnone',
            'ncycles', 'dotproduct', 'flatten', 'repeatfunc', 'pairwise',
@@ -268,7 +268,7 @@ def iter_except(func, exception, first=None):
     Like __builtin__.iter(func, sentinel) but uses an exception instead
     of a sentinel to end the loop.
 
-        >>> l = range(3)
+        >>> l = [0, 1, 2]
         >>> list(iter_except(l.pop, IndexError))
         [2, 1, 0]
 
@@ -319,7 +319,7 @@ def random_combination(iterable, r):
     """
     pool = tuple(iterable)
     n = len(pool)
-    indices = sorted(sample(xrange(n), r))
+    indices = sorted(sample(range(n), r))
     return tuple(pool[i] for i in indices)
 
 
@@ -332,5 +332,5 @@ def random_combination_with_replacement(iterable, r):
     """
     pool = tuple(iterable)
     n = len(pool)
-    indices = sorted(randrange(n) for i in xrange(r))
+    indices = sorted(randrange(n) for i in range(r))
     return tuple(pool[i] for i in indices)

--- a/more_itertools/recipes.py
+++ b/more_itertools/recipes.py
@@ -12,6 +12,7 @@ from itertools import chain, combinations, count, cycle, groupby, ifilterfalse, 
 import operator
 from random import randrange, sample, choice
 
+from six import PY2
 
 __all__ = ['take', 'tabulate', 'consume', 'nth', 'quantify', 'padnone',
            'ncycles', 'dotproduct', 'flatten', 'repeatfunc', 'pairwise',
@@ -200,7 +201,10 @@ def roundrobin(*iterables):
     """
     # Recipe credited to George Sakkis
     pending = len(iterables)
-    nexts = cycle(iter(it).next for it in iterables)
+    if PY2:
+        nexts = cycle(iter(it).next for it in iterables)
+    else:
+        nexts = cycle(iter(it).__next__ for it in iterables)
     while pending:
         try:
             for next in nexts:

--- a/more_itertools/recipes.py
+++ b/more_itertools/recipes.py
@@ -8,11 +8,12 @@ Some backward-compatible usability improvements have been made.
 
 """
 from collections import deque
-from itertools import chain, combinations, count, cycle, groupby, ifilterfalse, imap, islice, izip, izip_longest, repeat, starmap, tee  # Wrapping breaks 2to3.
+from itertools import chain, combinations, count, cycle, groupby, islice, repeat, starmap, tee  # Wrapping breaks 2to3.
 import operator
 from random import randrange, sample, choice
 
 from six import PY2
+from six.moves import filterfalse, map, zip, zip_longest
 
 __all__ = ['take', 'tabulate', 'consume', 'nth', 'quantify', 'padnone',
            'ncycles', 'dotproduct', 'flatten', 'repeatfunc', 'pairwise',
@@ -48,7 +49,7 @@ def tabulate(function, start=0):
         [9, 4, 1]
 
     """
-    return imap(function, count(start))
+    return map(function, count(start))
 
 
 def consume(iterator, n=None):
@@ -110,7 +111,7 @@ def quantify(iterable, pred=bool):
         2
 
     """
-    return sum(imap(pred, iterable))
+    return sum(map(pred, iterable))
 
 
 def padnone(iterable):
@@ -142,7 +143,7 @@ def dotproduct(vec1, vec2):
         400
 
     """
-    return sum(imap(operator.mul, vec1, vec2))
+    return sum(map(operator.mul, vec1, vec2))
 
 
 def flatten(listOfLists):
@@ -178,7 +179,7 @@ def pairwise(iterable):
     """
     a, b = tee(iterable)
     next(b, None)
-    return izip(a, b)
+    return zip(a, b)
 
 
 def grouper(n, iterable, fillvalue=None):
@@ -189,7 +190,7 @@ def grouper(n, iterable, fillvalue=None):
 
     """
     args = [iter(iterable)] * n
-    return izip_longest(fillvalue=fillvalue, *args)
+    return zip_longest(fillvalue=fillvalue, *args)
 
 
 def roundrobin(*iterables):
@@ -237,7 +238,7 @@ def unique_everseen(iterable, key=None):
     seen = set()
     seen_add = seen.add
     if key is None:
-        for element in ifilterfalse(seen.__contains__, iterable):
+        for element in filterfalse(seen.__contains__, iterable):
             seen_add(element)
             yield element
     else:
@@ -257,7 +258,7 @@ def unique_justseen(iterable, key=None):
         ['A', 'B', 'C', 'A', 'D']
 
     """
-    return imap(next, imap(operator.itemgetter(1), groupby(iterable, key)))
+    return map(next, map(operator.itemgetter(1), groupby(iterable, key)))
 
 
 def iter_except(func, exception, first=None):
@@ -291,7 +292,7 @@ def random_product(*args, **kwds):
         ('b', '2', 'c', '2')
 
     """
-    pools = map(tuple, args) * kwds.get('repeat', 1)
+    pools = [tuple(pool) for pool in args] * kwds.get('repeat', 1)
     return tuple(choice(pool) for pool in pools)
 
 

--- a/more_itertools/recipes.py
+++ b/more_itertools/recipes.py
@@ -8,7 +8,9 @@ Some backward-compatible usability improvements have been made.
 
 """
 from collections import deque
-from itertools import chain, combinations, count, cycle, groupby, islice, repeat, starmap, tee  # Wrapping breaks 2to3.
+from itertools import (
+    chain, combinations, count, cycle, groupby, islice, repeat, starmap, tee
+)
 import operator
 from random import randrange, sample, choice
 

--- a/more_itertools/tests/test_more.py
+++ b/more_itertools/tests/test_more.py
@@ -3,7 +3,7 @@ from __future__ import unicode_literals
 from contextlib import closing
 from functools import reduce
 from io import StringIO
-from itertools import count, islice, permutations
+from itertools import count, permutations
 from unittest import TestCase
 
 from nose.tools import eq_, assert_raises
@@ -199,19 +199,19 @@ class IntersperseTest(TestCase):
 
 class UniqueToEachTests(TestCase):
     """Tests for ``unique_to_each()``"""
-    
+
     def test_all_unique(self):
         """When all the input iterables are unique the output should match
         the input."""
         iterables = [[1, 2], [3, 4, 5], [6, 7, 8]]
         eq_(unique_to_each(*iterables), iterables)
-    
+
     def test_duplicates(self):
         """When there are duplicates in any of the input iterables that aren't
         in the rest, those duplicates should be emitted."""
         iterables = ["mississippi", "missouri"]
         eq_(unique_to_each(*iterables), [['p', 'p'], ['o', 'u', 'r']])
-    
+
     def test_mixed(self):
         """When the input iterables contain different types the function should
         still behave properly"""

--- a/more_itertools/tests/test_more.py
+++ b/more_itertools/tests/test_more.py
@@ -1,9 +1,13 @@
+from __future__ import unicode_literals
+
 from contextlib import closing
-from itertools import count, islice, ifilter, permutations
-from StringIO import StringIO
+from functools import reduce
+from io import StringIO
+from itertools import count, islice, permutations
 from unittest import TestCase
 
 from nose.tools import eq_, assert_raises
+from six.moves import filter, range
 
 from more_itertools import *  # Test all the symbols are in __all__.
 
@@ -14,13 +18,13 @@ class CollateTests(TestCase):
 
     def test_default(self):
         """Test with the default `key` function."""
-        iterables = [xrange(4), xrange(7), xrange(3, 6)]
+        iterables = [range(4), range(7), range(3, 6)]
         eq_(sorted(reduce(list.__add__, [list(it) for it in iterables])),
             list(collate(*iterables)))
 
     def test_key(self):
         """Test using a custom `key` function."""
-        iterables = [xrange(5, 0, -1), xrange(4, 0, -1)]
+        iterables = [range(5, 0, -1), range(4, 0, -1)]
         eq_(list(sorted(reduce(list.__add__,
                                         [list(it) for it in iterables]),
                         reverse=True)),
@@ -32,11 +36,11 @@ class CollateTests(TestCase):
 
     def test_one(self):
         """Work when only 1 iterable is passed."""
-        eq_([0, 1], list(collate(xrange(2))))
+        eq_([0, 1], list(collate(range(2))))
 
     def test_reverse(self):
         """Test the `reverse` kwarg."""
-        iterables = [xrange(4, 0, -1), xrange(7, 0, -1), xrange(3, 6, -1)]
+        iterables = [range(4, 0, -1), range(7, 0, -1), range(3, 6, -1)]
         eq_(sorted(reduce(list.__add__, [list(it) for it in iterables]),
                    reverse=True),
             list(collate(*iterables, reverse=True)))
@@ -64,7 +68,7 @@ class FirstTests(TestCase):
         """Test that it works on many-item iterables."""
         # Also try it on a generator expression to make sure it works on
         # whatever those return, across Python versions.
-        eq_(first(x for x in xrange(4)), 0)
+        eq_(first(x for x in range(4)), 0)
 
     def test_one(self):
         """Test that it doesn't raise StopIteration prematurely."""
@@ -96,7 +100,7 @@ class PeekableTests(TestCase):
         """
         p = peekable([])
         self.assertFalse(p)
-        p = peekable(xrange(3))
+        p = peekable(range(3))
         self.assertTrue(p)
 
     def test_simple_peeking(self):
@@ -104,7 +108,7 @@ class PeekableTests(TestCase):
         iterator, respectively.
 
         """
-        p = peekable(xrange(10))
+        p = peekable(range(10))
         eq_(next(p), 0)
         eq_(p.peek(), 1)
         eq_(next(p), 1)
@@ -136,7 +140,7 @@ def test_distinct_permutations():
 
 def test_ilen():
     """Sanity-check ``ilen()``."""
-    eq_(ilen(ifilter(lambda x: x % 10 == 0, range(101))), 11)
+    eq_(ilen(filter(lambda x: x % 10 == 0, range(101))), 11)
 
 
 def test_with_iter():
@@ -188,7 +192,7 @@ class IntersperseTest(TestCase):
         assert_raises(TypeError, next, itp)
 
     def test_intersperse_generator(self):
-        itp = intersperse('x', xrange(5))
+        itp = intersperse('x', range(5))
         assert next(itp) == 0
         assert next(itp) == 'x'
         assert next(itp) == 1

--- a/more_itertools/tests/test_more.py
+++ b/more_itertools/tests/test_more.py
@@ -95,9 +95,9 @@ class PeekableTests(TestCase):
 
         """
         p = peekable([])
-        self.failIf(p)
+        self.assertFalse(p)
         p = peekable(xrange(3))
-        self.failUnless(p)
+        self.assertTrue(p)
 
     def test_simple_peeking(self):
         """Make sure ``next`` and ``peek`` advance and don't advance the

--- a/more_itertools/tests/test_more.py
+++ b/more_itertools/tests/test_more.py
@@ -105,9 +105,9 @@ class PeekableTests(TestCase):
 
         """
         p = peekable(xrange(10))
-        eq_(p.next(), 0)
+        eq_(next(p), 0)
         eq_(p.peek(), 1)
-        eq_(p.next(), 1)
+        eq_(next(p), 1)
 
 
 class ConsumerTests(TestCase):

--- a/more_itertools/tests/test_recipes.py
+++ b/more_itertools/tests/test_recipes.py
@@ -2,6 +2,7 @@ from random import seed
 from unittest import TestCase
 
 from nose.tools import eq_, assert_raises, ok_
+from six.moves import range
 
 from more_itertools import *
 
@@ -15,24 +16,24 @@ class TakeTests(TestCase):
 
     def test_simple_take(self):
         """Test basic usage"""
-        t = take(5, xrange(10))
+        t = take(5, range(10))
         eq_(t, [0, 1, 2, 3, 4])
 
     def test_null_take(self):
         """Check the null case"""
-        t = take(0, xrange(10))
+        t = take(0, range(10))
         eq_(t, [])
 
     def test_negative_take(self):
         """Make sure taking negative items results in a ValueError"""
-        assert_raises(ValueError, take, -3, xrange(10))
+        assert_raises(ValueError, take, -3, range(10))
 
     def test_take_too_much(self):
         """Taking more than an iterator has remaining should return what the
         iterator has remaining.
 
         """
-        t = take(10, xrange(5))
+        t = take(10, range(5))
         eq_(t, [0, 1, 2, 3, 4])
 
 
@@ -157,7 +158,7 @@ class FlattenTests(TestCase):
     def test_basic_usage(self):
         """ensure list of lists is flattened one level"""
         f = [[0, 1, 2], [3, 4, 5]]
-        eq_(range(6), list(flatten(f)))
+        eq_(list(range(6)), list(flatten(f)))
 
     def test_single_level(self):
         """ensure list of lists is flattened only one level"""
@@ -380,7 +381,7 @@ class RandomPermutationTests(TestCase):
         items = range(15)
         item_set = set(items)
         all_items = set()
-        for _ in xrange(100):
+        for _ in range(100):
             permutation = random_permutation(items, 5)
             eq_(len(permutation), 5)
             permutation_set = set(permutation)
@@ -397,7 +398,7 @@ class RandomCombinationTests(TestCase):
         samplings of random combinations"""
         items = range(15)
         all_items = set()
-        for _ in xrange(50):
+        for _ in range(50):
             combination = random_combination(items, 5)
             all_items |= set(combination)
         eq_(all_items, set(items))
@@ -405,7 +406,7 @@ class RandomCombinationTests(TestCase):
     def test_no_replacement(self):
         """ensure that elements are sampled without replacement"""
         items = range(15)
-        for _ in xrange(50):
+        for _ in range(50):
             combination = random_combination(items, len(items))
             eq_(len(combination), len(set(combination)))
         assert_raises(ValueError, random_combination, items, len(items) + 1)
@@ -427,7 +428,7 @@ class RandomCombinationWithReplacementTests(TestCase):
         samplings of random combinations"""
         items = range(15)
         all_items = set()
-        for _ in xrange(50):
+        for _ in range(50):
             combination = random_combination_with_replacement(items, 5)
             all_items |= set(combination)
         eq_(all_items, set(items))

--- a/setup.py
+++ b/setup.py
@@ -5,20 +5,7 @@ try:
 except ImportError:
     pass
 
-import sys
-
 from setuptools import setup, find_packages
-
-
-extra_setup = {}
-if sys.version_info >= (3,):
-    extra_setup['use_2to3'] = True
-    extra_setup['use_2to3_exclude_fixers'] = [
-        'lib2to3.fixes.fix_nonzero',
-        'lib2to3.fixes.fix_map',
-        'lib2to3.fixes.fix_next',
-        'lib2to3.fixes.fix_zip',
-    ]
 
 
 setup(
@@ -43,12 +30,10 @@ setup(
         'Natural Language :: English',
         'License :: OSI Approved :: MIT License',
         'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.2',
         'Topic :: Software Development :: Libraries'],
     keywords=['itertools', 'iterator', 'iteration', 'filter', 'peek',
               'peekable', 'collate', 'chunk', 'chunked'],
-    **extra_setup
 )

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,9 @@ if sys.version_info >= (3,):
     extra_setup['use_2to3'] = True
     extra_setup['use_2to3_exclude_fixers'] = [
         'lib2to3.fixes.fix_nonzero',
+        'lib2to3.fixes.fix_map',
         'lib2to3.fixes.fix_next',
+        'lib2to3.fixes.fix_zip',
     ]
 
 

--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,10 @@ from setuptools import setup, find_packages
 extra_setup = {}
 if sys.version_info >= (3,):
     extra_setup['use_2to3'] = True
+    extra_setup['use_2to3_exclude_fixers'] = [
+        'lib2to3.fixes.fix_nonzero',
+        'lib2to3.fixes.fix_next',
+    ]
 
 
 setup(
@@ -26,6 +30,7 @@ setup(
     author_email='erikrose@grinchcentral.com',
     license='MIT',
     packages=find_packages(exclude=['ez_setup']),
+    install_requires=['six>=1.10.0'],
     tests_require=['nose'],
     test_suite='nose.collector',
     url='https://github.com/erikrose/more-itertools',

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
     author_email='erikrose@grinchcentral.com',
     license='MIT',
     packages=find_packages(exclude=['ez_setup']),
-    install_requires=['six>=1.10.0'],
+    install_requires=['six>=1.0.0,<2.0.0'],
     tests_require=['nose'],
     test_suite='nose.collector',
     url='https://github.com/erikrose/more-itertools',

--- a/tox.ini
+++ b/tox.ini
@@ -10,4 +10,4 @@ envlist = py27, py32, py34, py35
 [testenv]
 commands = nosetests more_itertools --with-doctest
 deps = nose
-changedir = .tox  # So Python 3 runs don't pick up incompatible, un-2to3'd source from the cwd
+changedir = .tox


### PR DESCRIPTION
This PR moves `more-itertools` to a single codebase for Python 2 and Python 3. I've used `six` judiciously (with Erik's [endorsement](https://twitter.com/ErikRose/status/794369557934866433)).

The commits show me slowly taking out the 2to3 scaffolding and then removing it. I'll leave a few comments on less-than-obvious changes.