### PR TITLE
Add sliced function

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -22,11 +22,8 @@ New Routines
 .. autofunction:: iterate
 .. autofunction:: one
 .. autoclass:: peekable
-<<<<<<< HEAD
-.. autofunction:: sliced
-=======
 .. autofunction:: side_effect
->>>>>>> origin/master
+.. autofunction:: sliced
 .. autofunction:: spy
 .. autofunction:: unique_to_each
 .. autofunction:: windowed

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -22,6 +22,7 @@ New Routines
 .. autofunction:: iterate
 .. autofunction:: one
 .. autoclass:: peekable
+.. autofunction:: sliced
 .. autofunction:: spy
 .. autofunction:: unique_to_each
 .. autofunction:: windowed

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -15,7 +15,7 @@ __all__ = [
     'chunked', 'first', 'peekable', 'collate', 'consumer', 'ilen', 'iterate',
     'with_iter', 'one', 'distinct_permutations', 'intersperse',
     'unique_to_each', 'windowed', 'bucket', 'spy', 'interleave',
-    'interleave_longest', 'collapse'
+    'interleave_longest', 'collapse', 'sliced'
 ]
 
 
@@ -650,3 +650,34 @@ def collapse(iterable, base_type=None, levels=None):
 
     for x in walk(iterable, 0):
         yield x
+
+
+def sliced(seq, n):
+    """Yield slices of length *n* from the sequence *seq*.
+
+        >>> list(sliced((1, 2, 3, 4, 5, 6), 3))
+        [(1, 2, 3), (4, 5, 6)]
+
+    If the length of the sequence is not divisible by the requested slice
+    length, the last slice will be shorter.
+
+        >>> list(sliced((1, 2, 3, 4, 5, 6, 7, 8), 3))
+        [(1, 2, 3), (4, 5, 6), (7, 8)]
+
+    This function will only work for sliceable objects. For non-sliceable
+    iterable, see ``chunked()``.
+
+    """
+    # To avoid leaving a reference to the slice in this generator function,
+    # we put the slice in a list and then pop it off the list when we yield.
+    slice_holder = []
+    append = slice_holder.append
+    pop = slice_holder.pop
+
+    i = 0
+    while True:
+        append(seq[i:i + n])
+        if not slice_holder[0]:
+            return
+        yield pop()
+        i += n

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -3,7 +3,7 @@ from __future__ import print_function
 from collections import defaultdict, deque
 from functools import partial, wraps
 from heapq import merge
-from itertools import chain, islice
+from itertools import chain, count, islice, takewhile
 from sys import version_info
 
 from six import iteritems, string_types
@@ -668,16 +668,4 @@ def sliced(seq, n):
     iterable, see ``chunked()``.
 
     """
-    # To avoid leaving a reference to the slice in this generator function,
-    # we put the slice in a list and then pop it off the list when we yield.
-    slice_holder = []
-    append = slice_holder.append
-    pop = slice_holder.pop
-
-    i = 0
-    while True:
-        append(seq[i:i + n])
-        if not slice_holder[0]:
-            return
-        yield pop()
-        i += n
+    return takewhile(bool, (seq[i: i + n] for i in count(0, n)))

--- a/more_itertools/tests/test_more.py
+++ b/more_itertools/tests/test_more.py
@@ -419,3 +419,23 @@ class TestCollapse(TestCase):
         actual = list(collapse(l, base_type=list))
         expected = [1, [2], 3, [4, (5,)], 'ab']
         eq_(actual, expected)
+
+
+class SlicedTests(TestCase):
+    """Tests for ``sliced()``"""
+
+    def test_even(self):
+        """Test when the length of the sequence is divisible by *n*"""
+        seq = 'ABCDEFGHI'
+        eq_(list(sliced(seq, 3)), ['ABC', 'DEF', 'GHI'])
+
+    def test_odd(self):
+        """Test when the length of the sequence is not divisible by *n*"""
+        seq = 'ABCDEFGHI'
+        eq_(list(sliced(seq, 4)), ['ABCD', 'EFGH', 'I'])
+
+    def test_not_sliceable(self):
+        seq = (x for x in 'ABCDEFGHI')
+
+        with self.assertRaises(TypeError):
+            list(sliced(seq, 3))


### PR DESCRIPTION
#5 is the last open issue without a PR. Here I add a `sliced()` function, which is like `chunked()` but for sequences that support slicing - see the [discussion](https://github.com/erikrose/more-itertools/issues/5#issuecomment-7404666) for reasoning behind adding anew function.

~~This PR uses the same trick as #80 does to avoid leaving a reference to the retrieved slice in the generator  function.~~

The open PRs will probably all conflict with each other, but once merged I'll do a changelog and such for a new release.
