### PR TITLE
Add step keyword to windowed()

### DIFF
--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -468,6 +468,8 @@ def windowed(seq, n, fillvalue=None, step=1):
     if n == 0:
         yield tuple()
         return
+    if step < 1:
+        raise ValueError('step must be >= 1')
 
     it = iter(seq)
     window = deque([], n)

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -488,9 +488,10 @@ def windowed(seq, n, fillvalue=None, step=1):
         if i % step == 0:
             yield tuple(window)
 
-    # If there are items left, fill with the given value
-    if i % step:
-        for _ in range(i, step):
+    # If there are items from the iterable in the window, pad with the given
+    # value and emit them.
+    if (i % step) and (step - i < n):
+        for _ in range(step - i):
             append(fillvalue)
         yield tuple(window)
 

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -6,7 +6,7 @@ from heapq import merge
 from itertools import chain, count, islice, takewhile
 from sys import version_info
 
-from six import iteritems, string_types
+from six import string_types
 from six.moves import filter, map, zip, zip_longest
 
 from .recipes import take
@@ -444,20 +444,23 @@ def unique_to_each(*iterables):
     return [list(filter(uniques.__contains__, it)) for it in pool]
 
 
-def windowed(seq, n, fillvalue=None):
-    """Return a sliding window (of width n) over data from the iterable.
-
-    When n=2 this is equivalent to ``pairwise(iterable)``.
-    When n is larger than the iterable, ``fillvalue`` is used in place of
-    missing values.
+def windowed(seq, n, fillvalue=None, step=1):
+    """Return a sliding window of width *n* over the given iterable.
 
         >>> all_windows = windowed([1, 2, 3, 4, 5], 3)
-        >>> next(all_windows)
-        (1, 2, 3)
-        >>> next(all_windows)
-        (2, 3, 4)
-        >>> next(all_windows)
-        (3, 4, 5)
+        >>> list(all_windows)
+        [(1, 2, 3), (2, 3, 4), (3, 4, 5)]
+
+    When the window is larger than the iterable, ``fillvalue`` is used in place
+    of missing values::
+
+        >>> list(windowed([1, 2, 3], 4))
+        [(1, 2, 3, None)]
+
+    Each window will advance in increments of *step*::
+
+        >>> list(windowed([1, 2, 3, 4, 5, 6], 3, fillvalue='!', step=2))
+        [(1, 2, 3), (3, 4, 5), (5, 6, '!')]
 
     """
     if n < 0:
@@ -476,8 +479,17 @@ def windowed(seq, n, fillvalue=None):
     yield tuple(window)
 
     # Appending new items to the right causes old items to fall off the left
+    i = 0
     for item in it:
         append(item)
+        i = (i + 1) % step
+        if i % step == 0:
+            yield tuple(window)
+
+    # If there are items left, fill with the given value
+    if i % step:
+        for _ in range(i, step):
+            append(fillvalue)
         yield tuple(window)
 
 

--- a/more_itertools/tests/test_more.py
+++ b/more_itertools/tests/test_more.py
@@ -330,6 +330,10 @@ class WindowedTests(TestCase):
             actual = list(windowed(iterable, n, step=step))
             eq_(actual, expected)
 
+        # Step must be greater than or equal to 1
+        with self.assertRaises(ValueError):
+            list(windowed(iterable, 3, step=0))
+
 
 class BucketTests(TestCase):
     """Tests for ``bucket()``"""

--- a/more_itertools/tests/test_more.py
+++ b/more_itertools/tests/test_more.py
@@ -295,12 +295,16 @@ class WindowedTests(TestCase):
 
     def test_fillvalue(self):
         """
-        When the window size is larger than the iterable, the given fill value
-        should be used.
+        When sizes don't match evenly, the given fill value should be used.
         """
-        actual = list(windowed([1, 2, 3, 4, 5], 6, '!'))
-        expected = [(1, 2, 3, 4, 5, '!')]
-        eq_(actual, expected)
+        iterable = [1, 2, 3, 4, 5]
+
+        for n, kwargs, expected in [
+            (6, {}, [(1, 2, 3, 4, 5, '!')]),  # n > len(iterable)
+            (3, {'step': 3}, [(1, 2, 3), (4, 5, '!')]),  # using ``step``
+        ]:
+            actual = list(windowed(iterable, n, fillvalue='!', **kwargs))
+            eq_(actual, expected)
 
     def test_zero(self):
         """When the window size is zero, an empty tuple should be emitted."""
@@ -312,6 +316,19 @@ class WindowedTests(TestCase):
         """When the window size is negative, ValueError should be raised."""
         with self.assertRaises(ValueError):
             list(windowed([1, 2, 3, 4, 5], -1))
+
+    def test_step(self):
+        """The window should advance by the number of steps provided"""
+        iterable = [1, 2, 3, 4, 5, 6, 7]
+        for n, step, expected in [
+            (3, 2, [(1, 2, 3), (3, 4, 5), (5, 6, 7)]),  # n > step
+            (3, 3, [(1, 2, 3), (4, 5, 6), (7, None, None)]),  # n == step
+            (2, 3, [(1, 2), (4, 5), (7, None)]),  # n < step
+            (3, 7, [(1, 2, 3), (None, None, None)]),  # step == len(iterable)
+            (7, 8, [(1, 2, 3, 4, 5, 6, 7)]),  # step > len(iterable)
+        ]:
+            actual = list(windowed(iterable, n, step=step))
+            eq_(actual, expected)
 
 
 class BucketTests(TestCase):

--- a/more_itertools/tests/test_more.py
+++ b/more_itertools/tests/test_more.py
@@ -323,8 +323,10 @@ class WindowedTests(TestCase):
         for n, step, expected in [
             (3, 2, [(1, 2, 3), (3, 4, 5), (5, 6, 7)]),  # n > step
             (3, 3, [(1, 2, 3), (4, 5, 6), (7, None, None)]),  # n == step
-            (2, 3, [(1, 2), (4, 5), (7, None)]),  # n < step
-            (3, 7, [(1, 2, 3), (None, None, None)]),  # step == len(iterable)
+            (3, 4, [(1, 2, 3), (5, 6, 7)]),  # line up nicely
+            (3, 5, [(1, 2, 3), (6, 7, None)]),  # off by one
+            (3, 6, [(1, 2, 3), (7, None, None)]),  # off by two
+            (3, 7, [(1, 2, 3)]),  # step past the end
             (7, 8, [(1, 2, 3, 4, 5, 6, 7)]),  # step > len(iterable)
         ]:
             actual = list(windowed(iterable, n, step=step))


### PR DESCRIPTION
Re: issue #91, this PR adds an optional `step` keyword to the `windowed()` function. It advances the window the specified number of places before emitting.

```python
>>> iterable = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
>>> list(windowed(iterable, 4, step=2))  # Each window will start +2 from the last start
[(1, 2, 3, 4), (3, 4, 5, 6), (5, 6, 7, 8), (7, 8, 9, 10)]
```

---

By default `step` is `1`, and the function behaves as it did before.

If `step >= n`, it's possible to slide past the edge of the iterable. In that case `fillvalue` will be inserted such that the size of the returned tuple is always `n`:
```python
>>> iterable = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
>>> list(windowed(iterable, 3, step=4))
[(1, 2, 3), (5, 6, 7), (9, 10, None)]
```

When `step == n`, this acts like a version of `chunked()` that pads the end with `fillvalue`:
```python
>>> iterable = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
>>> list(windowed(iterable, 4, step=4))
[(1, 2, 3, 4), (5, 6, 7, 8), (9, 10, None, None)]
```

---

The implementation is a bit different from the one in [this StackOverflow answer](http://stackoverflow.com/a/13408251/353839), which can emit an item full of fill values when `step > n`:

```python
>>> list(list(x) for x in so_version(range(1, 10 + 1), size=4, step=5))
[[1, 2, 3, 4], [6, 7, 8, 9], [None, None, None, None]]
```

In the issue we discussed wrapping around the iterable, but absent from real-world example from signal processing or something I'm inclined to leave it out.

Many thanks to @pylang for the suggestion.