### PR TITLE
Add split_before and split_after functions

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -22,6 +22,8 @@ New Routines
 .. autofunction:: iterate
 .. autofunction:: one
 .. autoclass:: peekable
+.. autofunction:: split_after
+.. autofunction:: split_before
 .. autofunction:: spy
 .. autofunction:: unique_to_each
 .. autofunction:: windowed

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -676,7 +676,7 @@ def split_after(iterable, pred):
     """Yield lists of items from *iterable*, where each list ends with an
     item where callable *pred* returns ``True``:
 
-        >>> list(split_after('one1two2', lambda s: s.isnumeric()))
+        >>> list(split_after('one1two2', lambda s: s.isdigit()))
         [['o', 'n', 'e', '1'], ['t', 'w', 'o', '2']]
 
         >>> list(split_after(range(10), lambda n: n % 3 == 0))

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -15,7 +15,7 @@ __all__ = [
     'chunked', 'first', 'peekable', 'collate', 'consumer', 'ilen', 'iterate',
     'with_iter', 'one', 'distinct_permutations', 'intersperse',
     'unique_to_each', 'windowed', 'bucket', 'spy', 'interleave',
-    'interleave_longest', 'collapse'
+    'interleave_longest', 'collapse', 'split_before', 'split_after'
 ]
 
 
@@ -650,3 +650,44 @@ def collapse(iterable, base_type=None, levels=None):
 
     for x in walk(iterable, 0):
         yield x
+
+
+def split_before(iterable, pred):
+    """Yield lists of items from *iterable*, where each list starts with an
+    item where callable *pred* returns ``True``:
+
+        >>> list(split_before('OneTwo', lambda s: s.isupper()))
+        [['O', 'n', 'e'], ['T', 'w', 'o']]
+
+        >>> list(split_before(range(10), lambda n: n % 3 == 0))
+        [[0, 1, 2], [3, 4, 5], [6, 7, 8], [9]]
+
+    """
+    buf = []
+    for item in iter(iterable):
+        if pred(item) and buf:
+            yield buf
+            buf = []
+        buf.append(item)
+    yield buf
+
+
+def split_after(iterable, pred):
+    """Yield lists of items from *iterable*, where each list ends with an
+    item where callable *pred* returns ``True``:
+
+        >>> list(split_after('one1two2', lambda s: s.isnumeric()))
+        [['o', 'n', 'e', '1'], ['t', 'w', 'o', '2']]
+
+        >>> list(split_after(range(10), lambda n: n % 3 == 0))
+        [[0], [1, 2, 3], [4, 5, 6], [7, 8, 9]]
+
+    """
+    buf = []
+    for item in iter(iterable):
+        buf.append(item)
+        if pred(item) and buf:
+            yield buf
+            buf = []
+    if buf:
+        yield buf

--- a/more_itertools/tests/test_more.py
+++ b/more_itertools/tests/test_more.py
@@ -419,3 +419,41 @@ class TestCollapse(TestCase):
         actual = list(collapse(l, base_type=list))
         expected = [1, [2], 3, [4, (5,)], 'ab']
         eq_(actual, expected)
+
+
+class SplitBeforeTest(TestCase):
+    """Tests for ``split_before()``"""
+
+    def test_starts_with_sep(self):
+        actual = list(split_before('xooxoo', lambda c: c == 'x'))
+        expected = [['x', 'o', 'o'], ['x', 'o', 'o']]
+        eq_(actual, expected)
+
+    def test_ends_with_sep(self):
+        actual = list(split_before('ooxoox', lambda c: c == 'x'))
+        expected = [['o', 'o'], ['x', 'o', 'o'], ['x']]
+        eq_(actual, expected)
+
+    def test_no_sep(self):
+        actual = list(split_before('ooo', lambda c: c == 'x'))
+        expected = [['o', 'o', 'o']]
+        eq_(actual, expected)
+
+
+class SplitAfterTest(TestCase):
+    """Tests for ``split_after()``"""
+
+    def test_starts_with_sep(self):
+        actual = list(split_after('xooxoo', lambda c: c == 'x'))
+        expected = [['x'], ['o', 'o', 'x'], ['o', 'o']]
+        eq_(actual, expected)
+
+    def test_ends_with_sep(self):
+        actual = list(split_after('ooxoox', lambda c: c == 'x'))
+        expected = [['o', 'o', 'x'], ['o', 'o', 'x']]
+        eq_(actual, expected)
+
+    def test_no_sep(self):
+        actual = list(split_after('ooo', lambda c: c == 'x'))
+        expected = [['o', 'o', 'o']]
+        eq_(actual, expected)


### PR DESCRIPTION
Re: Issue #39, this PR adds two new functions - `split_before()` and `split_after()`. These break up a list based on a user-supplied condition. There are two functions, as doing this with a keyword argument is pretty awkward, and there is precedent for that sort of thing in the `str` methods like `split` and `rsplit`.

Many thanks to @astronouth7303 for the idea and the implementation of `split_before()`. I like these examples in particular:
```python
>>> list(split_before('OneTwo', lambda s: s.isupper()))
[['O', 'n', 'e'], ['T', 'w', 'o']]
>>> list(split_after(iterable, is_prime))
[[2],
 [3],
 [4, 5],
 [6, 7],
 [8, 9, 10, 11],
 [12, 13],
 [14, 15, 16, 17],
 [18, 19],
 [20, 21, 22, 23]]
```
