### PR TITLE
Indexing and slicing of peekables

### DIFF
--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -70,8 +70,6 @@ def first(iterable, default=_marker):
         return default
 
 
-
-
 class peekable(object):
     """
     Wrapper for an iterator to allow lookahead.
@@ -161,15 +159,14 @@ class peekable(object):
         return self.__next__()
 
     def _get_slice(self, index):
-        start = 0 if index.start is None else index.start
+        start = index.start
         stop = index.stop
-        step = index.step
 
-        if (start < 0) or ((stop is not None) and (stop < 0)):
+        if (
+            ((start is not None) and (start < 0)) or
+            ((stop is not None) and (stop < 0))
+        ):
             raise ValueError('Negative indexing not supported')
-
-        if start == stop:
-            return []
 
         cache_len = len(self._cache)
 
@@ -186,7 +183,7 @@ class peekable(object):
                 except StopIteration:
                     break
 
-        return list(self._cache)[start:stop:step]
+        return list(self._cache)[index]
 
     def __getitem__(self, index):
         if isinstance(index, slice):

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -171,7 +171,7 @@ class peekable(object):
         cache_len = len(self._cache)
 
         if stop is None:
-            self._cache.extend(islice(self._it, None))
+            self._cache.extend(self._it)
         elif stop >= cache_len:
             self._cache.extend(islice(self._it, stop - cache_len))
 

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -7,7 +7,7 @@ from sys import version_info
 
 from six import iteritems
 
-from .recipes import take
+from .recipes import islice, take
 
 __all__ = ['chunked', 'first', 'peekable', 'collate', 'consumer', 'ilen',
            'iterate', 'with_iter', 'one', 'distinct_permutations',
@@ -171,17 +171,9 @@ class peekable(object):
         cache_len = len(self._cache)
 
         if stop is None:
-            while True:
-                try:
-                    self._cache.append(next(self._it))
-                except StopIteration:
-                    break
+            self._cache.extend(islice(self._it, None))
         elif stop >= cache_len:
-            for i in range(stop - cache_len):
-                try:
-                    self._cache.append(next(self._it))
-                except StopIteration:
-                    break
+            self._cache.extend(islice(self._it, stop - cache_len))
 
         return list(self._cache)[index]
 

--- a/more_itertools/tests/test_more.py
+++ b/more_itertools/tests/test_more.py
@@ -113,6 +113,63 @@ class PeekableTests(TestCase):
         eq_(p.peek(), 1)
         eq_(next(p), 1)
 
+    def test_indexing(self):
+        """
+        Indexing into the peekable shouldn't advance the iterator.
+        """
+        p = peekable('abcdefghijkl')
+
+        # The 0th index is what ``next()`` will return
+        eq_(p[0], 'a')
+        eq_(next(p), 'a')
+
+        # Indexing further into the peekable shouldn't advance the itertor
+        eq_(p[2], 'd')
+        eq_(next(p), 'b')
+
+        # The 0th index moves up with the iterator; the last index follows
+        eq_(p[0], 'c')
+        eq_(p[9], 'l')
+
+        eq_(next(p), 'c')
+        eq_(p[8], 'l')
+
+        # Negative indexing should fail
+        with self.assertRaises(ValueError):
+            p[-2]
+
+    def test_slicing(self):
+        """
+        Slicing the peekable shouldn't advance the iterator.
+        """
+        seq = list('abcdefghijkl')
+        p = peekable(seq)
+
+        # Slicing the peekable should just be like slicing a re-iterable
+        eq_(p[1:4], seq[1:4])
+
+        # Advancing the iterator moves the slices up also
+        eq_(next(p), 'a')
+        eq_(p[1:4], seq[1:][1:4])
+
+        # Implicit starts and stop should work
+        eq_(p[:5], seq[1:][:5])
+        eq_(p[:], seq[1:][:])
+
+        # Indexing past the end should work
+        eq_(p[:100], seq[1:][:100])
+
+        # Steps should work, including negative
+        eq_(p[::2], seq[1:][::2])
+        eq_(p[::-1], seq[1:][::-1])
+
+        # Negative indexing should fail
+        with self.assertRaises(ValueError):
+            p[-1:]
+
+        with self.assertRaises(ValueError):
+            p[:-1]
+
 
 class ConsumerTests(TestCase):
     """Tests for ``consumer()``"""


### PR DESCRIPTION
Re: Issue #4, this PR adds indexing and slicing support for peekables.

As described in the issue, you can think of this as analogous to calling `list()` on the remaining items in the iterable and indexing/slicing the result. The peekable will not be advanced, however.

You can even index and slice infinite iterables:
```python
>>> from itertools import count
... from more_itertools import peekable
... 
... p = peekable(count())
... p[10:21:2]
0: [10, 12, 14, 16, 18, 20]
>>> next(p)
0
>>> next(p)
1
```
