### PR TITLE
Updates for 2.4 release

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -48,7 +48,7 @@ copyright = u'2012, Erik Rose'
 # built documents.
 #
 # The short X.Y version.
-version = '2.3'
+version = '2.4'
 # The full version, including alpha/beta/rc tags.
 release = version
 

--- a/docs/versions.rst
+++ b/docs/versions.rst
@@ -2,9 +2,30 @@
 Version History
 ===============
 
+2.4
+    * New itertools:
+        * ``accumulate``, ``all_equal``, ``first_true``, ``partition``, and
+          ``tail`` from the itertools documentation.
+        * ``bucket`` (Thanks to Rosuav and cvrebert)
+        * ``collapse`` (Thanks to abarnet)
+        * ``interleave`` and ``interleave_longest`` (Thanks to abarnet)
+        * ``side_effect`` (Thanks to nvie)
+        * ``sliced`` (Thanks to j4mie and coady)
+        * ``split_before`` and ``split_after`` (Thanks to astronouth7303)
+        * ``spy`` (Thanks to themiurgo and mathieulongtin)
+    * Improvements to existing itertools:
+        * ``chunked`` is now simpler and more friendly to garbage collection.
+          (Contributed by coady, with thanks to piskvorky)
+        * ``collate`` now delegates to ``heapq.merge`` when possible.
+          (Thanks to kmike and julianpistorius)
+        * ``peekable``-wrapped iterables are now indexable and sliceable.
+          Iterating through ``peekable``-wrapped iterables is also faster.
+        * ``one`` and ``unique_to_each`` have been simplified.
+
+
 2.3
     * Added ``one`` from ``jaraco.util.itertools``. (Thanks, jaraco!)
-    * Added ``distinct_permutations`` and ``unique_to_each``. (contributed by
+    * Added ``distinct_permutations`` and ``unique_to_each``. (Contributed by
       bbayles)
     * Added ``windowed``. (Contributed by bbayles, with thanks to buchanae,
       jaraco, and abarnert)

--- a/docs/versions.rst
+++ b/docs/versions.rst
@@ -21,6 +21,7 @@ Version History
         * ``peekable``-wrapped iterables are now indexable and sliceable.
           Iterating through ``peekable``-wrapped iterables is also faster.
         * ``one`` and ``unique_to_each`` have been simplified.
+          (Thanks to coady)
 
 
 2.3

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -76,35 +76,35 @@ class peekable(object):
     Call ``peek()`` on the result to get the value that will next pop out of
     ``next()``, without advancing the iterator:
 
-    >>> p = peekable(['a', 'b'])
-    >>> p.peek()
-    'a'
-    >>> next(p)
-    'a'
+        >>> p = peekable(['a', 'b'])
+        >>> p.peek()
+        'a'
+        >>> next(p)
+        'a'
 
     Pass ``peek()`` a default value to return that instead of raising
     ``StopIteration`` when the iterator is exhausted.
 
-    >>> p = peekable([])
-    >>> p.peek('hi')
-    'hi'
+        >>> p = peekable([])
+        >>> p.peek('hi')
+        'hi'
 
     You may index the peekable to look ahead by more than one item.
     The values up to the index you specified will be cached.
     Index 0 is the item that will be returned by ``next()``, index 1 is the
     item after that, and so on:
 
-    >>> p = peekable(['a', 'b', 'c', 'd'])
-    >>> p[0]
-    'a'
-    >>> p[1]
-    'b'
-    >>> next(p)
-    'a'
-    >>> p[1]
-    'c'
-    >>> next(p)
-    'b'
+        >>> p = peekable(['a', 'b', 'c', 'd'])
+        >>> p[0]
+        'a'
+        >>> p[1]
+        'b'
+        >>> next(p)
+        'a'
+        >>> p[1]
+        'c'
+        >>> next(p)
+        'b'
 
     To test whether there are more items in the iterator, examine the
     peekable's truth value. If it is truthy, there are more items.
@@ -241,18 +241,18 @@ def consumer(func):
     to its first yield point so you don't have to call ``next()`` on it
     manually.
 
-    >>> @consumer
-    ... def tally():
-    ...     i = 0
-    ...     while True:
-    ...         print('Thing number %s is %s.' % (i, (yield)))
-    ...         i += 1
-    ...
-    >>> t = tally()
-    >>> t.send('red')
-    Thing number 0 is red.
-    >>> t.send('fish')
-    Thing number 1 is fish.
+        >>> @consumer
+        ... def tally():
+        ...     i = 0
+        ...     while True:
+        ...         print('Thing number %s is %s.' % (i, (yield)))
+        ...         i += 1
+        ...
+        >>> t = tally()
+        >>> t.send('red')
+        Thing number 0 is red.
+        >>> t.send('fish')
+        Thing number 1 is fish.
 
     Without the decorator, you would have to call ``next(t)`` before
     ``t.send()`` could be used.
@@ -269,8 +269,8 @@ def consumer(func):
 def ilen(iterable):
     """Return the number of items in ``iterable``.
 
-    >>> ilen(x for x in range(1000000) if x % 3 == 0)
-    333334
+        >>> ilen(x for x in range(1000000) if x % 3 == 0)
+        333334
 
     This does, of course, consume the iterable, so handle it with care.
 
@@ -281,9 +281,9 @@ def ilen(iterable):
 def iterate(func, start):
     """Return ``start``, ``func(start)``, ``func(func(start))``, ...
 
-    >>> from itertools import islice
-    >>> list(islice(iterate(lambda x: 2*x, 1), 10))
-    [1, 2, 4, 8, 16, 32, 64, 128, 256, 512]
+        >>> from itertools import islice
+        >>> list(islice(iterate(lambda x: 2*x, 1), 10))
+        [1, 2, 4, 8, 16, 32, 64, 128, 256, 512]
 
     """
     while True:
@@ -313,18 +313,18 @@ def one(iterable):
     Raise ValueError if the iterable is empty or longer than 1 element. For
     example, assert that a DB query returns a single, unique result.
 
-    >>> one(['val'])
-    'val'
+        >>> one(['val'])
+        'val'
 
-    >>> one(['val', 'other'])  # doctest: +IGNORE_EXCEPTION_DETAIL
-    Traceback (most recent call last):
-    ...
-    ValueError: too many values to unpack (expected 1)
+        >>> one(['val', 'other'])  # doctest: +IGNORE_EXCEPTION_DETAIL
+        Traceback (most recent call last):
+        ...
+        ValueError: too many values to unpack (expected 1)
 
-    >>> one([])  # doctest: +IGNORE_EXCEPTION_DETAIL
-    Traceback (most recent call last):
-    ...
-    ValueError: not enough values to unpack (expected 1, got 0)
+        >>> one([])  # doctest: +IGNORE_EXCEPTION_DETAIL
+        Traceback (most recent call last):
+        ...
+        ValueError: not enough values to unpack (expected 1, got 0)
 
     ``one()`` attempts to advance the iterable twice in order to ensure there
     aren't further items. Because this discards any second item, ``one()`` is
@@ -378,17 +378,17 @@ def distinct_permutations(iterable):
 def intersperse(e, iterable):
     """Intersperse element ``e`` between the elements of an iterable.
 
-    >>> from more_itertools import intersperse
-    >>> list(intersperse('x', [1, 'o', 5, 'k']))
-    [1, 'x', 'o', 'x', 5, 'x', 'k']
-    >>> list(intersperse(None, [1, 2, 3]))
-    [1, None, 2, None, 3]
-    >>> list(intersperse('x', 1))
-    Traceback (most recent call last):
-    ...
-    TypeError: 'int' object is not iterable
-    >>> list(intersperse('x', []))
-    []
+        >>> from more_itertools import intersperse
+        >>> list(intersperse('x', [1, 'o', 5, 'k']))
+        [1, 'x', 'o', 'x', 5, 'x', 'k']
+        >>> list(intersperse(None, [1, 2, 3]))
+        [1, None, 2, None, 3]
+        >>> list(intersperse('x', 1))
+        Traceback (most recent call last):
+        ...
+        TypeError: 'int' object is not iterable
+        >>> list(intersperse('x', []))
+        []
 
     """
     iterable = iter(iterable)
@@ -412,11 +412,13 @@ def unique_to_each(*iterables):
     If pkg_1 is removed, then A is no longer necessary - it is not associated
     with pkg_2 or pkg_3. Similarly, C is only needed for pkg_2, and D is
     only needed for pkg_3:
+
         >>> unique_to_each("AB", "BC", "BD")
         [['A'], ['C'], ['D']]
 
     If there are duplicates in one input iterable that aren't in the others
     they will be duplicated in the output. Input order is preserved:
+
         >>> unique_to_each("mississippi", "missouri")
         [['p', 'p'], ['o', 'u', 'r']]
 
@@ -445,13 +447,13 @@ def windowed(seq, n, fillvalue=None):
     When n is larger than the iterable, ``fillvalue`` is used in place of
     missing values.
 
-    >>> all_windows = windowed([1, 2, 3, 4, 5], 3)
-    >>> next(all_windows)
-    (1, 2, 3)
-    >>> next(all_windows)
-    (2, 3, 4)
-    >>> next(all_windows)
-    (3, 4, 5)
+        >>> all_windows = windowed([1, 2, 3, 4, 5], 3)
+        >>> next(all_windows)
+        (1, 2, 3)
+        >>> next(all_windows)
+        (2, 3, 4)
+        >>> next(all_windows)
+        (3, 4, 5)
 
     """
     if n < 0:
@@ -479,15 +481,15 @@ class bucket(object):
     """Wrap an iterable and return an object that buckets the iterable into
     child iterables based on a ``key`` function.
 
-    >>> iterable = ['a1', 'b1', 'c1', 'a2', 'b2', 'c2', 'b3']
-    >>> s = bucket(iterable, key=lambda s: s[0])  # Select by first character
-    >>> a_iterable = s['a']
-    >>> next(a_iterable)
-    'a1'
-    >>> next(a_iterable)
-    'a2'
-    >>> list(s['b'])
-    ['b1', 'b2', 'b3']
+        >>> iterable = ['a1', 'b1', 'c1', 'a2', 'b2', 'c2', 'b3']
+        >>> s = bucket(iterable, key=lambda s: s[0])
+        >>> a_iterable = s['a']
+        >>> next(a_iterable)
+        'a1'
+        >>> next(a_iterable)
+        'a2'
+        >>> list(s['b'])
+        ['b1', 'b2', 'b3']
 
     The original iterable will be advanced and its items will be cached until
     they are used by the child iterables. This may require significant storage.
@@ -585,8 +587,9 @@ def interleave(*iterables):
     until the shortest is exhausted. Note that this is the same as
     chain(*zip(*iterables)).
 
-    >>> list(interleave([1, 2, 3], [4, 5], [6, 7, 8]))
-    [1, 4, 6, 2, 5, 7]
+        >>> list(interleave([1, 2, 3], [4, 5], [6, 7, 8]))
+        [1, 4, 6, 2, 5, 7]
+
     """
     return chain.from_iterable(zip(*iterables))
 
@@ -596,8 +599,9 @@ def interleave_longest(*iterables):
     skipping any that are exhausted. Note that this is not the same as
     chain(*zip_longest(*iterables)).
 
-    >>> list(interleave_longest([1, 2, 3], [4, 5], [6, 7, 8]))
-    [1, 4, 6, 2, 5, 7, 3, 8]
+        >>> list(interleave_longest([1, 2, 3], [4, 5], [6, 7, 8]))
+        [1, 4, 6, 2, 5, 7, 3, 8]
+
     """
     i = chain.from_iterable(zip_longest(*iterables, fillvalue=_marker))
     return filter(lambda x: x is not _marker, i)
@@ -609,12 +613,13 @@ def collapse(iterable, base_type=None, levels=None):
     matching ``isinstance(element, base_type)``, and elements that are
     ``levels`` levels down.
 
-    >>> list(collapse([[1], 2, [[3], 4], [[[5]]], 'abc']))
-    [1, 2, 3, 4, 5, 'abc']
-    >>> list(collapse([[1], 2, [[3], 4], [[[5]]]], levels=2))
-    [1, 2, 3, 4, [5]]
-    >>> list(collapse((1, [2], (3, [4, (5,)])), list))
-    [1, [2], 3, [4, (5,)]]
+        >>> list(collapse([[1], 2, [[3], 4], [[[5]]], 'abc']))
+        [1, 2, 3, 4, 5, 'abc']
+        >>> list(collapse([[1], 2, [[3], 4], [[[5]]]], levels=2))
+        [1, 2, 3, 4, [5]]
+        >>> list(collapse((1, [2], (3, [4, (5,)])), list))
+        [1, [2], 3, [4, (5,)]]
+
     """
     def walk(node, level):
         if (

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -340,8 +340,18 @@ def one(iterable):
 def distinct_permutations(iterable):
     """Yield successive distinct permutations of the elements in the iterable.
 
+        >>> sorted(distinct_permutations([1, 0, 1]))
+        [(0, 1, 1), (1, 0, 1), (1, 1, 0)]
+
     Equivalent to ``set(permutations(iterable))``, except duplicates are not
-    generated. For large input sequences, this is much more efficient.
+    generated and thrown away. For larger input sequences this is much more
+    efficient.
+
+    Duplicate permutations arise when there are duplicated elements in the
+    input iterable. The number of items returned is
+    ``n! / (x_1! * x_2! * ... * x_n!)``, where ``n`` is the total number of
+    items input, and each ``x_i`` is the count of a distinct item in the input
+    sequence.
 
     """
     def perm_unique_helper(item_counts, perm, i):

--- a/more_itertools/recipes.py
+++ b/more_itertools/recipes.py
@@ -33,12 +33,12 @@ def accumulate(iterable, func=operator.add):
     (specified by the optional *func* argument) that takes two arguments.
     By default, returns accumulated sums with ``operator.add()``.
 
-    >>> list(accumulate([1, 2, 3, 4, 5]))  # Running sum
-    [1, 3, 6, 10, 15]
-    >>> list(accumulate([1, 2, 3, 4, 5], func=operator.mul))  # Running product
-    [1, 2, 6, 24, 120]
-    >>> list(accumulate([0, 1, -1, 2, 3, 2], func=max))  # Running maximum
-    [0, 1, 1, 2, 3, 3]
+        >>> list(accumulate([1, 2, 3, 4, 5]))  # Running sum
+        [1, 3, 6, 10, 15]
+        >>> list(accumulate([1, 2, 3], func=operator.mul))  # Running product
+        [1, 2, 6]
+        >>> list(accumulate([0, 1, -1, 2, 3, 2], func=max))  # Running maximum
+        [0, 1, 1, 2, 3, 3]
 
     This function is available in the ``itertools`` module for Python 3.2 and
     greater.
@@ -153,6 +153,7 @@ def nth(iterable, n, default=None):
 def all_equal(iterable):
     """
     Returns True if all the elements are equal to each other.
+
         >>> all_equal('aaaa')
         True
         >>> all_equal('aaab')
@@ -384,12 +385,12 @@ def first_true(iterable, default=False, pred=None):
     If *pred* is not None, returns the first item for which
     ``pred(item) == True`` .
 
-    >>> first_true(range(10))
-    1
-    >>> first_true(range(10), pred=lambda x: x > 5)
-    6
-    >>> first_true(range(10), default='missing', pred=lambda x: x > 9)
-    'missing'
+        >>> first_true(range(10))
+        1
+        >>> first_true(range(10), pred=lambda x: x > 5)
+        6
+        >>> first_true(range(10), default='missing', pred=lambda x: x > 9)
+        'missing'
 
     """
     return next(filter(pred, iterable), default)

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='more-itertools',
-    version='2.3',
+    version='2.4',
     description='More routines for operating on iterables, beyond itertools',
     long_description=open('README.rst').read() + '\n\n' +
                      '\n'.join(open('docs/versions.rst').read()


### PR DESCRIPTION
We've got a batch of new and improved itertools, and the issue / PR queue is clear - :ship: !

This PR updates the changelog with the new items (used different formatting this time), indents the code samples in docstrings consistently (some were indented, some weren't), and bumps the version to 2.4.

@erikrose , if you're good with this and can release to PyPI, I will make the GitHub release (as with the last one).