### PR TITLE
Bucket (was "Separate" and "Partition")

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -17,6 +17,7 @@ New Routines
 .. autofunction:: intersperse
 .. autofunction:: iterate
 .. autofunction:: one
+.. autofunction:: partition
 .. autoclass:: peekable
 .. autofunction:: unique_to_each
 .. autofunction:: windowed

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -8,6 +8,7 @@ API Reference
 New Routines
 ============
 
+.. autofunction:: bucket
 .. autofunction:: chunked
 .. autofunction:: collate(*iterables, key=lambda a: a, reverse=False)
 .. autofunction:: consumer
@@ -18,7 +19,6 @@ New Routines
 .. autofunction:: iterate
 .. autofunction:: one
 .. autoclass:: peekable
-.. autofunction:: separate
 .. autofunction:: unique_to_each
 .. autofunction:: windowed
 .. autofunction:: with_iter

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -17,8 +17,8 @@ New Routines
 .. autofunction:: intersperse
 .. autofunction:: iterate
 .. autofunction:: one
-.. autofunction:: partition
 .. autoclass:: peekable
+.. autofunction:: separate
 .. autofunction:: unique_to_each
 .. autofunction:: windowed
 .. autofunction:: with_iter

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -483,6 +483,7 @@ class separate(object):
                     item = next(self._it)
                     item_value = self._key(item)
                     if item_value == value:
+                        yield item
                         break
                     self._cache[item_value].append(item)
 

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -464,37 +464,17 @@ class bucket(object):
 
     The original iterable will be advanced and its items will be cached until
     they are used by the child iterables. This may require significant storage.
-
-    By default, attempting to select a value that does not match any items in
-    the iterable will exhaust the iterable, caching all the values.
-    If a set of *values* is provided, items that don't match any will not be
-    cached, and attempting to select them will generate a KeyError.
-
-    >>> iterable = [0, 1, 2, 3, 4, 5, 6, 7, 8]
-    >>> mod_3 = lambda x: x % 3  # Remainder when divided by 3
-    >>> values = {0, 1}  # Only keep items that equal 0 or 1 (mod 3)
-    >>> s = bucket(iterable, key=mod_3, values=values)
-    >>> list(s[0])
-    [0, 3, 6]
-    >>> list(s[1])
-    [1, 4, 7]
-    >>> list(s[2])
-    Traceback (most recent call last):
-    ...
-    KeyError: 2
+    Be aware that attempting to select a bucket that no items correspond to
+    will exhaust the iterable and cache all values.
 
     """
 
-    def __init__(self, iterable, key, values=()):
+    def __init__(self, iterable, key):
         self._it = iter(iterable)
         self._key = key
         self._cache = defaultdict(deque)
-        self._values = set(values)
 
     def __contains__(self, value):
-        if self._values and (value not in self._values):
-            return False
-
         try:
             item = next(self[value])
         except StopIteration:
@@ -524,12 +504,8 @@ class bucket(object):
                     if item_value == value:
                         yield item
                         break
-                    elif self._values and (item_value not in self._values):
-                        continue
                     else:
                         self._cache[item_value].append(item)
 
     def __getitem__(self, value):
-        if self._values and (value not in self._values):
-            raise KeyError(value)
         return self._get_values(value)

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -499,10 +499,3 @@ class separate(object):
 
     def __getitem__(self, value):
         return self._get_values(value)
-
-    def __next__(self):
-        return next(self._it)
-
-    def next(self):
-        # For Python 2 compatibility
-        return self.__next__()

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -11,7 +11,7 @@ from .recipes import take
 
 __all__ = ['chunked', 'first', 'peekable', 'collate', 'consumer', 'ilen',
            'iterate', 'with_iter', 'one', 'distinct_permutations',
-           'intersperse', 'unique_to_each', 'windowed', 'separate']
+           'intersperse', 'unique_to_each', 'windowed', 'bucket']
 
 
 _marker = object()
@@ -447,13 +447,13 @@ def windowed(seq, n, fillvalue=None):
         yield tuple(window)
 
 
-class separate(object):
+class bucket(object):
     """
-    Wraps an iterable and returns an object that separates the iterable
+    Wraps an iterable and returns an object that buckets the iterable
     into child iterables based on the *key* function.
 
     >>> iterable = ['a1', 'b1', 'c1', 'a2', 'b2', 'c2', 'b3']
-    >>> s = separate(iterable, key=lambda s: s[0])  # Select by first character
+    >>> s = bucket(iterable, key=lambda s: s[0])  # Select by first character
     >>> a_iterable = s['a']
     >>> next(a_iterable)
     'a1'
@@ -473,7 +473,7 @@ class separate(object):
     >>> iterable = [0, 1, 2, 3, 4, 5, 6, 7, 8]
     >>> mod_3 = lambda x: x % 3  # Remainder when divided by 3
     >>> values = {0, 1}  # Only keep items that equal 0 or 1 (mod 3)
-    >>> s = separate(iterable, key=mod_3, values=values)
+    >>> s = bucket(iterable, key=mod_3, values=values)
     >>> list(s[0])
     [0, 3, 6]
     >>> list(s[1])

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -9,7 +9,7 @@ from .recipes import take
 
 __all__ = ['chunked', 'first', 'peekable', 'collate', 'consumer', 'ilen',
            'iterate', 'with_iter', 'one', 'distinct_permutations',
-           'intersperse', 'unique_to_each', 'windowed', 'partition']
+           'intersperse', 'unique_to_each', 'windowed', 'separate']
 
 
 _marker = object()
@@ -426,7 +426,7 @@ def windowed(seq, n, fillvalue=None):
         yield tuple(window)
 
 
-def partition(iterable, keys=None, fn=None):
+def separate(iterable, keys=None, fn=None):
     """
     By default, returns a dictionary whose keys are ``True`` and ``False``,
     and whose values are iterables.
@@ -434,7 +434,7 @@ def partition(iterable, keys=None, fn=None):
     and the items in the ``False`` iterable have ``bool(item) == False``.
 
     >>> iterable = [0, '', 1, 'x', None, [1]]
-    >>> D = partition(iterable)
+    >>> D = separate(iterable)
     >>> list(D[False])
     [0, '', None]
     >>> list(D[True])
@@ -446,7 +446,7 @@ def partition(iterable, keys=None, fn=None):
     the ``keys`` arguments:
 
     >>> iterable = [0, 1, 2, 3, 4, 5, 6, 7, 8]
-    >>> D = partition(iterable, keys=(0, 1, 2), fn=lambda x: x % 3)
+    >>> D = separate(iterable, keys=(0, 1, 2), fn=lambda x: x % 3)
     >>> list(D[0])
     [0, 3, 6]
     >>> list(D[1])

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -474,6 +474,16 @@ class separate(object):
         self._key = key
         self._cache = defaultdict(deque)
 
+    def __contains__(self, value):
+        try:
+            item = next(self[value])
+        except StopIteration:
+            return False
+        else:
+            self._cache[value].appendleft(item)
+
+        return True
+
     def _get_values(self, value):
         while True:
             if self._cache[value]:

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -505,9 +505,18 @@ class bucket(object):
         return True
 
     def _get_values(self, value):
+        """
+        Helper to yield items from the parent iterator that match *value*.
+        Items that don't match are stored in the local cache as they
+        are encountered.
+        """
         while True:
+            # If we've cached some items that match the target value, emit
+            # the first one and evit it from the cache.
             if self._cache[value]:
                 yield self._cache[value].popleft()
+            # Otherwise we need to advance the parent iterator to search for
+            # a matching item, caching the rest.
             else:
                 while True:
                     item = next(self._it)

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -485,7 +485,7 @@ class bucket(object):
 
     """
 
-    def __init__(self, iterable, key, values=tuple()):
+    def __init__(self, iterable, key, values=()):
         self._it = iter(iterable)
         self._key = key
         self._cache = defaultdict(deque)

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -426,9 +426,9 @@ def windowed(seq, n, fillvalue=None):
         yield tuple(window)
 
 
-def partition(iterable, *keys, **kwargs):
+def partition(iterable, keys=None, fn=None):
     """
-    By defeault, returns a dictionary whose keys are ``True`` and ``False``,
+    By default, returns a dictionary whose keys are ``True`` and ``False``,
     and whose values are iterables.
     The items in the ``True`` iterable have ``bool(item) == True``,
     and the items in the ``False`` iterable have ``bool(item) == False``.
@@ -446,7 +446,7 @@ def partition(iterable, *keys, **kwargs):
     the ``keys`` arguments:
 
     >>> iterable = [0, 1, 2, 3, 4, 5, 6, 7, 8]
-    >>> D = partition(iterable, 0, 1, 2, fn=lambda x: x % 3)
+    >>> D = partition(iterable, keys=(0, 1, 2), fn=lambda x: x % 3)
     >>> list(D[0])
     [0, 3, 6]
     >>> list(D[1])
@@ -458,7 +458,8 @@ def partition(iterable, *keys, **kwargs):
     it will not be represented in the output dictionary.
 
     """
-    fn = kwargs.get('fn', bool)
+    keys = (False, True) if keys is None else keys
+    fn = bool if fn is None else fn
 
     if not keys:
         keys = [True, False]

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -492,6 +492,9 @@ class separate(object):
         self._values = set(values)
 
     def __contains__(self, value):
+        if self._values and (value not in self._values):
+            return False
+
         try:
             item = next(self[value])
         except StopIteration:

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -515,9 +515,10 @@ class bucket(object):
                     if item_value == value:
                         yield item
                         break
-                    if self._values and (item_value not in self._values):
+                    elif self._values and (item_value not in self._values):
                         continue
-                    self._cache[item_value].append(item)
+                    else:
+                        self._cache[item_value].append(item)
 
     def __getitem__(self, value):
         if self._values and (value not in self._values):

--- a/more_itertools/tests/test_more.py
+++ b/more_itertools/tests/test_more.py
@@ -257,12 +257,12 @@ class WindowedTests(TestCase):
             list(windowed([1, 2, 3, 4, 5], -1))
 
 
-class SeparateTests(TestCase):
-    """Tests for ``separate()``"""
+class BucketTests(TestCase):
+    """Tests for ``bucket()``"""
 
     def test_basic(self):
         iterable = [10, 20, 30, 11, 21, 31, 12, 22, 23, 33]
-        D = separate(iterable, key=lambda x: 10 * (x // 10))
+        D = bucket(iterable, key=lambda x: 10 * (x // 10))
 
         # In-order access
         eq_(list(D[10]), [10, 11, 12])
@@ -275,7 +275,7 @@ class SeparateTests(TestCase):
 
     def test_known_values(self):
         iterable = [10, 20, 30, 11, 21, 31, 12, 22, 23, 33]
-        D = separate(iterable, key=lambda x: 10 * (x // 10), values=(10, 20))
+        D = bucket(iterable, key=lambda x: 10 * (x // 10), values=(10, 20))
 
         self.assertIn(10, D)
         eq_(list(D[10]), [10, 11, 12])
@@ -289,7 +289,7 @@ class SeparateTests(TestCase):
 
     def test_in(self):
         iterable = [10, 20, 30, 11, 21, 31, 12, 22, 23, 33]
-        D = separate(iterable, key=lambda x: 10 * (x // 10))
+        D = bucket(iterable, key=lambda x: 10 * (x // 10))
 
         self.assertTrue(10 in D)
         self.assertFalse(40 in D)

--- a/more_itertools/tests/test_more.py
+++ b/more_itertools/tests/test_more.py
@@ -260,33 +260,15 @@ class WindowedTests(TestCase):
 class SeparateTests(TestCase):
     """Tests for ``separate()``"""
 
-    def test_default(self):
-        """By default the function is ``bool``"""
-        iterable = [0, 1, False, True, '', 'a', None]
-        D = separate(iterable)
-        eq_(list(D[False]), [0, False, '', None])
-        eq_(list(D[True]), [1, True, 'a'])
+    def test_basic(self):
+        iterable = [10, 20, 30, 11, 21, 31, 12, 22, 23, 33]
+        D = separate(iterable, key=lambda x: 10 * (x // 10))
 
-    def test_function(self):
-        """Custom function and keys: round down to nearest 10"""
-        iterable = [10, 20, 30, 11, 21, 31, 41, 12, 22, 23, 33, 43]
-        D = separate(iterable, keys=(10, 20, 30), fn=lambda x: 10 * (x // 10))
-        eq_(sorted(D), [10, 20, 30])  # No 40; it wasn't in keys
+        # In-order access
         eq_(list(D[10]), [10, 11, 12])
-        eq_(list(D[20]), [20, 21, 22, 23])
+
+        # Out of order access
         eq_(list(D[30]), [30, 31, 33])
+        eq_(list(D[20]), [20, 21, 22, 23])
 
-    def test_no_keys(self):
-        """Custom function but default keys: filter True and False"""
-        iterable = [0, 1, 2, 0, 1, 2]
-        D = separate(iterable, fn=lambda x: x)
-        eq_(list(D[False]), [0, 0])
-        eq_(list(D[True]), [1, 1])  # 1 == True
-
-    def test_no_function(self):
-        """Custom function but default keys: filter True and False"""
-        iterable = [0, 1, 2, 0, 1, 2]
-        D = separate(iterable, keys=(False, True, None))
-        eq_(list(D[False]), [0, 0])
-        eq_(list(D[True]), [1, 2, 1, 2])
-        eq_(list(D[None]), [])
+        eq_(list(D[40]), [])  # Nothing in here!

--- a/more_itertools/tests/test_more.py
+++ b/more_itertools/tests/test_more.py
@@ -1,4 +1,4 @@
-from __future__ import unicode_literals
+from __future__ import division, unicode_literals
 
 from contextlib import closing
 from functools import reduce
@@ -255,3 +255,38 @@ class WindowedTests(TestCase):
         """When the window size is negative, ValueError should be raised."""
         with self.assertRaises(ValueError):
             list(windowed([1, 2, 3, 4, 5], -1))
+
+
+class PartitionTests(TestCase):
+    """Tests for ``partition()``"""
+
+    def test_default(self):
+        """By default the function is ``bool``"""
+        iterable = [0, 1, False, True, '', 'a', None]
+        D = partition(iterable)
+        eq_(list(D[False]), [0, False, '', None])
+        eq_(list(D[True]), [1, True, 'a'])
+
+    def test_function(self):
+        """Custom function and keys: round down to nearest 10"""
+        iterable = [10, 20, 30, 11, 21, 31, 41, 12, 22, 23, 33, 43]
+        D = partition(iterable, 10, 20, 30, fn=lambda x: 10 * (x // 10))
+        eq_(sorted(D), [10, 20, 30])  # No 40; it wasn't in keys
+        eq_(list(D[10]), [10, 11, 12])
+        eq_(list(D[20]), [20, 21, 22, 23])
+        eq_(list(D[30]), [30, 31, 33])
+
+    def test_no_keys(self):
+        """Custom function but default keys: filter True and False"""
+        iterable = [0, 1, 2, 0, 1, 2]
+        D = partition(iterable, fn=lambda x: x)
+        eq_(list(D[False]), [0, 0])
+        eq_(list(D[True]), [1, 1])  # 1 == True
+
+    def test_no_function(self):
+        """Custom function but default keys: filter True and False"""
+        iterable = [0, 1, 2, 0, 1, 2]
+        D = partition(iterable, False, True, None)
+        eq_(list(D[False]), [0, 0])
+        eq_(list(D[True]), [1, 2, 1, 2])
+        eq_(list(D[None]), [])

--- a/more_itertools/tests/test_more.py
+++ b/more_itertools/tests/test_more.py
@@ -273,6 +273,17 @@ class SeparateTests(TestCase):
 
         eq_(list(D[40]), [])  # Nothing in here!
 
+    def test_known_values(self):
+        iterable = [10, 20, 30, 11, 21, 31, 12, 22, 23, 33]
+        D = separate(iterable, key=lambda x: 10 * (x // 10), values=(10, 20))
+
+        eq_(list(D[10]), [10, 11, 12])
+
+        with self.assertRaises(KeyError):
+            next(D[30])
+
+        eq_(list(D[20]), [20, 21, 22, 23])
+
     def test_in(self):
         iterable = [10, 20, 30, 11, 21, 31, 12, 22, 23, 33]
         D = separate(iterable, key=lambda x: 10 * (x // 10))

--- a/more_itertools/tests/test_more.py
+++ b/more_itertools/tests/test_more.py
@@ -270,7 +270,7 @@ class PartitionTests(TestCase):
     def test_function(self):
         """Custom function and keys: round down to nearest 10"""
         iterable = [10, 20, 30, 11, 21, 31, 41, 12, 22, 23, 33, 43]
-        D = partition(iterable, 10, 20, 30, fn=lambda x: 10 * (x // 10))
+        D = partition(iterable, keys=(10, 20, 30), fn=lambda x: 10 * (x // 10))
         eq_(sorted(D), [10, 20, 30])  # No 40; it wasn't in keys
         eq_(list(D[10]), [10, 11, 12])
         eq_(list(D[20]), [20, 21, 22, 23])
@@ -286,7 +286,7 @@ class PartitionTests(TestCase):
     def test_no_function(self):
         """Custom function but default keys: filter True and False"""
         iterable = [0, 1, 2, 0, 1, 2]
-        D = partition(iterable, False, True, None)
+        D = partition(iterable, keys=(False, True, None))
         eq_(list(D[False]), [0, 0])
         eq_(list(D[True]), [1, 2, 1, 2])
         eq_(list(D[None]), [])

--- a/more_itertools/tests/test_more.py
+++ b/more_itertools/tests/test_more.py
@@ -273,20 +273,6 @@ class BucketTests(TestCase):
 
         eq_(list(D[40]), [])  # Nothing in here!
 
-    def test_known_values(self):
-        iterable = [10, 20, 30, 11, 21, 31, 12, 22, 23, 33]
-        D = bucket(iterable, key=lambda x: 10 * (x // 10), values=(10, 20))
-
-        self.assertIn(10, D)
-        eq_(list(D[10]), [10, 11, 12])
-
-        self.assertNotIn(30, D)
-        with self.assertRaises(KeyError):
-            next(D[30])
-
-        eq_(list(D[20]), [20, 21, 22, 23])
-
-
     def test_in(self):
         iterable = [10, 20, 30, 11, 21, 31, 12, 22, 23, 33]
         D = bucket(iterable, key=lambda x: 10 * (x // 10))

--- a/more_itertools/tests/test_more.py
+++ b/more_itertools/tests/test_more.py
@@ -277,12 +277,15 @@ class SeparateTests(TestCase):
         iterable = [10, 20, 30, 11, 21, 31, 12, 22, 23, 33]
         D = separate(iterable, key=lambda x: 10 * (x // 10), values=(10, 20))
 
+        self.assertIn(10, D)
         eq_(list(D[10]), [10, 11, 12])
 
+        self.assertNotIn(30, D)
         with self.assertRaises(KeyError):
             next(D[30])
 
         eq_(list(D[20]), [20, 21, 22, 23])
+
 
     def test_in(self):
         iterable = [10, 20, 30, 11, 21, 31, 12, 22, 23, 33]

--- a/more_itertools/tests/test_more.py
+++ b/more_itertools/tests/test_more.py
@@ -272,3 +272,15 @@ class SeparateTests(TestCase):
         eq_(list(D[20]), [20, 21, 22, 23])
 
         eq_(list(D[40]), [])  # Nothing in here!
+
+    def test_in(self):
+        iterable = [10, 20, 30, 11, 21, 31, 12, 22, 23, 33]
+        D = separate(iterable, key=lambda x: 10 * (x // 10))
+
+        self.assertTrue(10 in D)
+        self.assertFalse(40 in D)
+        self.assertTrue(20 in D)
+        self.assertFalse(21 in D)
+
+        # Checking in-ness shouldn't advance the iterator
+        eq_(next(D[10]), 10)

--- a/more_itertools/tests/test_more.py
+++ b/more_itertools/tests/test_more.py
@@ -257,20 +257,20 @@ class WindowedTests(TestCase):
             list(windowed([1, 2, 3, 4, 5], -1))
 
 
-class PartitionTests(TestCase):
-    """Tests for ``partition()``"""
+class SeparateTests(TestCase):
+    """Tests for ``separate()``"""
 
     def test_default(self):
         """By default the function is ``bool``"""
         iterable = [0, 1, False, True, '', 'a', None]
-        D = partition(iterable)
+        D = separate(iterable)
         eq_(list(D[False]), [0, False, '', None])
         eq_(list(D[True]), [1, True, 'a'])
 
     def test_function(self):
         """Custom function and keys: round down to nearest 10"""
         iterable = [10, 20, 30, 11, 21, 31, 41, 12, 22, 23, 33, 43]
-        D = partition(iterable, keys=(10, 20, 30), fn=lambda x: 10 * (x // 10))
+        D = separate(iterable, keys=(10, 20, 30), fn=lambda x: 10 * (x // 10))
         eq_(sorted(D), [10, 20, 30])  # No 40; it wasn't in keys
         eq_(list(D[10]), [10, 11, 12])
         eq_(list(D[20]), [20, 21, 22, 23])
@@ -279,14 +279,14 @@ class PartitionTests(TestCase):
     def test_no_keys(self):
         """Custom function but default keys: filter True and False"""
         iterable = [0, 1, 2, 0, 1, 2]
-        D = partition(iterable, fn=lambda x: x)
+        D = separate(iterable, fn=lambda x: x)
         eq_(list(D[False]), [0, 0])
         eq_(list(D[True]), [1, 1])  # 1 == True
 
     def test_no_function(self):
         """Custom function but default keys: filter True and False"""
         iterable = [0, 1, 2, 0, 1, 2]
-        D = partition(iterable, keys=(False, True, None))
+        D = separate(iterable, keys=(False, True, None))
         eq_(list(D[False]), [0, 0])
         eq_(list(D[True]), [1, 2, 1, 2])
         eq_(list(D[None]), [])


### PR DESCRIPTION
This PR builds on the ideas in #26 and adds a `separate` function. By default it will split an input iterable into two - items that have `bool(item) == True` and items that have `bool(item) == False`. A dictionary with `True` and `False` keys is returned:

```python
>>> iterable = [0, '', 1, 'x', None, [1]]
>>> D = separate(iterable)
>>> list(D[False])
[0, '', None]
>>> list(D[True])
[1, 'x', [1]]
```

You can customize the keys of the returned dictionary as well as the function that operates on the items:

```python
>>> iterable = [0, 1, 2, 3, 4, 5, 6, 7, 8]
>>> D = separate(iterable, keys=(0, 1, 2), fn=lambda x: x % 3)
>>> list(D[0])  # Divisible by 3
[0, 3, 6]
>>> list(D[1])  # Remainder 1 when divided by 3
[1, 4, 7]
>>> list(D[2])  # Remainder 2 when divided by 3
[2, 5, 8]
```

Since we can't know what the return values of the function will be until we run it on all of the items, you must specify up-front what you think they'll be (obviously `bool` only returns `True` and `False`). I considered having an "other" key in the dictionary for items that don't match any `keys`, but decided against it.