### PR TITLE
Sliding window function

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -19,6 +19,7 @@ New Routines
 .. autofunction:: one
 .. autoclass:: peekable
 .. autofunction:: unique_to_each
+.. autofunction:: windowed
 .. autofunction:: with_iter
 
 

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -1,5 +1,6 @@
 from __future__ import print_function
 
+from collections import deque
 from functools import partial, wraps
 
 from six import iteritems
@@ -8,7 +9,7 @@ from .recipes import take
 
 __all__ = ['chunked', 'first', 'peekable', 'collate', 'consumer', 'ilen',
            'iterate', 'with_iter', 'one', 'distinct_permutations',
-           'intersperse', 'unique_to_each']
+           'intersperse', 'unique_to_each', 'windowed']
 
 
 _marker = object()
@@ -387,3 +388,39 @@ def unique_to_each(*iterables):
                     pool[i].remove(element)
 
     return pool
+
+
+def windowed(seq, n, fillvalue=None):
+    """
+    Returns a sliding window (of width n) over data from the iterable.
+    When n=2 this is equivalent to ``pairwise(iterable)``.
+    When n is larger than the iterable, ``fillvalue`` is used in place of
+    missing values.
+
+    >>> all_windows = windowed([1, 2, 3, 4, 5], 3)
+    >>> next(all_windows)
+    (1, 2, 3)
+    >>> next(all_windows)
+    (2, 3, 4)
+    >>> next(all_windows)
+    (3, 4, 5)
+     """
+    if n < 0:
+        raise ValueError('n must be >= 0')
+    if n == 0:
+        yield tuple()
+        return
+
+    it = iter(seq)
+    window = deque([], n)
+    append = window.append
+
+    # Initial deque fill
+    for __ in range(n):
+        append(next(it, fillvalue))
+    yield tuple(window)
+
+    # Appending new items to the right causes old items to fall off the left
+    for item in it:
+        append(item)
+        yield tuple(window)

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -416,7 +416,7 @@ def windowed(seq, n, fillvalue=None):
     append = window.append
 
     # Initial deque fill
-    for __ in range(n):
+    for _ in range(n):
         append(next(it, fillvalue))
     yield tuple(window)
 

--- a/more_itertools/tests/test_more.py
+++ b/more_itertools/tests/test_more.py
@@ -217,3 +217,41 @@ class UniqueToEachTests(TestCase):
         still behave properly"""
         iterables = ['x', (i for i in range(3)), [1, 2, 3], tuple()]
         eq_(unique_to_each(*iterables), [['x'], [0], [3], []])
+
+
+class WindowedTests(TestCase):
+    """Tests for ``windowed()``"""
+
+    def test_basic(self):
+        actual = list(windowed([1, 2, 3, 4, 5], 3))
+        expected = [(1, 2, 3), (2, 3, 4), (3, 4, 5)]
+        eq_(actual, expected)
+
+    def test_large_size(self):
+        """
+        When the window size is larger than the iterable, and no fill value is
+        given,``None`` should be filled in.
+        """
+        actual = list(windowed([1, 2, 3, 4, 5], 6))
+        expected = [(1, 2, 3, 4, 5, None)]
+        eq_(actual, expected)
+
+    def test_fillvalue(self):
+        """
+        When the window size is larger than the iterable, the given fill value
+        should be used.
+        """
+        actual = list(windowed([1, 2, 3, 4, 5], 6, '!'))
+        expected = [(1, 2, 3, 4, 5, '!')]
+        eq_(actual, expected)
+
+    def test_zero(self):
+        """When the window size is zero, an empty tuple should be emitted."""
+        actual = list(windowed([1, 2, 3, 4, 5], 0))
+        expected = [tuple()]
+        eq_(actual, expected)
+
+    def test_negative(self):
+        """When the window size is negative, ValueError should be raised."""
+        with self.assertRaises(ValueError):
+            list(windowed([1, 2, 3, 4, 5], -1))


### PR DESCRIPTION
This PR adds a `windowed` function, which produces a sliding window over an iterable. It's a generalization of `pairwise`, which does a window of length 2.

```python
>>> all_windows = windowed([1, 2, 3, 4, 5], 3)
>>> next(all_windows)
(1, 2, 3)
>>> next(all_windows)
(2, 3, 4)
>>> next(all_windows)
(3, 4, 5)
```

---

This seems to be a popular request: we have it in issue #29, in PR #32, and again in PR #54.

There are various implementations floating around - @buchanae uses one with a `deque`, @abarnert extends the method of `pairwise`, Raymond Hettinger's [initial version](https://github.com/python/cpython/blob/f6dca3649114dc488b8df02328e6962d8ae9f6ad/Lib/test/test_itertools.py#L441-L450) took a different approach, and there are lots of attempts in [this StackOverflow thread](http://stackoverflow.com/questions/6822725/rolling-or-sliding-window-iterator-in-python).

I like the simplicity of the `tee` versions, but they have the disadvantage of emitting nothing when the window's width exceeds the length of the iterable.

I think when you specify that you want a window of width `n` you expect back `n` items, so I pad with a `fillvalue` (default `None)`, a la `itertools.zip_longest`.

```python
# fillvalue not specified
>>> all_windows = windowed([1, 2, 3, 4, 5], 6)
>>> next(all_windows)
(1, 2, 3, 4, 5, None)

# fillvalue specified
>>> all_windows = windowed([1, 2, 3, 4, 5], 6, fillvalue='')
>>> next(all_windows)
(1, 2, 3, 4, 5, '')
```

This allows you to do things like `a, b, c = next(all_windows, 3)` without needing to worry about the input iterable.