### PR TITLE
New padded() itertool

### DIFF
--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -3,7 +3,7 @@ from __future__ import print_function
 from collections import Counter, defaultdict, deque
 from functools import partial, wraps
 from heapq import merge
-from itertools import chain, count, islice, takewhile
+from itertools import chain, count, islice, repeat, takewhile
 from sys import version_info
 
 from six import iteritems, string_types
@@ -745,3 +745,36 @@ def split_after(iterable, pred):
             buf = []
     if buf:
         yield buf
+
+
+def padded(iterable, fillvalue=None, n=None, multiple=False):
+    """Yield the elements from *iterable*, followed by *fillvalue*, such that
+    at least *n* items are emitted.
+
+        >>> list(padded([1, 2, 3], '?', 5))
+        [1, 2, 3, '?', '?']
+
+    If *multiple* is ``True``, *fillvalue* will be emitted until the number of
+    items emitted is a multiple of *n*::
+
+        >>> list(padded([1, 2, 3, 4], n=3, multiple=True))
+        [1, 2, 3, 4, None, None]
+
+    If *n* is ``None``, *fillvalue* will be emitted indefinitely.
+
+    """
+    it = iter(iterable)
+    if n is None:
+        for item in chain(it, repeat(fillvalue)):
+            yield item
+    elif n < 1:
+        raise ValueError('n must be at least 1')
+    else:
+        item_count = 0
+        for item in it:
+            yield item
+            item_count += 1
+
+        remaining = (n - (item_count % n)) % n if multiple else n - item_count
+        for _ in range(remaining):
+            yield fillvalue

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -747,17 +747,17 @@ def split_after(iterable, pred):
         yield buf
 
 
-def padded(iterable, fillvalue=None, n=None, multiple=False):
+def padded(iterable, fillvalue=None, n=None, next_multiple=False):
     """Yield the elements from *iterable*, followed by *fillvalue*, such that
     at least *n* items are emitted.
 
         >>> list(padded([1, 2, 3], '?', 5))
         [1, 2, 3, '?', '?']
 
-    If *multiple* is ``True``, *fillvalue* will be emitted until the number of
-    items emitted is a multiple of *n*::
+    If *next_multiple* is ``True``, *fillvalue* will be emitted until the
+    number of items emitted is a multiple of *n*::
 
-        >>> list(padded([1, 2, 3, 4], n=3, multiple=True))
+        >>> list(padded([1, 2, 3, 4], n=3, next_multiple=True))
         [1, 2, 3, 4, None, None]
 
     If *n* is ``None``, *fillvalue* will be emitted indefinitely.
@@ -775,6 +775,6 @@ def padded(iterable, fillvalue=None, n=None, multiple=False):
             yield item
             item_count += 1
 
-        remaining = (n - item_count) % n if multiple else n - item_count
+        remaining = (n - item_count) % n if next_multiple else n - item_count
         for _ in range(remaining):
             yield fillvalue

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -14,9 +14,9 @@ from .recipes import take
 __all__ = [
     'bucket', 'chunked', 'collapse', 'collate', 'consumer',
     'distinct_permutations', 'first', 'ilen', 'interleave_longest',
-    'interleave', 'intersperse', 'iterate', 'one', 'peekable', 'side_effect',
-    'sliced', 'split_after', 'split_before', 'spy', 'unique_to_each',
-    'windowed', 'with_iter'
+    'interleave', 'intersperse', 'iterate', 'one', 'padded', 'peekable',
+    'side_effect', 'sliced', 'split_after', 'split_before', 'spy',
+    'unique_to_each', 'windowed', 'with_iter'
 ]
 
 
@@ -775,6 +775,6 @@ def padded(iterable, fillvalue=None, n=None, multiple=False):
             yield item
             item_count += 1
 
-        remaining = (n - (item_count % n)) % n if multiple else n - item_count
+        remaining = (n - item_count) % n if multiple else n - item_count
         for _ in range(remaining):
             yield fillvalue

--- a/more_itertools/tests/test_more.py
+++ b/more_itertools/tests/test_more.py
@@ -503,3 +503,66 @@ class SplitAfterTest(TestCase):
         actual = list(split_after('ooo', lambda c: c == 'x'))
         expected = [['o', 'o', 'o']]
         eq_(actual, expected)
+
+
+class PaddedTest(TestCase):
+    """Tests for ``padded()``"""
+
+    def test_no_n(self):
+        seq = [1, 2, 3]
+
+        # No fillvalue
+        self.assertEqual(take(5, padded(seq)), [1, 2, 3, None, None])
+
+        # With fillvalue
+        self.assertEqual(take(5, padded(seq, fillvalue='')), [1, 2, 3, '', ''])
+
+    def test_invalid_n(self):
+        self.assertRaises(ValueError, lambda: list(padded([1, 2, 3], n=-1)))
+        self.assertRaises(ValueError, lambda: list(padded([1, 2, 3], n=0)))
+
+    def test_valid_n(self):
+        seq = [1, 2, 3, 4, 5]
+
+        # No need for padding: len(seq) <= n
+        self.assertEqual(list(padded(seq, n=4)), [1, 2, 3, 4, 5])
+        self.assertEqual(list(padded(seq, n=5)), [1, 2, 3, 4, 5])
+
+        # No fillvalue
+        self.assertEqual(list(padded(seq, n=7)), [1, 2, 3, 4, 5, None, None])
+
+        # With fillvalue
+        self.assertEqual(
+            list(padded(seq, fillvalue='', n=7)), [1, 2, 3, 4, 5, '', '']
+        )
+
+    def test_multiple(self):
+        seq = [1, 2, 3, 4, 5, 6]
+
+        # No need for padding: len(seq) % n == 0
+        self.assertEqual(
+            list(padded(seq, n=3, multiple=True)), [1, 2, 3, 4, 5, 6]
+        )
+
+        # Padding needed: len(seq) < n
+        self.assertEqual(
+            list(padded(seq, n=8, multiple=True)),
+            [1, 2, 3, 4, 5, 6, None, None]
+        )
+
+        # No padding needed: len(seq) == n
+        self.assertEqual(
+            list(padded(seq, n=6, multiple=True)), [1, 2, 3, 4, 5, 6]
+        )
+
+        # Padding needed: len(seq) > n
+        self.assertEqual(
+            list(padded(seq, n=4, multiple=True)),
+            [1, 2, 3, 4, 5, 6, None, None]
+        )
+
+        # With fillvalue
+        self.assertEqual(
+            list(padded(seq, fillvalue='', n=4, multiple=True)),
+            [1, 2, 3, 4, 5, 6, '', '']
+        )

--- a/more_itertools/tests/test_more.py
+++ b/more_itertools/tests/test_more.py
@@ -536,33 +536,33 @@ class PaddedTest(TestCase):
             list(padded(seq, fillvalue='', n=7)), [1, 2, 3, 4, 5, '', '']
         )
 
-    def test_multiple(self):
+    def test_next_multiple(self):
         seq = [1, 2, 3, 4, 5, 6]
 
         # No need for padding: len(seq) % n == 0
         self.assertEqual(
-            list(padded(seq, n=3, multiple=True)), [1, 2, 3, 4, 5, 6]
+            list(padded(seq, n=3, next_multiple=True)), [1, 2, 3, 4, 5, 6]
         )
 
         # Padding needed: len(seq) < n
         self.assertEqual(
-            list(padded(seq, n=8, multiple=True)),
+            list(padded(seq, n=8, next_multiple=True)),
             [1, 2, 3, 4, 5, 6, None, None]
         )
 
         # No padding needed: len(seq) == n
         self.assertEqual(
-            list(padded(seq, n=6, multiple=True)), [1, 2, 3, 4, 5, 6]
+            list(padded(seq, n=6, next_multiple=True)), [1, 2, 3, 4, 5, 6]
         )
 
         # Padding needed: len(seq) > n
         self.assertEqual(
-            list(padded(seq, n=4, multiple=True)),
+            list(padded(seq, n=4, next_multiple=True)),
             [1, 2, 3, 4, 5, 6, None, None]
         )
 
         # With fillvalue
         self.assertEqual(
-            list(padded(seq, fillvalue='', n=4, multiple=True)),
+            list(padded(seq, fillvalue='', n=4, next_multiple=True)),
             [1, 2, 3, 4, 5, 6, '', '']
         )


### PR DESCRIPTION
This PR adds `padded()`, a wrapper that pads an iterable to at least `n` items (or to the next multiple of `n` items). This is a generalization of `padnone()` from the itertools recipes. I found myself wanting this when working on #55.

If you want to make sure your iterable has at least `n` items, you can ensure that missing values are substituted with a fill value:
```python
>>> list(padded([1, 2, 3], fillvalue='?', n=5))
 [1, 2, 3, '?', '?']
```

If you want to make sure your iterable has at least `k * n` items, you can ensure that as well:
```python
>>> list(padded([1, 2, 3, 4], n=3, multiple=True))
[1, 2, 3, 4, None, None]
```

With just the iterable specified, this will act just like `padnone()` and yield `None` indefinitely after the iterable is exhausted.

---

Is `multiple` a good keyword argument for padding to the nearest multiple of `n`? I considered `mod` as well.