### PR TITLE
Make unique_everseen work with unhashable values, round 2

### DIFF
--- a/more_itertools/recipes.py
+++ b/more_itertools/recipes.py
@@ -233,15 +233,28 @@ def unique_everseen(iterable, key=None):
     seen = set()
     seen_add = seen.add
     if key is None:
-        for element in ifilterfalse(seen.__contains__, iterable):
-            seen_add(element)
+        for element in iterable:
+            try:
+                if element not in seen:
+                    seen_add(element)
+            except TypeError as e:
+                seen = list(seen)
+                seen_add = seen.append
+                if element not in seen:
+                    seen_add(element)
             yield element
     else:
         for element in iterable:
             k = key(element)
-            if k not in seen:
-                seen_add(k)
-                yield element
+            try:
+                if k not in seen:
+                    seen_add(k)
+            except TypeError as e:
+                seen = list(seen)
+                seen_add = seen.append
+                if k not in seen:
+                    seen_add(k)
+            yield element
 
 
 def unique_justseen(iterable, key=None):

--- a/more_itertools/recipes.py
+++ b/more_itertools/recipes.py
@@ -230,31 +230,31 @@ def unique_everseen(iterable, key=None):
         ['A', 'B', 'C', 'D']
 
     """
-    seen = set()
-    seen_add = seen.add
+    seenset = set()
+    seenset_add = seenset.add
+    seenlist = []
+    seenlist_add = seenlist.append
     if key is None:
         for element in iterable:
             try:
-                if element not in seen:
-                    seen_add(element)
+                if element not in seenset:
+                    seenset_add(element)
+                    yield element
             except TypeError as e:
-                seen = list(seen)
-                seen_add = seen.append
-                if element not in seen:
-                    seen_add(element)
-            yield element
+                if element not in seenlist:
+                    seenlist_add(element)
+                    yield element
     else:
         for element in iterable:
             k = key(element)
             try:
-                if k not in seen:
-                    seen_add(k)
+                if k not in seenset:
+                    seenset_add(k)
+                    yield element
             except TypeError as e:
-                seen = list(seen)
-                seen_add = seen.append
-                if k not in seen:
-                    seen_add(k)
-            yield element
+                if k not in seenlist:
+                    seenlist_add(k)
+                    yield element
 
 
 def unique_justseen(iterable, key=None):

--- a/more_itertools/recipes.py
+++ b/more_itertools/recipes.py
@@ -304,11 +304,16 @@ def powerset(iterable):
 
 
 def unique_everseen(iterable, key=None):
-    """Yield unique elements, preserving order.
+    """
+    Yield unique elements, preserving order.
         >>> list(unique_everseen('AAAABBBCCDAABBB'))
         ['A', 'B', 'C', 'D']
         >>> list(unique_everseen('ABBCcAD', str.lower))
         ['A', 'B', 'C', 'D']
+
+    Sequences with a mix of hashable and unhashable items can be used.
+    The function will be slower (i.e., O(N^2)) for unhashable items.
+
     """
     seenset = set()
     seenset_add = seenset.add

--- a/more_itertools/tests/test_recipes.py
+++ b/more_itertools/tests/test_recipes.py
@@ -334,6 +334,18 @@ class UniqueEverseenTests(TestCase):
         u = unique_everseen('aAbACCc', key=str.lower)
         eq_(list('abC'), list(u))
 
+    def test_unhashable(self):
+        """ensure things work for unhashable items"""
+        iterable = ['a', [1, 2, 3], [1, 2, 3], 'a']
+        u = unique_everseen(iterable)
+        eq_(list(u), ['a', [1, 2, 3]])
+
+    def test_unhashable_key(self):
+        """ensure things work for unhashable items with a custom key"""
+        iterable = ['a', [1, 2, 3], [1, 2, 3], 'a']
+        u = unique_everseen(iterable, key=lambda x: x)
+        eq_(list(u), ['a', [1, 2, 3]])
+
 
 class UniqueJustseenTests(TestCase):
     """Tests for ``unique_justseen()``"""


### PR DESCRIPTION
This PR includes @abarnert's commits from PR #20, a note in the docstring for `unique_everseen` about unhashable values, and some tests for the new behavior.

I'll close that PR in favor of this one.

---

I looked into simplifying the code, since both the "key specified" and "key not specified" branches use `for element in iterable` now. However, testing on some sample iterables showed that the current approach is significantly faster than two obvious simplifications.

```python
def unique_everseen_2(iterable, key=None):
    seenset = set()
    seenset_add = seenset.add
    seenlist = []
    seenlist_add = seenlist.append
    for element in iterable:
        k = element if key is None else key(element)  # Apply key function if specified
        try:
            if k not in seenset:
                seenset_add(k)
                yield element
        except TypeError as e:
            if k not in seenlist:
                seenlist_add(k)
                yield element
```

```python
def unique_everseen_3(iterable, key=lambda x: x):
    seenset = set()
    seenset_add = seenset.add
    seenlist = []
    seenlist_add = seenlist.append
    for element in iterable:
        k = key(element)  # Always apply key function, default is identity function
        try:
            if k not in seenset:
                seenset_add(k)
                yield element
        except TypeError as e:
            if k not in seenlist:
                seenlist_add(k)
                yield element
```

Testing code and results:
```python
>>> from more_itertools.recipes import unique_everseen, unique_everseen_2, unique_everseen_3
... from random import shuffle
... from string import ascii_lowercase
... from timeit import timeit
... 
... letters = list(ascii_lowercase * 100)
... shuffle(letters)
... 
... for f in (unique_everseen, unique_everseen_2, unique_everseen_3):
...     def stmt():
...         result = list(f(letters))
...         assert len(result) == 26
...     
...     elapsed = timeit(stmt, number=10000)
...     print(f.__name__, elapsed, sep='\t')
unique_everseen	1.2559344579931349
unique_everseen_2	1.8456749120086897
unique_everseen_3	3.4712724200217053
```