### PR TITLE
Add look_ahead function

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -17,9 +17,9 @@ New Routines
 .. autofunction:: ilen
 .. autofunction:: intersperse
 .. autofunction:: iterate
-.. autofunction:: look_ahead
 .. autofunction:: one
 .. autoclass:: peekable
+.. autofunction:: spy
 .. autofunction:: unique_to_each
 .. autofunction:: windowed
 .. autofunction:: with_iter

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -17,6 +17,7 @@ New Routines
 .. autofunction:: ilen
 .. autofunction:: intersperse
 .. autofunction:: iterate
+.. autofunction:: look_ahead
 .. autofunction:: one
 .. autoclass:: peekable
 .. autofunction:: unique_to_each

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -3,15 +3,18 @@ from __future__ import print_function
 from collections import defaultdict, deque
 from functools import partial, wraps
 from heapq import merge
+from itertools import chain
 from sys import version_info
 
 from six import iteritems
 
 from .recipes import islice, take
 
-__all__ = ['chunked', 'first', 'peekable', 'collate', 'consumer', 'ilen',
-           'iterate', 'with_iter', 'one', 'distinct_permutations',
-           'intersperse', 'unique_to_each', 'windowed', 'bucket']
+__all__ = [
+    'chunked', 'first', 'peekable', 'collate', 'consumer', 'ilen', 'iterate',
+    'with_iter', 'one', 'distinct_permutations', 'intersperse',
+    'unique_to_each', 'windowed', 'bucket', 'look_ahead'
+]
 
 
 _marker = object()
@@ -545,3 +548,47 @@ class bucket(object):
 
     def __getitem__(self, value):
         return self._get_values(value)
+
+
+def look_ahead(iterable, n=1):
+    """
+    Returns a 2-tuple with a list containing the first *n* elements of
+    *iterable*, and an iterator with the same items as *iterable*.
+    This allows you to "look ahead" at the items in the iterable without
+    advancing it.
+
+    There is one item in the list by default:
+
+        >>> iterable = 'abcdefg'
+        >>> head, iterable = look_ahead(iterable)
+        >>> head
+        ['a']
+        >>> list(iterable)
+        ['a', 'b', 'c', 'd', 'e', 'f', 'g']
+
+    You may use unpacking to retrieve items instead of lists:
+
+        >>> (head,), iterable = look_ahead('abcdefg')
+        >>> head
+        'a'
+        >>> (first, second), iterable = look_ahead('abcdefg', 2)
+        >>> first
+        'a'
+        >>> second
+        'b'
+
+    The number of items requested can be larger than the number of items in
+    the iterable:
+
+        >>> iterable = [1, 2, 3, 4, 5]
+        >>> head, iterable = look_ahead(iterable, 10)
+        >>> head
+        [1, 2, 3, 4, 5]
+        >>> list(iterable)
+        [1, 2, 3, 4, 5]
+
+    """
+    it = iter(iterable)
+    head = take(n, it)
+
+    return head, chain(head, it)

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -13,7 +13,7 @@ from .recipes import islice, take
 __all__ = [
     'chunked', 'first', 'peekable', 'collate', 'consumer', 'ilen', 'iterate',
     'with_iter', 'one', 'distinct_permutations', 'intersperse',
-    'unique_to_each', 'windowed', 'bucket', 'look_ahead'
+    'unique_to_each', 'windowed', 'bucket', 'spy'
 ]
 
 
@@ -531,7 +531,7 @@ class bucket(object):
         """
         while True:
             # If we've cached some items that match the target value, emit
-            # the first one and evit it from the cache.
+            # the first one and evict it from the cache.
             if self._cache[value]:
                 yield self._cache[value].popleft()
             # Otherwise we need to advance the parent iterator to search for
@@ -550,9 +550,8 @@ class bucket(object):
         return self._get_values(value)
 
 
-def look_ahead(iterable, n=1):
-    """
-    Returns a 2-tuple with a list containing the first *n* elements of
+def spy(iterable, n=1):
+    """Return a 2-tuple with a list containing the first *n* elements of
     *iterable*, and an iterator with the same items as *iterable*.
     This allows you to "look ahead" at the items in the iterable without
     advancing it.
@@ -560,7 +559,7 @@ def look_ahead(iterable, n=1):
     There is one item in the list by default:
 
         >>> iterable = 'abcdefg'
-        >>> head, iterable = look_ahead(iterable)
+        >>> head, iterable = spy(iterable)
         >>> head
         ['a']
         >>> list(iterable)
@@ -568,10 +567,10 @@ def look_ahead(iterable, n=1):
 
     You may use unpacking to retrieve items instead of lists:
 
-        >>> (head,), iterable = look_ahead('abcdefg')
+        >>> (head,), iterable = spy('abcdefg')
         >>> head
         'a'
-        >>> (first, second), iterable = look_ahead('abcdefg', 2)
+        >>> (first, second), iterable = spy('abcdefg', 2)
         >>> first
         'a'
         >>> second
@@ -581,7 +580,7 @@ def look_ahead(iterable, n=1):
     the iterable:
 
         >>> iterable = [1, 2, 3, 4, 5]
-        >>> head, iterable = look_ahead(iterable, 10)
+        >>> head, iterable = spy(iterable, 10)
         >>> head
         [1, 2, 3, 4, 5]
         >>> list(iterable)

--- a/more_itertools/tests/test_more.py
+++ b/more_itertools/tests/test_more.py
@@ -343,18 +343,18 @@ class BucketTests(TestCase):
         eq_(next(D[10]), 10)
 
 
-class LookAheadTests(TestCase):
-    """Tests for ``lookahead()``"""
+class SpyTests(TestCase):
+    """Tests for ``spy()``"""
 
     def test_basic(self):
         original_iterable = iter('abcdefg')
-        head, new_iterable = look_ahead(original_iterable)
+        head, new_iterable = spy(original_iterable)
         eq_(head, ['a'])
         eq_(list(new_iterable), ['a', 'b', 'c', 'd', 'e', 'f', 'g'])
 
     def test_unpacking(self):
         original_iterable = iter('abcdefg')
-        (first, second, third), new_iterable = look_ahead(original_iterable, 3)
+        (first, second, third), new_iterable = spy(original_iterable, 3)
         eq_(first, 'a')
         eq_(second, 'b')
         eq_(third, 'c')
@@ -362,12 +362,12 @@ class LookAheadTests(TestCase):
 
     def test_too_many(self):
         original_iterable = iter('abc')
-        head, new_iterable = look_ahead(original_iterable, 4)
+        head, new_iterable = spy(original_iterable, 4)
         eq_(head, ['a', 'b', 'c'])
         eq_(list(new_iterable), ['a', 'b', 'c'])
 
     def test_zero(self):
         original_iterable = iter('abc')
-        head, new_iterable = look_ahead(original_iterable, 0)
+        head, new_iterable = spy(original_iterable, 0)
         eq_(head, [])
         eq_(list(new_iterable), ['a', 'b', 'c'])

--- a/more_itertools/tests/test_more.py
+++ b/more_itertools/tests/test_more.py
@@ -341,3 +341,33 @@ class BucketTests(TestCase):
 
         # Checking in-ness shouldn't advance the iterator
         eq_(next(D[10]), 10)
+
+
+class LookAheadTests(TestCase):
+    """Tests for ``lookahead()``"""
+
+    def test_basic(self):
+        original_iterable = iter('abcdefg')
+        head, new_iterable = look_ahead(original_iterable)
+        eq_(head, ['a'])
+        eq_(list(new_iterable), ['a', 'b', 'c', 'd', 'e', 'f', 'g'])
+
+    def test_unpacking(self):
+        original_iterable = iter('abcdefg')
+        (first, second, third), new_iterable = look_ahead(original_iterable, 3)
+        eq_(first, 'a')
+        eq_(second, 'b')
+        eq_(third, 'c')
+        eq_(list(new_iterable), ['a', 'b', 'c', 'd', 'e', 'f', 'g'])
+
+    def test_too_many(self):
+        original_iterable = iter('abc')
+        head, new_iterable = look_ahead(original_iterable, 4)
+        eq_(head, ['a', 'b', 'c'])
+        eq_(list(new_iterable), ['a', 'b', 'c'])
+
+    def test_zero(self):
+        original_iterable = iter('abc')
+        head, new_iterable = look_ahead(original_iterable, 0)
+        eq_(head, [])
+        eq_(list(new_iterable), ['a', 'b', 'c'])


### PR DESCRIPTION
Re: Issue #53, this adds a "peek without `peekable()`" function called `look_ahead()`. It returns the first `n` items from an iterable, plus a copy of the iterable that has not been advanced.

Iterating over `look_ahead()`-returned iterable is _much_ faster than iterating over a `peekable()`-wrapped iterable.
```python
>>> from more_itertools import look_ahead, peekable
... from timeit import timeit
... 
... def old():
...     iterable = iter(range(10000))
...     p = peekable(iterable)
...     assert sum(peekable(iterable)) == 49995000
... 
... def new():
...     iterable = iter(range(10000))
...     head, p = look_ahead(iterable, 0)
...     assert sum(look_ahead(iterable)[1]) == 49995000
... 
... print(timeit(old, number=1000))
... print(timeit(new, number=1000))
8.047204594011419
0.25736623600823805
```

That's over 30x faster than the master branch, and still at least 15x faster than the optimized `peekable` in PR #75.

Many thanks to @themiurgo and @mathieulongtin for their contribution to this.

