### PR TITLE
Add line break to fix RTD docs

### DIFF
--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -416,6 +416,7 @@ def unique_to_each(*iterables):
     other input iterables.
 
     For example, suppose packages 1, 2, and 3 have these dependencies:
+
         ``pkg_1: (A, B), pkg_2: (B, C), pkg_3: (B, D)``
 
     If you remove one package, which dependencies can also be removed?

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -415,22 +415,19 @@ def unique_to_each(*iterables):
     """Return the elements from each of the input iterables that aren't in the
     other input iterables.
 
-    For example, suppose packages 1, 2, and 3 have these dependencies:
-
+    For example, suppose packages 1, 2, and 3 have these dependencies::
         ``pkg_1: (A, B), pkg_2: (B, C), pkg_3: (B, D)``
 
     If you remove one package, which dependencies can also be removed?
 
     If pkg_1 is removed, then A is no longer necessary - it is not associated
     with pkg_2 or pkg_3. Similarly, C is only needed for pkg_2, and D is
-    only needed for pkg_3:
-
+    only needed for pkg_3::
         >>> unique_to_each("AB", "BC", "BD")
         [['A'], ['C'], ['D']]
 
     If there are duplicates in one input iterable that aren't in the others
-    they will be duplicated in the output. Input order is preserved:
-
+    they will be duplicated in the output. Input order is preserved::
         >>> unique_to_each("mississippi", "missouri")
         [['p', 'p'], ['o', 'u', 'r']]
 

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -415,19 +415,23 @@ def unique_to_each(*iterables):
     """Return the elements from each of the input iterables that aren't in the
     other input iterables.
 
-    For example, suppose packages 1, 2, and 3 have these dependencies::
-        ``pkg_1: (A, B), pkg_2: (B, C), pkg_3: (B, D)``
+    For example, suppose you have a set of packages, each with a set of
+    dependencies::
+
+        {'pkg_1': {'A', 'B'}, 'pkg_2': {'B', 'C'}, 'pkg_3': {'B', 'D'}}
 
     If you remove one package, which dependencies can also be removed?
 
-    If pkg_1 is removed, then A is no longer necessary - it is not associated
-    with pkg_2 or pkg_3. Similarly, C is only needed for pkg_2, and D is
-    only needed for pkg_3::
-        >>> unique_to_each("AB", "BC", "BD")
+    If ``pkg_1`` is removed, then ``A`` is no longer necessary - it is not
+    associated with ``pkg_2`` or ``pkg_3``. Similarly, ``C`` is only needed for
+    ``pkg_2``, and ``D`` is only needed for ``pkg_3``::
+
+        >>> unique_to_each({'A', 'B'}, {'B', 'C'}, {'B', 'D'})
         [['A'], ['C'], ['D']]
 
     If there are duplicates in one input iterable that aren't in the others
     they will be duplicated in the output. Input order is preserved::
+
         >>> unique_to_each("mississippi", "missouri")
         [['p', 'p'], ['o', 'u', 'r']]
 


### PR DESCRIPTION
This PR fixes a docstring that looked OK on PythonHosted, but is incorrectly indented on RTD:

![rtd-shot](https://cloud.githubusercontent.com/assets/1922815/20862156/eb207ede-b968-11e6-9322-4b391a11aa9f.png)
