### PR TITLE
Avoid leaving a reference in chunked()

### DIFF
--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -39,11 +39,18 @@ def chunked(iterable, n):
 
     """
     iterable = iter(iterable)
+
+    # To avoid leaving a reference to to the chunk in this generator function,
+    # we put the chunk in a list and then pop it off the list when we yield.
+    chunk_holder = []
+    append = chunk_holder.append
+    pop = chunk_holder.pop
+
     while True:
-        chunk = take(n, iterable)
-        if not chunk:
+        append(list(islice(iterable, n)))
+        if not chunk_holder[0]:
             return
-        yield chunk
+        yield pop()
 
 
 def first(iterable, default=_marker):


### PR DESCRIPTION
Re: Issue #13, this PR modifies `chunked()` in order to make garbage collection of retrieved chunks possible. The method comes from @piskvorky's code. See also [my](https://github.com/erikrose/more-itertools/issues/13#issuecomment-260221700) [comments](https://github.com/erikrose/more-itertools/issues/13#issuecomment-261435348) re: performance.

I couldn't get `sys.getrefcount()` to show me that there was a difference, but maybe someone else has an idea for how to test?