### PR TITLE
Bump to version 2.3

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -48,7 +48,7 @@ copyright = u'2012, Erik Rose'
 # built documents.
 #
 # The short X.Y version.
-version = '2.2'
+version = '2.3'
 # The full version, including alpha/beta/rc tags.
 release = version
 

--- a/docs/versions.rst
+++ b/docs/versions.rst
@@ -4,7 +4,13 @@ Version History
 
 2.3
     * Added ``one`` from ``jaraco.util.itertools``. (Thanks, jaraco!)
-    * Added ``distinct_permutations``. (Thanks, Bo Bayles!)
+    * Added ``distinct_permutations`` and ``unique_to_each``. (contributed by
+      bbayles)
+    * Added ``windowed``. (Contributed by bbayles, with thanks to buchanae,
+      jaraco, and abarnert)
+    * Simplified the implementation of ``chunked``. (Thanks, nvie!)
+    * Python 3.5 is now supported. Python 2.6 is no longer supported.
+    * Python 3 is now supported directly; there is no 2to3 step.
 
 2.2
     * Added ``iterate`` and ``with_iter``. (Thanks, abarnert!)

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='more-itertools',
-    version='2.2',
+    version='2.3',
     description='More routines for operating on iterables, beyond itertools',
     long_description=open('README.rst').read() + '\n\n' +
                      '\n'.join(open('docs/versions.rst').read()


### PR DESCRIPTION
Now that we have `windowed`, I'd like to get it out to PyPI for the world to enjoy. I've updated the version strings and changelog in this PR.

@erikrose, if you're good with sending this to PyPI, I can create the GitHub release.

FWIW, in [redis-collections](https://github.com/honzajavorek/redis-collections/blob/master/.travis.yml) we have Travis do the PyPI push - that might be a good thing here?