### PR TITLE
Iterate through peekables more quickly

### DIFF
--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -150,9 +150,10 @@ class peekable(object):
         return self._cache[0]
 
     def __next__(self):
-        ret = self.peek()
-        self._cache.popleft()
-        return ret
+        if self._cache:
+            return self._cache.popleft()
+
+        return next(self._it)
 
     def next(self):
         # For Python 2 compatibility


### PR DESCRIPTION
Re: [this discussion in issue #53](https://github.com/erikrose/more-itertools/issues/53#issuecomment-260524759), this PR modifies `peekable.__next__` to make (destructive) iteration through `peekable()`-wrapped iterators faster.

On some tests (like this one) the difference is 2.5x:
```python
>>> for func in (peekable_old, peekable_new):
...     def stmt():
...         iterable = iter(range(10000))
...         sum(func(iterable))
... 
...     result = timeit(stmt, number=1000)
...     print(result)
8.013842238986399
3.322781088994816
```

The simplification is that we don't need to mess with the cache if it's empty (likely to be the case if we're iterating through in a loop), and if it's not empty we can pop off its leftmost item and return that.