### PR TITLE
Normalize docstring formatting.

### DIFF
--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -71,8 +71,7 @@ def first(iterable, default=_marker):
 
 
 class peekable(object):
-    """
-    Wrapper for an iterator to allow lookahead.
+    """Wrap an iterator to allow lookahead.
 
     Call ``peek()`` on the result to get the value that will next pop out of
     ``next()``, without advancing the iterator:
@@ -114,7 +113,6 @@ class peekable(object):
         >>> assert not peekable([])
 
     """
-
     def __init__(self, iterable):
         self._it = iter(iterable)
         self._cache = deque()
@@ -185,9 +183,9 @@ class peekable(object):
 
 
 def _collate(*iterables, **kwargs):
-    """
-    Helper for ``collate()`` - called when the user is using the ``reverse`` or
-    ``key`` keyword arguments on Python versions below 3.5 .
+    """Helper for ``collate()``, called when the user is using the ``reverse``
+    or ``key`` keyword arguments on Python versions below 3.5.
+
     """
     key = kwargs.pop('key', lambda a: a)
     reverse = kwargs.pop('reverse', False)
@@ -223,6 +221,7 @@ def collate(*iterables, **kwargs):
 
     If neither of the keyword arguments are specified, this function delegates
     to ``heapq.merge()``.
+
     """
     if not kwargs:
         return merge(*iterables)
@@ -384,9 +383,7 @@ def distinct_permutations(iterable):
 
 
 def intersperse(e, iterable):
-    """
-    The intersperse generator takes an element and an iterable and
-    `intersperses' that element between the elements of the iterable.
+    """Intersperse element ``e`` between the elements of an iterable.
 
     >>> from more_itertools import intersperse
     >>> list(intersperse('x', [1, 'o', 5, 'k']))
@@ -399,6 +396,7 @@ def intersperse(e, iterable):
     TypeError: 'int' object is not iterable
     >>> list(intersperse('x', []))
     []
+
     """
     iterable = iter(iterable)
     if iterable:
@@ -410,8 +408,7 @@ def intersperse(e, iterable):
 
 
 def unique_to_each(*iterables):
-    """
-    Return the elements from each of the input iterables that aren't in the
+    """Return the elements from each of the input iterables that aren't in the
     other input iterables.
 
     For example, suppose packages 1, 2, and 3 have these dependencies:
@@ -431,6 +428,7 @@ def unique_to_each(*iterables):
     [['p', 'p'], ['o', 'u', 'r']]
 
     It is assumed that the elements of each iterable are hashable.
+
     """
     elements_to_indices = {}
     pool = [list(it) for it in iterables]
@@ -448,8 +446,8 @@ def unique_to_each(*iterables):
 
 
 def windowed(seq, n, fillvalue=None):
-    """
-    Returns a sliding window (of width n) over data from the iterable.
+    """Return a sliding window (of width n) over data from the iterable.
+    
     When n=2 this is equivalent to ``pairwise(iterable)``.
     When n is larger than the iterable, ``fillvalue`` is used in place of
     missing values.
@@ -461,7 +459,8 @@ def windowed(seq, n, fillvalue=None):
     (2, 3, 4)
     >>> next(all_windows)
     (3, 4, 5)
-     """
+
+    """
     if n < 0:
         raise ValueError('n must be >= 0')
     if n == 0:
@@ -484,9 +483,8 @@ def windowed(seq, n, fillvalue=None):
 
 
 class bucket(object):
-    """
-    Wraps an iterable and returns an object that buckets the iterable
-    into child iterables based on the *key* function.
+    """Wrap an iterable and return an object that buckets the iterable into
+    child iterables based on a ``key`` function.
 
     >>> iterable = ['a1', 'b1', 'c1', 'a2', 'b2', 'c2', 'b3']
     >>> s = bucket(iterable, key=lambda s: s[0])  # Select by first character
@@ -504,7 +502,6 @@ class bucket(object):
     will exhaust the iterable and cache all values.
 
     """
-
     def __init__(self, iterable, key):
         self._it = iter(iterable)
         self._key = key


### PR DESCRIPTION
Follow PEP 257: specifically, the version that was in force when the original docstrings in more-itertools were written:

* "Return" rather than "Returns".
* Skip a line before the closing quotes of a multi-line docstring.
* Start the docstring on the same line as the opening quotes.