### PR TITLE
Add interleave, interleave_longest, and collapse

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -10,11 +10,14 @@ New Routines
 
 .. autofunction:: bucket
 .. autofunction:: chunked
+.. autofunction:: collapse
 .. autofunction:: collate(*iterables, key=lambda a: a, reverse=False)
 .. autofunction:: consumer
 .. autofunction:: distinct_permutations
 .. autofunction:: first(iterable[, default])
 .. autofunction:: ilen
+.. autofunction:: interleave
+.. autofunction:: interleave_longest
 .. autofunction:: intersperse
 .. autofunction:: iterate
 .. autofunction:: one

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -571,9 +571,8 @@ def interleave_longest(*iterables):
     >>> list(interleave_longest([1, 2, 3], [4, 5], [6, 7, 8]))
     [1, 4, 6, 2, 5, 7, 3, 8]
     """
-    dummy = object()
-    i = chain.from_iterable(zip_longest(*iterables, fillvalue=dummy))
-    return filter(lambda x: x is not dummy, i)
+    i = chain.from_iterable(zip_longest(*iterables, fillvalue=_marker))
+    return filter(lambda x: x is not _marker, i)
 
 
 def collapse(iterable, basetype=None, levels=None):
@@ -595,6 +594,7 @@ def collapse(iterable, basetype=None, levels=None):
             basetype and isinstance(node, basetype)):
             yield node
             return
+
         try:
             tree = iter(node)
         except TypeError:
@@ -602,7 +602,8 @@ def collapse(iterable, basetype=None, levels=None):
             return
         else:
             for child in tree:
-                for x in walk(child, level+1):
+                for x in walk(child, level + 1):
                     yield x
+
     for x in walk(iterable, 0):
         yield x

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -581,8 +581,8 @@ def collapse(iterable, basetype=None, levels=None):
     matching ``isinstance(element, basetype)``, and elements that are
     ``levels`` levels down.
 
-    >>> list(collapse([[1], 2, [[3], 4], [[[5]]]]))
-    [1, 2, 3, 4, 5]
+    >>> list(collapse([[1], 2, [[3], 4], [[[5]]], 'abc']))
+    [1, 2, 3, 4, 5, 'abc']
     >>> list(collapse([[1], 2, [[3], 4], [[[5]]]], levels=2))
     [1, 2, 3, 4, [5]]
     >>> list(collapse((1, [2], (3, [4, (5,)])), list))

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -616,10 +616,10 @@ def interleave_longest(*iterables):
     return filter(lambda x: x is not _marker, i)
 
 
-def collapse(iterable, basetype=None, levels=None):
+def collapse(iterable, base_type=None, levels=None):
     """Flatten an iterable containing some iterables (themselves containing
     some iterables, etc.) into non-iterable types, strings, elements
-    matching ``isinstance(element, basetype)``, and elements that are
+    matching ``isinstance(element, base_type)``, and elements that are
     ``levels`` levels down.
 
     >>> list(collapse([[1], 2, [[3], 4], [[[5]]], 'abc']))
@@ -633,7 +633,7 @@ def collapse(iterable, basetype=None, levels=None):
         if (
             ((levels is not None) and (level > levels)) or
             isinstance(node, string_types) or
-            ((basetype is not None) and isinstance(node, basetype))
+            ((base_type is not None) and isinstance(node, base_type))
         ):
             yield node
             return

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -209,22 +209,6 @@ def ilen(iterable):
     """
     return sum(1 for _ in iterable)
 
-def append(iterable, value):
-    """Return a new iterable with ``value`` appended to the end.
-
-    >>> list(append(range(5), 5))
-    [0, 1, 2, 3, 4, 5]
-    """
-    # This seems to be the fastest implementation of everything I tried.
-    return chain(iterable, [value])
-
-def prepend(iterable, value):
-    """Return a new iterable with ``value`` prepended to the start.
-
-    >>> list(prepend(range(5), -1))
-    [-1, 0, 1, 2, 3, 4]
-    """
-    return chain([value], iterable)
 
 def interleave(*iterables):
     """Return a new iterable yielding from each iterable in turn,
@@ -235,6 +219,7 @@ def interleave(*iterables):
     [1, 4, 6, 2, 5, 7]
     """
     return chain.from_iterable(izip(*iterables))
+
 
 def interleave_longest(*iterables):
     """Return a new iterable yielding from each iterable in turn,
@@ -247,6 +232,7 @@ def interleave_longest(*iterables):
     dummy = object()
     i = chain.from_iterable(izip_longest(*iterables, fillvalue=dummy))
     return ifilter(lambda x: x is not dummy, i)
+
 
 def collapse(iterable, basetype=None, levels=None):
     """Flatten an iterable containing some iterables (themselves containing
@@ -263,7 +249,7 @@ def collapse(iterable, basetype=None, levels=None):
     """
     def walk(node, level):
         if (levels is not None and level > levels or
-            isinstance(node, basestring) or 
+            isinstance(node, basestring) or
             basetype and isinstance(node, basetype)):
             yield node
             return

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -589,9 +589,11 @@ def collapse(iterable, basetype=None, levels=None):
     [1, [2], 3, [4, (5,)]]
     """
     def walk(node, level):
-        if (levels is not None and level > levels or
+        if (
+            ((levels is not None) and (level > levels)) or
             isinstance(node, string_types) or
-            basetype and isinstance(node, basetype)):
+            ((basetype is not None) and isinstance(node, basetype))
+        ):
             yield node
             return
 

--- a/more_itertools/tests/test_more.py
+++ b/more_itertools/tests/test_more.py
@@ -416,6 +416,6 @@ class TestCollapse(TestCase):
 
     def test_collapse_to_list(self):
         l = (1, [2], (3, [4, (5,)], 'ab'))
-        actual = list(collapse(l, basetype=list))
+        actual = list(collapse(l, base_type=list))
         expected = [1, [2], 3, [4, (5,)], 'ab']
         eq_(actual, expected)

--- a/more_itertools/tests/test_more.py
+++ b/more_itertools/tests/test_more.py
@@ -385,5 +385,7 @@ class TestCollapse(TestCase):
             list(collapse(l, levels=2)))
 
     def test_collapse_to_list(self):
-        l = (1, [2], (3, [4, (5,)]))
-        eq_(list(collapse(l, basetype=list)), [1, [2], 3, [4, (5,)]])
+        l = (1, [2], (3, [4, (5,)], 'ab'))
+        actual = list(collapse(l, basetype=list))
+        expected = [1, [2], 3, [4, (5,)], 'ab']
+        eq_(actual, expected)

--- a/more_itertools/tests/test_more.py
+++ b/more_itertools/tests/test_more.py
@@ -125,15 +125,10 @@ def test_ilen():
     """Sanity-check ``ilen()``."""
     eq_(ilen(ifilter(lambda x: x % 10 == 0, range(101))), 11)
 
-class TestAppendPrepend(TestCase):
-    """Tests for ``append()`` and ``prepend()``"""
-    def test_append(self):
-        eq_(list(append(range(5), 5)), list(range(6)))
-    def test_prepend(self):
-        eq_(list(prepend(range(5), -1)), list(range(-1, 5)))
 
 class TestInterleave(TestCase):
     """Tests for ``interleave()`` and ``interleave_longest()``"""
+
     def test_interleave(self):
         l = [[1, 2, 3], [4, 5], [6, 7, 8]]
         eq_(list(interleave(*l)), [1, 4, 6, 2, 5, 7])
@@ -141,6 +136,7 @@ class TestInterleave(TestCase):
         eq_(list(interleave(*l)), [1, 3, 6, 2, 4, 7])
         l = [[1, 2, 3], [4, 5, 6], [7, 8]]
         eq_(list(interleave(*l)), [1, 4, 7, 2, 5, 8])
+
     def test_interleave_longest(self):
         l = [[1, 2, 3], [4, 5], [6, 7, 8]]
         eq_(list(interleave_longest(*l)), [1, 4, 6, 2, 5, 7, 3, 8])
@@ -149,21 +145,27 @@ class TestInterleave(TestCase):
         l = [[1, 2, 3], [4, 5, 6], [7, 8]]
         eq_(list(interleave_longest(*l)), [1, 4, 7, 2, 5, 8, 3, 6])
 
+
 class TestCollapse(TestCase):
+
     def test_collapse(self):
         l = [[1], 2, [[3], 4], [[[5]]]]
         eq_(list(collapse(l)), [1, 2, 3, 4, 5])
+
     def test_collapse_to_string(self):
-        l = [["s1"], "s2", [["s3"], "s4"], [[["s5"]]]] 
+        l = [["s1"], "s2", [["s3"], "s4"], [[["s5"]]]]
         eq_(list(collapse(l)), ["s1", "s2", "s3", "s4", "s5"])
+
     def test_collapse_flatten(self):
         l = [[1], [2], [[3], 4], [[[5]]]]
         eq_(list(collapse(l, levels=1)), list(flatten(l)))
+
     def test_collapse_to_level(self):
         l = [[1], 2, [[3], 4], [[[5]]]]
         eq_(list(collapse(l, levels=2)), [1, 2, 3, 4, [5]])
         eq_(list(collapse(collapse(l, levels=1), levels=1)),
             list(collapse(l, levels=2)))
+
     def test_collapse_to_list(self):
         l = (1, [2], (3, [4, (5,)]))
         eq_(list(collapse(l, basetype=list)), [1, [2], 3, [4, (5,)]])

--- a/more_itertools/tests/test_more.py
+++ b/more_itertools/tests/test_more.py
@@ -124,3 +124,46 @@ class ConsumerTests(TestCase):
 def test_ilen():
     """Sanity-check ``ilen()``."""
     eq_(ilen(ifilter(lambda x: x % 10 == 0, range(101))), 11)
+
+class TestAppendPrepend(TestCase):
+    """Tests for ``append()`` and ``prepend()``"""
+    def test_append(self):
+        eq_(list(append(range(5), 5)), list(range(6)))
+    def test_prepend(self):
+        eq_(list(prepend(range(5), -1)), list(range(-1, 5)))
+
+class TestInterleave(TestCase):
+    """Tests for ``interleave()`` and ``interleave_longest()``"""
+    def test_interleave(self):
+        l = [[1, 2, 3], [4, 5], [6, 7, 8]]
+        eq_(list(interleave(*l)), [1, 4, 6, 2, 5, 7])
+        l = [[1, 2], [3, 4, 5], [6, 7, 8]]
+        eq_(list(interleave(*l)), [1, 3, 6, 2, 4, 7])
+        l = [[1, 2, 3], [4, 5, 6], [7, 8]]
+        eq_(list(interleave(*l)), [1, 4, 7, 2, 5, 8])
+    def test_interleave_longest(self):
+        l = [[1, 2, 3], [4, 5], [6, 7, 8]]
+        eq_(list(interleave_longest(*l)), [1, 4, 6, 2, 5, 7, 3, 8])
+        l = [[1, 2], [3, 4, 5], [6, 7, 8]]
+        eq_(list(interleave_longest(*l)), [1, 3, 6, 2, 4, 7, 5, 8])
+        l = [[1, 2, 3], [4, 5, 6], [7, 8]]
+        eq_(list(interleave_longest(*l)), [1, 4, 7, 2, 5, 8, 3, 6])
+
+class TestCollapse(TestCase):
+    def test_collapse(self):
+        l = [[1], 2, [[3], 4], [[[5]]]]
+        eq_(list(collapse(l)), [1, 2, 3, 4, 5])
+    def test_collapse_to_string(self):
+        l = [["s1"], "s2", [["s3"], "s4"], [[["s5"]]]] 
+        eq_(list(collapse(l)), ["s1", "s2", "s3", "s4", "s5"])
+    def test_collapse_flatten(self):
+        l = [[1], [2], [[3], 4], [[[5]]]]
+        eq_(list(collapse(l, levels=1)), list(flatten(l)))
+    def test_collapse_to_level(self):
+        l = [[1], 2, [[3], 4], [[[5]]]]
+        eq_(list(collapse(l, levels=2)), [1, 2, 3, 4, [5]])
+        eq_(list(collapse(collapse(l, levels=1), levels=1)),
+            list(collapse(l, levels=2)))
+    def test_collapse_to_list(self):
+        l = (1, [2], (3, [4, (5,)]))
+        eq_(list(collapse(l, basetype=list)), [1, [2], 3, [4, (5,)]])


### PR DESCRIPTION
This PR builds on #22, adding @abarnert's `interleave`, `interleave_longest`, and `collapse` functions.

I've updated them to work with Python 3 natively, and addressed some of the comments from the original PR.

Re: [this comment thread](https://github.com/erikrose/more-itertools/pull/22#r3275958) about `collapse`, the situation is a bit more complicated than it seems.

The function currently special-cases text types. The thread suggested that `basestring` (or `six.string_types`) could be used as the default for the `basetype` argument. However, this will cause infinite recursion without a special case, as `iter(s)` will return an iterator even when `s` is a single character string.

My feeling is that @abarnert was basically right about what people want (strings treated as a unit, not just another iterable) and that this should continue to be the behavior, but I'm open to alternate suggestions.