### PR TITLE
Allow negative indexing and arbitrary slicing for peekable()

### DIFF
--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -189,7 +189,7 @@ class peekable(object):
         cache_len = len(self._cache)
         if index < 0:
             self._cache.extend(self._it)
-        elif index + 1 >= cache_len:
+        elif index >= cache_len:
             self._cache.extend(islice(self._it, index + 1 - cache_len))
 
         return self._cache[index]

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -181,7 +181,14 @@ class peekable(object):
         if isinstance(index, slice):
             return self._get_slice(index)
 
-        return self._get_slice(slice(index, index + 1, None))[0]
+        cache_len = len(self._cache)
+
+        if index < 0:
+            raise ValueError('Negative indexing not supported')
+        elif index + 1 >= cache_len:
+            self._cache.extend(islice(self._it, index + 1 - cache_len))
+
+        return self._cache[index]
 
 
 def _collate(*iterables, **kwargs):

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -166,10 +166,9 @@ class peekable(object):
             ((start is not None) and (start < 0)) or
             ((stop is not None) and (stop < 0))
         ):
-            raise ValueError('Negative indexing not supported')
+            stop = None
 
         cache_len = len(self._cache)
-
         if stop is None:
             self._cache.extend(self._it)
         elif stop >= cache_len:
@@ -182,9 +181,8 @@ class peekable(object):
             return self._get_slice(index)
 
         cache_len = len(self._cache)
-
         if index < 0:
-            raise ValueError('Negative indexing not supported')
+            self._cache.extend(self._it)
         elif index + 1 >= cache_len:
             self._cache.extend(islice(self._it, index + 1 - cache_len))
 

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -107,6 +107,10 @@ class peekable(object):
         >>> next(p)
         'b'
 
+    Negative indexes are supported, but be aware that they will cache the
+    remaining items in the source iterator, which may require significant
+    storage.
+
     To test whether there are more items in the iterator, examine the
     peekable's truth value. If it is truthy, there are more items.
 
@@ -168,9 +172,7 @@ class peekable(object):
         ):
             stop = None
         elif (
-            (start is not None) and
-            (stop is not None) and
-            (start > stop)
+            (start is not None) and (stop is not None) and (start > stop)
         ):
             stop = start + 1
 

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -167,6 +167,12 @@ class peekable(object):
             ((stop is not None) and (stop < 0))
         ):
             stop = None
+        elif (
+            (start is not None) and
+            (stop is not None) and
+            (start > stop)
+        ):
+            stop = start + 1
 
         cache_len = len(self._cache)
         if stop is None:

--- a/more_itertools/tests/test_more.py
+++ b/more_itertools/tests/test_more.py
@@ -134,9 +134,10 @@ class PeekableTests(TestCase):
         eq_(next(p), 'c')
         eq_(p[8], 'l')
 
-        # Negative indexing should fail
-        with self.assertRaises(ValueError):
-            p[-2]
+        # Negative indexing should work too
+        eq_(p[-2], 'k')
+        eq_(p[-9], 'd')
+        self.assertRaises(IndexError, lambda: p[-10])
 
     def test_slicing(self):
         """
@@ -163,12 +164,12 @@ class PeekableTests(TestCase):
         eq_(p[::2], seq[1:][::2])
         eq_(p[::-1], seq[1:][::-1])
 
-        # Negative indexing should fail
-        with self.assertRaises(ValueError):
-            p[-1:]
-
-        with self.assertRaises(ValueError):
-            p[:-1]
+        # Negative indexing should work too
+        eq_(p[-1:], seq[1:][-1:])
+        eq_(p[:-1], seq[1:][:-1])
+        eq_(p[2:-2], seq[1:][2:-2])
+        eq_(p[-9:4], seq[1:][-9:4])
+        eq_(p[6:1:-2], seq[1:][6:1:-2])
 
 
 class ConsumerTests(TestCase):

--- a/more_itertools/tests/test_more.py
+++ b/more_itertools/tests/test_more.py
@@ -140,9 +140,7 @@ class PeekableTests(TestCase):
         self.assertRaises(IndexError, lambda: p[-10])
 
     def test_slicing(self):
-        """
-        Slicing the peekable shouldn't advance the iterator.
-        """
+        """Slicing the peekable shouldn't advance the iterator."""
         seq = list('abcdefghijkl')
         p = peekable(seq)
 
@@ -164,12 +162,20 @@ class PeekableTests(TestCase):
         eq_(p[::2], seq[1:][::2])
         eq_(p[::-1], seq[1:][::-1])
 
-        # Negative indexing should work too
-        eq_(p[-1:], seq[1:][-1:])
-        eq_(p[:-1], seq[1:][:-1])
-        eq_(p[2:-2], seq[1:][2:-2])
-        eq_(p[-9:4], seq[1:][-9:4])
-        eq_(p[6:1:-2], seq[1:][6:1:-2])
+    def test_slicing_reset(self):
+        """Test slicing on a fresh iterable each time"""
+        seq = list(range(11))
+        for index in [
+            slice(None, None, None),
+            slice(1, None, None),
+            slice(None, 1, None),
+            slice(1, 8, 3),
+            slice(8, 1, -3),
+            slice(8, -9, -3),
+        ]:
+            p = peekable(seq)
+            next(p)
+            eq_(p[index], seq[1:][index])
 
 
 class ConsumerTests(TestCase):


### PR DESCRIPTION
`peekable()`-wrapped iterables supports indexing and slicing as of PR #71. They raise an exception when using negative indexes or slices with negative bounds, but are otherwise supposed to behave like normal sequences when indexed/sliced.

However, I missed a case: when using a slice with start > stop and step < 0, the peekable doesn't slice properly:
```python
>>> iterable = list(range(10))
>>> p = peekable(iterable)
>>> iterable[8: 1: -3]
[8, 5, 2]
>>> p[8: 1: -3]
[]
```

This PR fixes that, and in the process removes the restriction on negative indexes and slices with negative bounds.

I think I got this right, but off-by-one errors are easy to stumble into here!