### PR TITLE
New distribute() itertool

### DIFF
--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -763,6 +763,13 @@ def distribute(n, iterable):
         >>> [list(c) for c in children]
         [[1, 4, 7], [2, 5], [3, 6]]
 
+    If the length of the iterable is smaller than n, then the last returned
+    iterables will be empty:
+
+        >>> children = distribute(5, [1, 2, 3])
+        >>> [list(c) for c in children]
+        [[1], [2], [3], [], []]
+
     This function uses ``itertools.tee``, and may require significant storage.
 
     """

--- a/more_itertools/tests/test_more.py
+++ b/more_itertools/tests/test_more.py
@@ -503,3 +503,29 @@ class SplitAfterTest(TestCase):
         actual = list(split_after('ooo', lambda c: c == 'x'))
         expected = [['o', 'o', 'o']]
         eq_(actual, expected)
+
+
+class DistributeTest(TestCase):
+    """Tests for distribute()"""
+
+    def test_invalid_n(self):
+        self.assertRaises(ValueError, lambda: distribute(-1, [1, 2, 3]))
+        self.assertRaises(ValueError, lambda: distribute(0, [1, 2, 3]))
+
+    def test_basic(self):
+        iterable = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+
+        for n, expected in [
+            (1, [iterable]),
+            (2, [[1, 3, 5, 7, 9], [2, 4, 6, 8, 10]]),
+            (3, [[1, 4, 7, 10], [2, 5, 8], [3, 6, 9]]),
+            (10, [[n] for n in range(1, 10 + 1)]),
+        ]:
+            eq_([list(x) for x in distribute(n, iterable)], expected)
+
+    def test_large_n(self):
+        iterable = [1, 2, 3, 4]
+        eq_(
+            [list(x) for x in distribute(6, iterable)],
+            [[1], [2], [3], [4], [], []]
+        )


### PR DESCRIPTION
Re: Issue #55, this PR adds `distribute()`, a new itertool that splits an iterable into a fixed number of chunks. The items are distributed among the chunks as evenly as possible.

The `i`th item in the iterable goes in the `(i % n)`th chunk, so we have:

```python
>>> group_1, group_2 = distribute(2, [1, 2, 3, 4, 5, 6])
>>> list(group_1)
[1, 3, 5]
>>> list(group_2)
[2, 4, 6]
```

This allows the items to be distributed evenly without knowing the length of the input iterable.

When `n` doesn't match the length of the input iterable, the sizes of the chunks won't be identical:

```python
>>> children = distribute(3, [1, 2, 3, 4, 5, 6, 7])
>>> [list(c) for c in children]
[[1, 4, 7], [2, 5], [3, 6]]
```

The input iterable is `tee`d, so behind the scenes the items from the input iterable are being cached if you iterate through one returned sub-iterator before the others.
