### PR TITLE
Test against Python 3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ python:
     - "3.3"
     - "3.4"
     - "3.5"
+    - "3.6"
 
 install:
     - "pip install -U nose tox tox-travis"


### PR DESCRIPTION
Python 3.6 is now available; we can test against it in Travis.