### PR TITLE
New stagger() and zip_offsets() itertools

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -14,6 +14,7 @@ New Routines
 .. autofunction:: collate(*iterables, key=lambda a: a, reverse=False)
 .. autofunction:: consumer
 .. autofunction:: distinct_permutations
+.. autofunction:: distribute
 .. autofunction:: first(iterable[, default])
 .. autofunction:: ilen
 .. autofunction:: interleave
@@ -21,15 +22,18 @@ New Routines
 .. autofunction:: intersperse
 .. autofunction:: iterate
 .. autofunction:: one
+.. autofunction:: padded
 .. autoclass:: peekable
 .. autofunction:: side_effect
 .. autofunction:: sliced
 .. autofunction:: split_after
 .. autofunction:: split_before
 .. autofunction:: spy
+.. autofunction:: stagger
 .. autofunction:: unique_to_each
 .. autofunction:: windowed
 .. autofunction:: with_iter
+.. autofunction:: zip_offset(*iterables, offsets, longest=False, fillvalue=None)
 
 
 Itertools Recipes

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -874,6 +874,9 @@ def stagger(iterable, offsets=(-1, 0, 1), longest=False, fillvalue=None):
         >>> list(stagger([0, 1, 2, 3], longest=True))
         [(None, 0, 1), (0, 1, 2), (1, 2, 3), (2, 3, None), (3, None, None)]
 
+    By default, ``None`` will be used to replace offsets beyond the end of the
+    sequence. Specify *fillvalue* to use some other value.
+
     """
     children = tee(iterable, len(offsets))
 
@@ -888,6 +891,9 @@ def zip_offset(*iterables, **kwargs):
 
         >>> list(zip_offset('0123', 'abcdef', offsets=(0, 1)))
         [('0', 'b'), ('1', 'c'), ('2', 'd'), ('3', 'e')]
+
+    This can be used as a lightweight alternative to SciPy or pandas to analyze
+    data sets in which somes series have a lead or lag relationship.
 
     By default, the sequence will end when the shortest iterable is exhausted.
     To continue until the longest iterable is exhausted, set *longest* to

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -12,11 +12,30 @@ from six.moves import filter, map, zip, zip_longest
 from .recipes import take
 
 __all__ = [
-    'bucket', 'chunked', 'collapse', 'collate', 'consumer',
-    'distinct_permutations', 'distribute', 'first', 'ilen',
-    'interleave_longest', 'interleave', 'intersperse', 'iterate',
-    'offset_groups', 'one', 'padded', 'peekable', 'side_effect', 'sliced',
-    'split_after', 'split_before', 'spy', 'unique_to_each', 'windowed',
+    'bucket',
+    'chunked',
+    'collapse',
+    'collate',
+    'consumer',
+    'distinct_permutations',
+    'distribute',
+    'first',
+    'ilen',
+    'interleave_longest',
+    'interleave',
+    'intersperse',
+    'iterate',
+    'one',
+    'padded',
+    'peekable',
+    'side_effect',
+    'sliced',
+    'split_after',
+    'split_before',
+    'spy',
+    'stagger',
+    'unique_to_each',
+    'windowed',
     'with_iter',
 ]
 
@@ -837,27 +856,27 @@ def distribute(n, iterable):
     return [_iterator(index) for index in range(n)]
 
 
-def offset_groups(iterable, offsets=(-1, 0, 1), longest=False, fillvalue=None):
+def stagger(iterable, offsets=(-1, 0, 1), longest=False, fillvalue=None):
     """Yield tuples whose elements from are offset from *iterable*.
-    The amount by which the ith item in each tuple offset is given by the
-    ith item in *offsets*.
+    The amount by which the ``i``th item in each tuple is offset is given by
+    the ``i``th item in *offsets*.
 
-        >>> list(offset_groups([0, 1, 2, 3]))
+        >>> list(stagger([0, 1, 2, 3]))
         [(None, 0, 1), (0, 1, 2), (1, 2, 3)]
-        >>> list(offset_groups(range(8), offsets=(0, 2, 4)))
+        >>> list(stagger(range(8), offsets=(0, 2, 4)))
         [(0, 2, 4), (1, 3, 5), (2, 4, 6), (3, 5, 7)]
 
     By default, the sequence will end when the final element of a tuple is the
     last item in the iterable. To continue until the first element of a tuple
     is the last item in the iterable, set *longest* to ``True``::
 
-        >>> list(offset_groups([0, 1, 2, 3], longest=True))
+        >>> list(stagger([0, 1, 2, 3], longest=True))
         [(None, 0, 1), (0, 1, 2), (1, 2, 3), (2, 3, None), (3, None, None)]
 
     By default, ``None`` will be used to replace offsets beyond the end of the
     sequence. Specify *fillvalue* to use some other value::
 
-        >>> list(offset_groups([0, 1, 2, 3], fillvalue='?'))
+        >>> list(stagger([0, 1, 2, 3], fillvalue='?'))
         [('?', 0, 1), (0, 1, 2), (1, 2, 3)]
 
     """

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -859,8 +859,8 @@ def distribute(n, iterable):
 
 def stagger(iterable, offsets=(-1, 0, 1), longest=False, fillvalue=None):
     """Yield tuples whose elements from are offset from *iterable*.
-    The amount by which the ``i``th item in each tuple is offset is given by
-    the ``i``th item in *offsets*.
+    The amount by which the ``i``-th item in each tuple is offset is given by
+    the ``i``-th item in *offsets*.
 
         >>> list(stagger([0, 1, 2, 3]))
         [(None, 0, 1), (0, 1, 2), (1, 2, 3)]
@@ -883,8 +883,8 @@ def stagger(iterable, offsets=(-1, 0, 1), longest=False, fillvalue=None):
 
 
 def zip_offset(*iterables, **kwargs):
-    """``zip`` the input *iterables* together, but offset the ``i``th iterable
-    by the ``i``th item in *offsets*.
+    """``zip`` the input *iterables* together, but offset the ``i``-th iterable
+    by the ``i``-th item in *offsets*.
 
         >>> list(zip_offset('0123', 'abcdef', offsets=(0, 1)))
         [('0', 'b'), ('1', 'c'), ('2', 'd'), ('3', 'e')]

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -14,9 +14,10 @@ from .recipes import take
 __all__ = [
     'bucket', 'chunked', 'collapse', 'collate', 'consumer',
     'distinct_permutations', 'distribute', 'first', 'ilen',
-    'interleave_longest', 'interleave', 'intersperse', 'iterate', 'one',
-    'padded', 'peekable', 'side_effect', 'sliced', 'split_after',
-    'split_before', 'spy', 'unique_to_each', 'windowed', 'with_iter',
+    'interleave_longest', 'interleave', 'intersperse', 'iterate',
+    'offset_groups', 'one', 'padded', 'peekable', 'side_effect', 'sliced',
+    'split_after', 'split_before', 'spy', 'unique_to_each', 'windowed',
+    'with_iter',
 ]
 
 
@@ -836,27 +837,27 @@ def distribute(n, iterable):
     return [_iterator(index) for index in range(n)]
 
 
-def offsetter(iterable, offsets=(-1, 0, 1), longest=False, fillvalue=None):
+def offset_groups(iterable, offsets=(-1, 0, 1), longest=False, fillvalue=None):
     """Yield tuples whose elements from are offset from *iterable*.
     The amount by which the ith item in each tuple offset is given by the
     ith item in *offsets*.
 
-        >>> list(offsetter([0, 1, 2, 3]))
+        >>> list(offset_groups([0, 1, 2, 3]))
         [(None, 0, 1), (0, 1, 2), (1, 2, 3)]
-        >>> list(offsetter(range(8), offsets=(0, 2, 4)))
+        >>> list(offset_groups(range(8), offsets=(0, 2, 4)))
         [(0, 2, 4), (1, 3, 5), (2, 4, 6), (3, 5, 7)]
 
     By default, the sequence will end when the final element of a tuple is the
     last item in the iterable. To continue until the first element of a tuple
     is the last item in the iterable, set *longest* to ``True``::
 
-        >>> list(offsetter([0, 1, 2, 3], longest=True))
+        >>> list(offset_groups([0, 1, 2, 3], longest=True))
         [(None, 0, 1), (0, 1, 2), (1, 2, 3), (2, 3, None), (3, None, None)]
 
     By default, ``None`` will be used to replace offsets beyond the end of the
     sequence. Specify *fillvalue* to use some other value::
 
-        >>> list(offsetter([0, 1, 2, 3], fillvalue='?'))
+        >>> list(offset_groups([0, 1, 2, 3], fillvalue='?'))
         [('?', 0, 1), (0, 1, 2), (1, 2, 3)]
 
     """

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -795,21 +795,28 @@ def padded(iterable, fillvalue=None, n=None, next_multiple=False):
             yield fillvalue
 
 
-def something(iterable, offsets=(-1, 0, 1), fillvalue=None):
+def offsetter(iterable, offsets=(-1, 0, 1), longest=False, fillvalue=None):
     """Yield tuples whose elements from are offset from *iterable*.
     The amount by which the ith item in each tuple offset is given by the
     ith item in *offsets*.
 
-        >>> list(something([1, 2, 3]))
-        [(None, 1, 2), (1, 2, 3), (2, 3, None), (3, None, None)]
-        >>> list(something([1, 2, 3, 4], offsets=(0, 2)))
-        [(1, 3), (2, 4), (3, None), (4, None)]
+        >>> list(offsetter([0, 1, 2, 3]))
+        [(None, 0, 1), (0, 1, 2), (1, 2, 3)]
+        >>> list(offsetter(range(8), offsets=(0, 2, 4)))
+        [(0, 2, 4), (1, 3, 5), (2, 4, 6), (3, 5, 7)]
 
-    If an offset extends past the boundaries of the iterable, *fillvalue*
-    will be used.
+    By default, the sequence will end when the final element of a tuple is the
+    last item in the iterable. To continue until the first element of a tuple
+    is the last item in the iterable, set *longest* to ``True``::
 
-        >>> list(something([1, 2, 3], offsets=(-1, 1), fillvalue='?'))
-        [('?', 2), (1, 3), (2, '?'), (3, '?')]
+        >>> list(offsetter([0, 1, 2, 3], longest=True))
+        [(None, 0, 1), (0, 1, 2), (1, 2, 3), (2, 3, None), (3, None, None)]
+
+    By default, ``None`` will be used to replace offsets beyond the end of the
+    sequence. Specify *fillvalue* to use some other value::
+
+        >>> list(offsetter([0, 1, 2, 3], fillvalue='?'))
+        [('?', 0, 1), (0, 1, 2), (1, 2, 3)]
 
     """
     children = tee(iterable, len(offsets))
@@ -823,4 +830,7 @@ def something(iterable, offsets=(-1, 0, 1), fillvalue=None):
         else:
             iterables.append(child)
 
-    return zip_longest(*iterables, fillvalue=fillvalue)
+    if longest:
+        return zip_longest(*iterables, fillvalue=fillvalue)
+
+    return zip(*iterables)

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -858,7 +858,7 @@ def distribute(n, iterable):
 
 
 def stagger(iterable, offsets=(-1, 0, 1), longest=False, fillvalue=None):
-    """Yield tuples whose elements from are offset from *iterable*.
+    """Yield tuples whose elements are offset from *iterable*.
     The amount by which the ``i``-th item in each tuple is offset is given by
     the ``i``-th item in *offsets*.
 

--- a/more_itertools/tests/test_more.py
+++ b/more_itertools/tests/test_more.py
@@ -682,3 +682,10 @@ class ZipOffsetTest(TestCase):
             (None, None, 7),
         ]
         eq_(actual, expected)
+
+    def test_mismatch(self):
+        iterables = [0, 1, 2], [2, 3, 4]
+        offsets = (-1, 0, 1)
+        self.assertRaises(
+            ValueError, lambda: list(zip_offset(*iterables, offsets=offsets))
+        )

--- a/more_itertools/tests/test_more.py
+++ b/more_itertools/tests/test_more.py
@@ -617,12 +617,12 @@ class DistributeTest(TestCase):
         )
 
 
-class OffsetGroupsTestCase(TestCase):
-    """Tests for ``offset_groups()``"""
+class StaggerTest(TestCase):
+    """Tests for ``stagger()``"""
 
     def test_default(self):
         iterable = [0, 1, 2, 3]
-        actual = list(offset_groups(iterable))
+        actual = list(stagger(iterable))
         expected = [(None, 0, 1), (0, 1, 2), (1, 2, 3)]
         eq_(actual, expected)
 
@@ -633,7 +633,7 @@ class OffsetGroupsTestCase(TestCase):
             ((-2, -1), [('', ''), ('', 0), (0, 1), (1, 2), (2, 3)]),
             ((1, 2), [(1, 2), (2, 3)]),
         ]:
-            all_groups = offset_groups(iterable, offsets=offsets, fillvalue='')
+            all_groups = stagger(iterable, offsets=offsets, fillvalue='')
             eq_(list(all_groups), expected)
 
     def test_longest(self):
@@ -646,7 +646,7 @@ class OffsetGroupsTestCase(TestCase):
             ((-2, -1), [('', ''), ('', 0), (0, 1), (1, 2), (2, 3), (3, '')]),
             ((1, 2), [(1, 2), (2, 3), (3, '')]),
         ]:
-            all_groups = offset_groups(
+            all_groups = stagger(
                 iterable, offsets=offsets, fillvalue='', longest=True
             )
             eq_(list(all_groups), expected)

--- a/more_itertools/tests/test_more.py
+++ b/more_itertools/tests/test_more.py
@@ -615,3 +615,38 @@ class DistributeTest(TestCase):
             [list(x) for x in distribute(6, iterable)],
             [[1], [2], [3], [4], [], []]
         )
+
+
+class OffsetGroupsTestCase(TestCase):
+    """Tests for ``offset_groups()``"""
+
+    def test_default(self):
+        iterable = [0, 1, 2, 3]
+        actual = list(offset_groups(iterable))
+        expected = [(None, 0, 1), (0, 1, 2), (1, 2, 3)]
+        eq_(actual, expected)
+
+    def test_offsets(self):
+        iterable = [0, 1, 2, 3]
+        for offsets, expected in [
+            ((-2, 0, 2), [('', 0, 2), ('', 1, 3)]),
+            ((-2, -1), [('', ''), ('', 0), (0, 1), (1, 2), (2, 3)]),
+            ((1, 2), [(1, 2), (2, 3)]),
+        ]:
+            all_groups = offset_groups(iterable, offsets=offsets, fillvalue='')
+            eq_(list(all_groups), expected)
+
+    def test_longest(self):
+        iterable = [0, 1, 2, 3]
+        for offsets, expected in [
+            (
+                (-1, 0, 1),
+                [('', 0, 1), (0, 1, 2), (1, 2, 3), (2, 3, ''), (3, '', '')]
+            ),
+            ((-2, -1), [('', ''), ('', 0), (0, 1), (1, 2), (2, 3), (3, '')]),
+            ((1, 2), [(1, 2), (2, 3), (3, '')]),
+        ]:
+            all_groups = offset_groups(
+                iterable, offsets=offsets, fillvalue='', longest=True
+            )
+            eq_(list(all_groups), expected)

--- a/more_itertools/tests/test_more.py
+++ b/more_itertools/tests/test_more.py
@@ -650,3 +650,35 @@ class StaggerTest(TestCase):
                 iterable, offsets=offsets, fillvalue='', longest=True
             )
             eq_(list(all_groups), expected)
+
+
+class ZipOffsetTest(TestCase):
+    """Tests for ``zip_offset()``"""
+
+    def test_shortest(self):
+        seq_1 = [0, 1, 2, 3]
+        seq_2 = [0, 1, 2, 3, 4, 5]
+        seq_3 = [0, 1, 2, 3, 4, 5, 6, 7]
+        actual = list(
+            zip_offset(seq_1, seq_2, seq_3, offsets=(-1, 0, 1), fillvalue='')
+        )
+        expected = [('', 0, 1), (0, 1, 2), (1, 2, 3), (2, 3, 4), (3, 4, 5)]
+        eq_(actual, expected)
+
+    def test_longest(self):
+        seq_1 = [0, 1, 2, 3]
+        seq_2 = [0, 1, 2, 3, 4, 5]
+        seq_3 = [0, 1, 2, 3, 4, 5, 6, 7]
+        actual = list(
+            zip_offset(seq_1, seq_2, seq_3, offsets=(-1, 0, 1), longest=True)
+        )
+        expected = [
+            (None, 0, 1),
+            (0, 1, 2),
+            (1, 2, 3),
+            (2, 3, 4),
+            (3, 4, 5),
+            (None, 5, 6),
+            (None, None, 7),
+        ]
+        eq_(actual, expected)


### PR DESCRIPTION
This addition is adapted from @joshbode's [ActiveState recipe](https://code.activestate.com/recipes/577852-iterator-offsetter/?in=user-4179046).

__Updated__, see thread below.

---

~~`offset_groups()`~~ `stagger()` lets you specify a set of offsets by which to lead or lag the iterable. It will yield groups of items, the `i`th of which corresponds to the `i`th offset. This is a sort of generalization of a sliding window.

For example, to get a sliding window with both lookback and lookahead:
```python
>>> list(stagger('abcdefg', offsets=(-2, -1, 0, 1)))
[(None, None, 'a', 'b'),
 (None, 'a', 'b', 'c'),
 ('a', 'b', 'c', 'd'),
 ('b', 'c', 'd', 'e'),
 ('c', 'd', 'e', 'f'),
 ('d', 'e', 'f', 'g')]
```

The `longest` parameter will continue until the last item of the iterable is the first item of the last group:
```python
>>> list(stagger('abcdefg', offsets=(0, 1, 2), longest=True))
[('a', 'b', 'c'),
 ('b', 'c', 'd'),
 ('c', 'd', 'e'),
 ('d', 'e', 'f'),
 ('e', 'f', 'g'),
 ('f', 'g', None),
 ('g', None, None)]
```

`fillvalue` can be used in place of `None` as well. `offsets` is `(-1, 0, 1)` by default to get `(before, during after`) groups:
```python
>>> for before, during, after in stagger('abcd', longest=True, fillvalue='?'):
...     print(before, during, after, sep='\t')
?	a	b
a	b	c
b	c	d
c	d	?
d	?	?
```