### PR TITLE
Additional tests for all_equal recipe

### DIFF
--- a/more_itertools/tests/test_recipes.py
+++ b/more_itertools/tests/test_recipes.py
@@ -142,15 +142,27 @@ class AllEqualTests(TestCase):
     def test_true(self):
         """Everything is equal"""
         self.assertTrue(all_equal('aaaaaa'))
+        self.assertTrue(all_equal([0, 0, 0, 0]))
 
     def test_false(self):
         """Not everything is equal"""
         self.assertFalse(all_equal('aaaaab'))
+        self.assertFalse(all_equal([0, 0, 0, 1]))
 
     def test_tricky(self):
         """Not everything is identical, but everything is equal"""
         items = [1, complex(1, 0), 1.0]
         self.assertTrue(all_equal(items))
+
+    def test_empty(self):
+        """Return True if the iterable is empty"""
+        self.assertTrue(all_equal(''))
+        self.assertTrue(all_equal([]))
+
+    def test_one(self):
+        """Return True if the iterable is singular"""
+        self.assertTrue(all_equal('0'))
+        self.assertTrue(all_equal([0]))
 
 
 class QuantifyTests(TestCase):


### PR DESCRIPTION
Re: Issue #88, @pylang suggested adding some tests for the corner cases of `all_equal()`. I agree that this is a good idea; I've added tests for the "empty" and "one item" edge cases.