### PR TITLE
Recipes 3

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -17,6 +17,7 @@ New Routines
 .. autofunction:: intersperse
 .. autofunction:: iterate
 .. autofunction:: one
+.. autofunction:: partition
 .. autoclass:: peekable
 .. autofunction:: unique_to_each
 .. autofunction:: windowed

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -17,8 +17,8 @@ New Routines
 .. autofunction:: intersperse
 .. autofunction:: iterate
 .. autofunction:: one
-.. autofunction:: partition
 .. autoclass:: peekable
+.. autofunction:: separate
 .. autofunction:: unique_to_each
 .. autofunction:: windowed
 .. autofunction:: with_iter

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -27,6 +27,7 @@ New Routines
 Itertools Recipes
 =================
 
+.. autofunction:: accumulate
 .. autofunction:: take
 .. autofunction:: tabulate
 .. autofunction:: tail

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -29,8 +29,10 @@ Itertools Recipes
 
 .. autofunction:: take
 .. autofunction:: tabulate
+.. autofunction:: tail
 .. autofunction:: consume
 .. autofunction:: nth
+.. autofunction:: all_equal
 .. autofunction:: quantify
 .. autofunction:: padnone
 .. autofunction:: ncycles
@@ -40,10 +42,12 @@ Itertools Recipes
 .. autofunction:: pairwise
 .. autofunction:: grouper
 .. autofunction:: roundrobin
+.. autofunction:: partition
 .. autofunction:: powerset
 .. autofunction:: unique_everseen
 .. autofunction:: unique_justseen
 .. autofunction:: iter_except
+.. autofunction:: first_true
 .. autofunction:: random_product
 .. autofunction:: random_permutation
 .. autofunction:: random_combination

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -9,7 +9,7 @@ from .recipes import take
 
 __all__ = ['chunked', 'first', 'peekable', 'collate', 'consumer', 'ilen',
            'iterate', 'with_iter', 'one', 'distinct_permutations',
-           'intersperse', 'unique_to_each', 'windowed', 'partition']
+           'intersperse', 'unique_to_each', 'windowed', 'separate']
 
 
 _marker = object()
@@ -426,7 +426,7 @@ def windowed(seq, n, fillvalue=None):
         yield tuple(window)
 
 
-def partition(iterable, keys=None, fn=None):
+def separate(iterable, keys=None, fn=None):
     """
     By default, returns a dictionary whose keys are ``True`` and ``False``,
     and whose values are iterables.
@@ -434,7 +434,7 @@ def partition(iterable, keys=None, fn=None):
     and the items in the ``False`` iterable have ``bool(item) == False``.
 
     >>> iterable = [0, '', 1, 'x', None, [1]]
-    >>> D = partition(iterable)
+    >>> D = separate(iterable)
     >>> list(D[False])
     [0, '', None]
     >>> list(D[True])
@@ -446,7 +446,7 @@ def partition(iterable, keys=None, fn=None):
     the ``keys`` arguments:
 
     >>> iterable = [0, 1, 2, 3, 4, 5, 6, 7, 8]
-    >>> D = partition(iterable, keys=(0, 1, 2), fn=lambda x: x % 3)
+    >>> D = separate(iterable, keys=(0, 1, 2), fn=lambda x: x % 3)
     >>> list(D[0])
     [0, 3, 6]
     >>> list(D[1])

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -426,9 +426,9 @@ def windowed(seq, n, fillvalue=None):
         yield tuple(window)
 
 
-def partition(iterable, *keys, **kwargs):
+def partition(iterable, keys=None, fn=None):
     """
-    By defeault, returns a dictionary whose keys are ``True`` and ``False``,
+    By default, returns a dictionary whose keys are ``True`` and ``False``,
     and whose values are iterables.
     The items in the ``True`` iterable have ``bool(item) == True``,
     and the items in the ``False`` iterable have ``bool(item) == False``.
@@ -446,7 +446,7 @@ def partition(iterable, *keys, **kwargs):
     the ``keys`` arguments:
 
     >>> iterable = [0, 1, 2, 3, 4, 5, 6, 7, 8]
-    >>> D = partition(iterable, 0, 1, 2, fn=lambda x: x % 3)
+    >>> D = partition(iterable, keys=(0, 1, 2), fn=lambda x: x % 3)
     >>> list(D[0])
     [0, 3, 6]
     >>> list(D[1])
@@ -458,7 +458,8 @@ def partition(iterable, *keys, **kwargs):
     it will not be represented in the output dictionary.
 
     """
-    fn = kwargs.get('fn', bool)
+    keys = (False, True) if keys is None else keys
+    fn = bool if fn is None else fn
 
     if not keys:
         keys = [True, False]

--- a/more_itertools/recipes.py
+++ b/more_itertools/recipes.py
@@ -17,12 +17,14 @@ from random import randrange, sample, choice
 from six import PY2
 from six.moves import filterfalse, map, range, zip, zip_longest
 
-__all__ = ['take', 'tabulate', 'consume', 'nth', 'quantify', 'padnone',
-           'ncycles', 'dotproduct', 'flatten', 'repeatfunc', 'pairwise',
-           'grouper', 'roundrobin', 'powerset', 'unique_everseen',
-           'unique_justseen', 'iter_except', 'random_product',
-           'random_permutation', 'random_combination',
-           'random_combination_with_replacement']
+__all__ = [
+    'take', 'tabulate', 'tail', 'consume', 'nth', 'all_equal', 'quantify',
+    'padnone', 'ncycles', 'dotproduct', 'flatten', 'repeatfunc', 'pairwise',
+    'grouper', 'roundrobin', 'partition', 'powerset', 'unique_everseen',
+    'unique_justseen', 'iter_except', 'first_true', 'random_product',
+    'random_permutation', 'random_combination',
+    'random_combination_with_replacement',
+]
 
 
 def take(n, iterable):
@@ -52,6 +54,18 @@ def tabulate(function, start=0):
 
     """
     return map(function, count(start))
+
+
+def tail(n, iterable):
+    """
+    Return an iterator over the last n items"
+
+        >>> t = tail(3, 'ABCDEFG')
+        >>> list(t)
+        ['E', 'F', 'G']
+
+    """
+    return iter(deque(iterable, maxlen=n))
 
 
 def consume(iterator, n=None):
@@ -104,6 +118,19 @@ def nth(iterable, n, default=None):
 
     """
     return next(islice(iterable, n, None), default)
+
+
+def all_equal(iterable):
+    """
+    Returns True if all the elements are equal to each other.
+        >>> all_equal('aaaa')
+        True
+        >>> all_equal('aaab')
+        False
+
+    """
+    g = groupby(iterable)
+    return next(g, True) and not next(g, False)
 
 
 def quantify(iterable, pred=bool):
@@ -217,6 +244,24 @@ def roundrobin(*iterables):
             nexts = cycle(islice(nexts, pending))
 
 
+def partition(pred, iterable):
+    """
+    Returns a 2-tuple of iterables derived from the input iterable.
+    The first yields the items that have ``pred(item) == False``.
+    The first yields the items that have ``pred(item) == False``.
+
+        >>> is_odd = lambda x: x % 2 != 0
+        >>> iterable = range(10)
+        >>> even_items, odd_items = partition(is_odd, iterable)
+        >>> list(even_items), list(odd_items)
+        ([0, 2, 4, 6, 8], [1, 3, 5, 7, 9])
+
+    """
+    # partition(is_odd, range(10)) --> 0 2 4 6 8   and  1 3 5 7 9
+    t1, t2 = tee(iterable)
+    return filterfalse(pred, t1), filter(pred, t2)
+
+
 def powerset(iterable):
     """Yields all possible subsets of the iterable
 
@@ -282,6 +327,26 @@ def iter_except(func, exception, first=None):
             yield func()
     except exception:
         pass
+
+
+def first_true(iterable, default=False, pred=None):
+    """
+    Returns the first true value in the iterable.
+
+    If no true value is found, returns *default*
+
+    If *pred* is not None, returns the first item for which
+    ``pred(item) == True`` .
+
+    >>> first_true(range(10))
+    1
+    >>> first_true(range(10), pred=lambda x: x > 5)
+    6
+    >>> first_true(range(10), default='missing', pred=lambda x: x > 9)
+    'missing'
+
+    """
+    return next(filter(pred, iterable), default)
 
 
 def random_product(*args, **kwds):

--- a/more_itertools/recipes.py
+++ b/more_itertools/recipes.py
@@ -15,7 +15,7 @@ import operator
 from random import randrange, sample, choice
 
 from six import PY2
-from six.moves import filterfalse, map, range, zip, zip_longest
+from six.moves import filter, filterfalse, map, range, zip, zip_longest
 
 __all__ = [
     'accumulate', 'take', 'tabulate', 'tail', 'consume', 'nth', 'all_equal',

--- a/more_itertools/recipes.py
+++ b/more_itertools/recipes.py
@@ -18,13 +18,43 @@ from six import PY2
 from six.moves import filterfalse, map, range, zip, zip_longest
 
 __all__ = [
-    'take', 'tabulate', 'tail', 'consume', 'nth', 'all_equal', 'quantify',
-    'padnone', 'ncycles', 'dotproduct', 'flatten', 'repeatfunc', 'pairwise',
-    'grouper', 'roundrobin', 'partition', 'powerset', 'unique_everseen',
-    'unique_justseen', 'iter_except', 'first_true', 'random_product',
-    'random_permutation', 'random_combination',
+    'accumulate', 'take', 'tabulate', 'tail', 'consume', 'nth', 'all_equal',
+    'quantify', 'padnone', 'ncycles', 'dotproduct', 'flatten', 'repeatfunc',
+    'pairwise', 'grouper', 'roundrobin', 'partition', 'powerset',
+    'unique_everseen', 'unique_justseen', 'iter_except', 'first_true',
+    'random_product', 'random_permutation', 'random_combination',
     'random_combination_with_replacement',
 ]
+
+
+def accumulate(iterable, func=operator.add):
+    """
+    Return an iterator whose items are the accumulated results of a function
+    (specified by the optional *func* argument) that takes two arguments.
+    By default, returns accumulated sums with ``operator.add()``.
+
+    >>> list(accumulate([1, 2, 3, 4, 5]))  # Running sum
+    [1, 3, 6, 10, 15]
+    >>> list(accumulate([1, 2, 3, 4, 5], func=operator.mul))  # Running product
+    [1, 2, 6, 24, 120]
+    >>> list(accumulate([0, 1, -1, 2, 3, 2], func=max))  # Running maximum
+    [0, 1, 1, 2, 3, 3]
+
+    This function is available in the ``itertools`` module for Python 3.2 and
+    greater.
+
+    """
+    it = iter(iterable)
+    try:
+        total = next(it)
+    except StopIteration:
+        return
+    else:
+        yield total
+
+    for element in it:
+        total = func(total, element)
+        yield total
 
 
 def take(n, iterable):

--- a/more_itertools/tests/test_more.py
+++ b/more_itertools/tests/test_more.py
@@ -1,4 +1,4 @@
-from __future__ import unicode_literals
+from __future__ import division, unicode_literals
 
 from contextlib import closing
 from functools import reduce
@@ -255,3 +255,38 @@ class WindowedTests(TestCase):
         """When the window size is negative, ValueError should be raised."""
         with self.assertRaises(ValueError):
             list(windowed([1, 2, 3, 4, 5], -1))
+
+
+class PartitionTests(TestCase):
+    """Tests for ``partition()``"""
+
+    def test_default(self):
+        """By default the function is ``bool``"""
+        iterable = [0, 1, False, True, '', 'a', None]
+        D = partition(iterable)
+        eq_(list(D[False]), [0, False, '', None])
+        eq_(list(D[True]), [1, True, 'a'])
+
+    def test_function(self):
+        """Custom function and keys: round down to nearest 10"""
+        iterable = [10, 20, 30, 11, 21, 31, 41, 12, 22, 23, 33, 43]
+        D = partition(iterable, 10, 20, 30, fn=lambda x: 10 * (x // 10))
+        eq_(sorted(D), [10, 20, 30])  # No 40; it wasn't in keys
+        eq_(list(D[10]), [10, 11, 12])
+        eq_(list(D[20]), [20, 21, 22, 23])
+        eq_(list(D[30]), [30, 31, 33])
+
+    def test_no_keys(self):
+        """Custom function but default keys: filter True and False"""
+        iterable = [0, 1, 2, 0, 1, 2]
+        D = partition(iterable, fn=lambda x: x)
+        eq_(list(D[False]), [0, 0])
+        eq_(list(D[True]), [1, 1])  # 1 == True
+
+    def test_no_function(self):
+        """Custom function but default keys: filter True and False"""
+        iterable = [0, 1, 2, 0, 1, 2]
+        D = partition(iterable, False, True, None)
+        eq_(list(D[False]), [0, 0])
+        eq_(list(D[True]), [1, 2, 1, 2])
+        eq_(list(D[None]), [])

--- a/more_itertools/tests/test_more.py
+++ b/more_itertools/tests/test_more.py
@@ -270,7 +270,7 @@ class PartitionTests(TestCase):
     def test_function(self):
         """Custom function and keys: round down to nearest 10"""
         iterable = [10, 20, 30, 11, 21, 31, 41, 12, 22, 23, 33, 43]
-        D = partition(iterable, 10, 20, 30, fn=lambda x: 10 * (x // 10))
+        D = partition(iterable, keys=(10, 20, 30), fn=lambda x: 10 * (x // 10))
         eq_(sorted(D), [10, 20, 30])  # No 40; it wasn't in keys
         eq_(list(D[10]), [10, 11, 12])
         eq_(list(D[20]), [20, 21, 22, 23])
@@ -286,7 +286,7 @@ class PartitionTests(TestCase):
     def test_no_function(self):
         """Custom function but default keys: filter True and False"""
         iterable = [0, 1, 2, 0, 1, 2]
-        D = partition(iterable, False, True, None)
+        D = partition(iterable, keys=(False, True, None))
         eq_(list(D[False]), [0, 0])
         eq_(list(D[True]), [1, 2, 1, 2])
         eq_(list(D[None]), [])

--- a/more_itertools/tests/test_more.py
+++ b/more_itertools/tests/test_more.py
@@ -257,20 +257,20 @@ class WindowedTests(TestCase):
             list(windowed([1, 2, 3, 4, 5], -1))
 
 
-class PartitionTests(TestCase):
-    """Tests for ``partition()``"""
+class SeparateTests(TestCase):
+    """Tests for ``separate()``"""
 
     def test_default(self):
         """By default the function is ``bool``"""
         iterable = [0, 1, False, True, '', 'a', None]
-        D = partition(iterable)
+        D = separate(iterable)
         eq_(list(D[False]), [0, False, '', None])
         eq_(list(D[True]), [1, True, 'a'])
 
     def test_function(self):
         """Custom function and keys: round down to nearest 10"""
         iterable = [10, 20, 30, 11, 21, 31, 41, 12, 22, 23, 33, 43]
-        D = partition(iterable, keys=(10, 20, 30), fn=lambda x: 10 * (x // 10))
+        D = separate(iterable, keys=(10, 20, 30), fn=lambda x: 10 * (x // 10))
         eq_(sorted(D), [10, 20, 30])  # No 40; it wasn't in keys
         eq_(list(D[10]), [10, 11, 12])
         eq_(list(D[20]), [20, 21, 22, 23])
@@ -279,14 +279,14 @@ class PartitionTests(TestCase):
     def test_no_keys(self):
         """Custom function but default keys: filter True and False"""
         iterable = [0, 1, 2, 0, 1, 2]
-        D = partition(iterable, fn=lambda x: x)
+        D = separate(iterable, fn=lambda x: x)
         eq_(list(D[False]), [0, 0])
         eq_(list(D[True]), [1, 1])  # 1 == True
 
     def test_no_function(self):
         """Custom function but default keys: filter True and False"""
         iterable = [0, 1, 2, 0, 1, 2]
-        D = partition(iterable, keys=(False, True, None))
+        D = separate(iterable, keys=(False, True, None))
         eq_(list(D[False]), [0, 0])
         eq_(list(D[True]), [1, 2, 1, 2])
         eq_(list(D[None]), [])

--- a/more_itertools/tests/test_recipes.py
+++ b/more_itertools/tests/test_recipes.py
@@ -11,6 +11,27 @@ def setup_module():
     seed(1337)
 
 
+class AccumulateTests(TestCase):
+    """Tests for ``accumulate()``"""
+
+    def test_empty(self):
+        """Test that an empty input returns an empty output"""
+        eq_(list(accumulate([])), [])
+
+    def test_default(self):
+        """Test accumulate with the default function (addition)"""
+        eq_(list(accumulate([1, 2, 3])), [1, 3, 6])
+
+    def test_bogus_function(self):
+        """Test accumulate with an invalid function"""
+        with self.assertRaises(TypeError):
+            list(accumulate([1, 2, 3], func=lambda x: x))
+
+    def test_custom_function(self):
+        """Test accumulate with a custom function"""
+        eq_(list(accumulate((1, 2, 3, 2, 1), func=max)), [1, 2, 3, 3, 3])
+
+
 class TakeTests(TestCase):
     """Tests for ``take()``"""
 

--- a/more_itertools/tests/test_recipes.py
+++ b/more_itertools/tests/test_recipes.py
@@ -53,6 +53,22 @@ class TabulateTests(TestCase):
         eq_(f, (-2, 0, 2))
 
 
+class TailTests(TestCase):
+    """Tests for ``tail()``"""
+
+    def test_greater(self):
+        """Length of iterable is greather than requested tail"""
+        eq_(list(tail(3, 'ABCDEFG')), ['E', 'F', 'G'])
+
+    def test_equal(self):
+        """Length of iterable is equal to the requested tail"""
+        eq_(list(tail(7, 'ABCDEFG')), ['A', 'B', 'C', 'D', 'E', 'F', 'G'])
+
+    def test_less(self):
+        """Length of iterable is less than requested tail"""
+        eq_(list(tail(8, 'ABCDEFG')), ['A', 'B', 'C', 'D', 'E', 'F', 'G'])
+
+
 class ConsumeTests(TestCase):
     """Tests for ``consume()``"""
 
@@ -97,6 +113,23 @@ class NthTests(TestCase):
     def test_negative_item_raises(self):
         """Ensure asking for a negative item raises an exception"""
         assert_raises(ValueError, nth, range(10), -3)
+
+
+class AllEqualTests(TestCase):
+    """Tests for ``all_equal()``"""
+
+    def test_true(self):
+        """Everything is equal"""
+        self.assertTrue(all_equal('aaaaaa'))
+
+    def test_false(self):
+        """Not everything is equal"""
+        self.assertFalse(all_equal('aaaaab'))
+
+    def test_tricky(self):
+        """Not everything is identical, but everything is equal"""
+        items = [1, complex(1, 0), 1.0]
+        self.assertTrue(all_equal(items))
 
 
 class QuantifyTests(TestCase):
@@ -240,6 +273,22 @@ class RoundrobinTests(TestCase):
             ['A', 1, 'B', 2, 'C', 'D'])
 
 
+class PartitionTests(TestCase):
+    """Tests for ``partition()``"""
+
+    def test_bool(self):
+        """Test when pred() returns a boolean"""
+        lesser, greater = partition(lambda x: x > 5, range(10))
+        eq_(list(lesser), [0, 1, 2, 3, 4, 5])
+        eq_(list(greater), [6, 7, 8, 9])
+
+    def test_arbitrary(self):
+        """Test when pred() returns an integer"""
+        divisibles, remainders = partition(lambda x: x % 3, range(10))
+        eq_(list(divisibles), [0, 3, 6, 9])
+        eq_(list(remainders), [1, 2, 4, 5, 7, 8])
+
+
 class PowersetTests(TestCase):
     """Tests for ``powerset()``"""
 
@@ -306,6 +355,26 @@ class IterExceptTests(TestCase):
         f = lambda: 25
         i = iter_except(l.pop, IndexError, f)
         eq_(list(i), [25, 3, 2, 1])
+
+
+class FirstTrueTests(TestCase):
+    """Tests for ``first_true()``"""
+
+    def test_something_true(self):
+        """Test with no keywords"""
+        eq_(first_true(range(10)), 1)
+
+    def test_nothing_true(self):
+        """Test default return value."""
+        eq_(first_true([0, 0, 0]), False)
+
+    def test_default(self):
+        """Test with a default keyword"""
+        eq_(first_true([0, 0, 0], default='!'), '!')
+
+    def test_pred(self):
+        """Test with a custom predicate"""
+        eq_(first_true([2, 4, 6], pred=lambda x: x % 3 == 0), 6)
 
 
 class RandomProductTests(TestCase):


### PR DESCRIPTION
Re: #67, this adds these functions from the [Python 3 itertools docs](https://docs.python.org/3/library/itertools.html) to `more_itertools.recipes`:
- `accumulate` - part of `itertools` in Python 3.2+
- `tail`
- `all_equal`
- `partition`
- `first_true`

I've built this on top of #66 to avoid conflicts.