### PR TITLE
sort_together(), with merge conflicts resolved

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -26,6 +26,7 @@ New Routines
 .. autoclass:: peekable
 .. autofunction:: side_effect
 .. autofunction:: sliced
+.. autofunction:: sort_together
 .. autofunction:: split_after
 .. autofunction:: split_before
 .. autofunction:: spy

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -847,32 +847,32 @@ def sort_together(iterables, key_list=(0,), reverse=False):
     for sorting. Default sort is ascending. All iterables are trimmed to the
     shortest iterable length before sorting.
 
-        >>> data = [['GA', 'GA', 'GA', 'CT', 'CT', 'CT'],
-                    ['May', 'Aug.', 'May', 'June', 'July', 'July'],
-                    [97, 20, 100, 70, 100, 20]]
-        >>> sort_together(data, key_list=(0,))
-        [('CT', 'CT', 'CT', 'GA', 'GA', 'GA'),
-         ('July', 'June', 'July', 'May', 'Aug.', 'May'),
-         (70, 100, 20, 97, 20, 100)]
-        >>> sort_together(data, key_list=(0, 1, 2))
-        [('CT', 'CT', 'CT', 'GA', 'GA', 'GA'),
-         ('July', 'July', 'June', 'Aug.', 'May', 'May'),
-         (20, 70, 100, 20, 97, 100)]
+        >>> iterables = [['GA', 'GA', 'GA', 'CT', 'CT', 'CT'],
+        ...              ['May', 'Aug.', 'May', 'June', 'July', 'July'],
+        ...              [97, 20, 100, 70, 100, 20]]
+        >>> sort_together(iterables, key_list=(0,))
+        [('CT', 'CT', 'CT', 'GA', 'GA', 'GA'), \
+('June', 'July', 'July', 'May', 'Aug.', 'May'), \
+(70, 100, 20, 97, 20, 100)]
+        >>> sort_together(iterables, key_list=(0, 1, 2))
+        [('CT', 'CT', 'CT', 'GA', 'GA', 'GA'), \
+('July', 'July', 'June', 'Aug.', 'May', 'May'), \
+(20, 100, 70, 20, 97, 100)]
 
     With `reverse=True` the sort order is descending:
 
-        >>> sort_together(data, key_list=(0, 1, 2), reverse=True)
-        [('GA', 'GA', 'GA', 'CT', 'CT', 'CT'),
-         ('May', 'May', 'Aug.', 'June', 'July', 'July'),
-         (100, 97, 20, 100, 70, 20)]
+        >>> sort_together(iterables, key_list=(0, 1, 2), reverse=True)
+        [('GA', 'GA', 'GA', 'CT', 'CT', 'CT'), \
+('May', 'May', 'Aug.', 'June', 'July', 'July'), \
+(100, 97, 20, 70, 100, 20)]
 
     Default behavior of `key_list` sorts all iterables to the ascending sort
-    order of the first iterable only.
+    order of the first iterable only:
 
-        >>> sort_together(data)
-        [('CT', 'CT', 'CT', 'GA', 'GA', 'GA'),
-         ('July', 'June', 'July', 'May', 'Aug.', 'May'),
-         (70, 100, 20, 97, 20, 100)]
+        >>> sort_together(iterables)
+        [('CT', 'CT', 'CT', 'GA', 'GA', 'GA'), \
+('June', 'July', 'July', 'May', 'Aug.', 'May'), \
+(70, 100, 20, 97, 20, 100)]
     """
     return list(zip(*sorted(zip(*iterables),
                             key=itemgetter(*key_list),

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -4,6 +4,7 @@ from collections import Counter, defaultdict, deque
 from functools import partial, wraps
 from heapq import merge
 from itertools import chain, count, islice, repeat, takewhile, tee
+from operator import itemgetter
 from sys import version_info
 
 from six import string_types
@@ -15,8 +16,9 @@ __all__ = [
     'bucket', 'chunked', 'collapse', 'collate', 'consumer',
     'distinct_permutations', 'distribute', 'first', 'ilen',
     'interleave_longest', 'interleave', 'intersperse', 'iterate', 'one',
-    'padded', 'peekable', 'side_effect', 'sliced', 'split_after',
-    'split_before', 'spy', 'unique_to_each', 'windowed', 'with_iter',
+    'padded', 'peekable', 'side_effect', 'sliced', 'sort_together',
+    'split_after', 'split_before', 'spy', 'unique_to_each', 'windowed',
+    'with_iter',
 ]
 
 
@@ -838,3 +840,40 @@ def distribute(n, iterable):
             i = (i + 1) % n
 
     return [_iterator(index) for index in range(n)]
+
+
+def sort_together(iterables, key_list=(0,), reverse=False):
+    """Returns sorted iterables using the indexes in key_list as the priority
+    for sorting. Default sort is ascending. All iterables are trimmed to the
+    shortest iterable length before sorting.
+
+        >>> data = [['GA', 'GA', 'GA', 'CT', 'CT', 'CT'],
+                    ['May', 'Aug.', 'May', 'June', 'July', 'July'],
+                    [97, 20, 100, 70, 100, 20]]
+        >>> sort_together(data, key_list=(0,))
+        [('CT', 'CT', 'CT', 'GA', 'GA', 'GA'),
+         ('July', 'June', 'July', 'May', 'Aug.', 'May'),
+         (70, 100, 20, 97, 20, 100)]
+        >>> sort_together(data, key_list=(0, 1, 2))
+        [('CT', 'CT', 'CT', 'GA', 'GA', 'GA'),
+         ('July', 'July', 'June', 'Aug.', 'May', 'May'),
+         (20, 70, 100, 20, 97, 100)]
+
+    With `reverse=True` the sort order is descending:
+
+        >>> sort_together(data, key_list=(0, 1, 2), reverse=True)
+        [('GA', 'GA', 'GA', 'CT', 'CT', 'CT'),
+         ('May', 'May', 'Aug.', 'June', 'July', 'July'),
+         (100, 97, 20, 100, 70, 20)]
+
+    Default behavior of `key_list` sorts all iterables to the ascending sort
+    order of the first iterable only.
+
+        >>> sort_together(data)
+        [('CT', 'CT', 'CT', 'GA', 'GA', 'GA'),
+         ('July', 'June', 'July', 'May', 'Aug.', 'May'),
+         (70, 100, 20, 97, 20, 100)]
+    """
+    return list(zip(*sorted(zip(*iterables),
+                            key=itemgetter(*key_list),
+                            reverse=reverse)))

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -927,36 +927,33 @@ def zip_offset(*iterables, **kwargs):
 
 
 def sort_together(iterables, key_list=(0,), reverse=False):
-    """Returns sorted iterables using the indexes in key_list as the priority
-    for sorting. Default sort is ascending. All iterables are trimmed to the
-    shortest iterable length before sorting.
+    """Return the input iterables sorted together, with *key_list* as the
+    priority for sorting. All iterables are trimmed to the length of the
+    shortest one.
 
-        >>> iterables = [['GA', 'GA', 'GA', 'CT', 'CT', 'CT'],
-        ...              ['May', 'Aug.', 'May', 'June', 'July', 'July'],
-        ...              [97, 20, 100, 70, 100, 20]]
-        >>> sort_together(iterables, key_list=(0,))  # doctest: +NORMALIZE_WHITESPACE
-        [('CT', 'CT', 'CT', 'GA', 'GA', 'GA'),
-         ('June', 'July', 'July', 'May', 'Aug.', 'May'),
-         (70, 100, 20, 97, 20, 100)]
-        >>> sort_together(iterables, key_list=(0, 1, 2))  # doctest: +NORMALIZE_WHITESPACE
-        [('CT', 'CT', 'CT', 'GA', 'GA', 'GA'),
-         ('July', 'July', 'June', 'Aug.', 'May', 'May'),
-         (20, 100, 70, 20, 97, 100)]
+    This can be used like the sorting function in a spreadsheet. If each
+    iterable represents a column of data, the key list determines which
+    columns are used for sorting.
 
-    With `reverse=True` the sort order is descending:
+    By default, all iterables are sorted using the ``0``-th iterable::
 
-        >>> sort_together(iterables, key_list=(0, 1, 2), reverse=True)  # doctest: +NORMALIZE_WHITESPACE
-        [('GA', 'GA', 'GA', 'CT', 'CT', 'CT'),
-         ('May', 'May', 'Aug.', 'June', 'July', 'July'),
-         (100, 97, 20, 70, 100, 20)]
+        >>> iterables = [(4, 3, 2, 1), ('a', 'b', 'c', 'd')]
+        >>> sort_together(iterables)
+        [(1, 2, 3, 4), ('d', 'c', 'b', 'a')]
 
-    Default behavior of `key_list` sorts all iterables to the ascending sort
-    order of the first iterable only:
+    Set a different key list to sort according to another iterable.
+    Specifying mutliple keys dictates how ties are broken::
 
-        >>> sort_together(iterables)  # doctest: +NORMALIZE_WHITESPACE
-        [('CT', 'CT', 'CT', 'GA', 'GA', 'GA'),
-         ('June', 'July', 'July', 'May', 'Aug.', 'May'),
-         (70, 100, 20, 97, 20, 100)]
+        >>> iterables = [(3, 1, 2), (0, 1, 0), ('c', 'b', 'a')]
+        >>> sort_together(iterables, key_list=(1, 2))
+        [(2, 3, 1), (0, 0, 1), ('a', 'c', 'b')]
+
+
+    With *reverse* to ``True`` to sort descending:
+
+        >>> sort_together([(1, 2, 3), ('a', 'b', 'c')], reverse=True)
+        [(3, 2, 1), ('c', 'b', 'a')]
+
     """
     return list(zip(*sorted(zip(*iterables),
                             key=itemgetter(*key_list),

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -950,8 +950,8 @@ def sort_together(iterables, key_list=(0,), reverse=False):
 
     Set *reverse* to ``True`` to sort in descending order.
 
-        >>> sort_together([(1, 2, 3), ('a', 'b', 'c')], reverse=True)
-        [(3, 2, 1), ('c', 'b', 'a')]
+        >>> sort_together([(1, 2, 3), ('c', 'b', 'a')], reverse=True)
+        [(3, 2, 1), ('a', 'b', 'c')]
 
     """
     return list(zip(*sorted(zip(*iterables),

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -949,7 +949,7 @@ def sort_together(iterables, key_list=(0,), reverse=False):
         [(2, 3, 1), (0, 0, 1), ('a', 'c', 'b')]
 
 
-    With *reverse* to ``True`` to sort descending:
+    Set *reverse* to ``True`` to sort in descending order.
 
         >>> sort_together([(1, 2, 3), ('a', 'b', 'c')], reverse=True)
         [(3, 2, 1), ('c', 'b', 'a')]

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -948,7 +948,6 @@ def sort_together(iterables, key_list=(0,), reverse=False):
         >>> sort_together(iterables, key_list=(1, 2))
         [(2, 3, 1), (0, 0, 1), ('a', 'c', 'b')]
 
-
     Set *reverse* to ``True`` to sort in descending order.
 
         >>> sort_together([(1, 2, 3), ('a', 'b', 'c')], reverse=True)

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -934,29 +934,29 @@ def sort_together(iterables, key_list=(0,), reverse=False):
         >>> iterables = [['GA', 'GA', 'GA', 'CT', 'CT', 'CT'],
         ...              ['May', 'Aug.', 'May', 'June', 'July', 'July'],
         ...              [97, 20, 100, 70, 100, 20]]
-        >>> sort_together(iterables, key_list=(0,))
-        [('CT', 'CT', 'CT', 'GA', 'GA', 'GA'), \
-('June', 'July', 'July', 'May', 'Aug.', 'May'), \
-(70, 100, 20, 97, 20, 100)]
-        >>> sort_together(iterables, key_list=(0, 1, 2))
-        [('CT', 'CT', 'CT', 'GA', 'GA', 'GA'), \
-('July', 'July', 'June', 'Aug.', 'May', 'May'), \
-(20, 100, 70, 20, 97, 100)]
+        >>> sort_together(iterables, key_list=(0,))  # doctest: +NORMALIZE_WHITESPACE
+        [('CT', 'CT', 'CT', 'GA', 'GA', 'GA'),
+         ('June', 'July', 'July', 'May', 'Aug.', 'May'),
+         (70, 100, 20, 97, 20, 100)]
+        >>> sort_together(iterables, key_list=(0, 1, 2))  # doctest: +NORMALIZE_WHITESPACE
+        [('CT', 'CT', 'CT', 'GA', 'GA', 'GA'),
+         ('July', 'July', 'June', 'Aug.', 'May', 'May'),
+         (20, 100, 70, 20, 97, 100)]
 
     With `reverse=True` the sort order is descending:
 
-        >>> sort_together(iterables, key_list=(0, 1, 2), reverse=True)
-        [('GA', 'GA', 'GA', 'CT', 'CT', 'CT'), \
-('May', 'May', 'Aug.', 'June', 'July', 'July'), \
-(100, 97, 20, 70, 100, 20)]
+        >>> sort_together(iterables, key_list=(0, 1, 2), reverse=True)  # doctest: +NORMALIZE_WHITESPACE
+        [('GA', 'GA', 'GA', 'CT', 'CT', 'CT'),
+         ('May', 'May', 'Aug.', 'June', 'July', 'July'),
+         (100, 97, 20, 70, 100, 20)]
 
     Default behavior of `key_list` sorts all iterables to the ascending sort
     order of the first iterable only:
 
-        >>> sort_together(iterables)
-        [('CT', 'CT', 'CT', 'GA', 'GA', 'GA'), \
-('June', 'July', 'July', 'May', 'Aug.', 'May'), \
-(70, 100, 20, 97, 20, 100)]
+        >>> sort_together(iterables)  # doctest: +NORMALIZE_WHITESPACE
+        [('CT', 'CT', 'CT', 'GA', 'GA', 'GA'),
+         ('June', 'July', 'July', 'May', 'Aug.', 'May'),
+         (70, 100, 20, 97, 20, 100)]
     """
     return list(zip(*sorted(zip(*iterables),
                             key=itemgetter(*key_list),

--- a/more_itertools/tests/test_more.py
+++ b/more_itertools/tests/test_more.py
@@ -608,3 +608,64 @@ class DistributeTest(TestCase):
             [list(x) for x in distribute(6, iterable)],
             [[1], [2], [3], [4], [], []]
         )
+
+
+class SortTogetherTest(TestCase):
+    """Tests for sort_together()"""
+
+    def test_key_list(self):
+        """tests `key_list` including default, iterables include duplicates"""
+        iterables = [['GA', 'GA', 'GA', 'CT', 'CT', 'CT'],
+                     ['May', 'Aug.', 'May', 'June', 'July', 'July'],
+                     [97, 20, 100, 70, 100, 20]]
+
+        eq_(sort_together(iterables),
+            [('CT', 'CT', 'CT', 'GA', 'GA', 'GA'),
+             ('June', 'July', 'July', 'May', 'Aug.', 'May'),
+             (70, 100, 20, 97, 20, 100)])
+
+        eq_(sort_together(iterables, key_list=(0, 1)),
+            [('CT', 'CT', 'CT', 'GA', 'GA', 'GA'),
+             ('July', 'July', 'June', 'Aug.', 'May', 'May'),
+             (100, 20, 70, 20, 97, 100)])
+
+        eq_(sort_together(iterables, key_list=(0, 1, 2)),
+            [('CT', 'CT', 'CT', 'GA', 'GA', 'GA'),
+             ('July', 'July', 'June', 'Aug.', 'May', 'May'),
+             (20, 100, 70, 20, 97, 100)])
+
+        eq_(sort_together(iterables, key_list=(2,)),
+            [('GA', 'CT', 'CT', 'GA', 'GA', 'CT'),
+             ('Aug.', 'July', 'June', 'May', 'May', 'July'),
+             (20, 20, 70, 97, 100, 100)])
+
+    def test_invalid_key_list(self):
+        """tests `key_list` for indexes not available in `iterables`"""
+        iterables = [['GA', 'GA', 'GA', 'CT', 'CT', 'CT'],
+                     ['May', 'Aug.', 'May', 'June', 'July', 'July'],
+                     [97, 20, 100, 70, 100, 20]]
+
+        self.assertRaises(IndexError,
+                          lambda: sort_together(iterables, key_list=(5,)))
+
+    def test_reverse(self):
+        """tests `reverse` to ensure a reverse sort for `key_list` iterables"""
+        iterables = [['GA', 'GA', 'GA', 'CT', 'CT', 'CT'],
+                     ['May', 'Aug.', 'May', 'June', 'July', 'July'],
+                     [97, 20, 100, 70, 100, 20]]
+
+        eq_(sort_together(iterables, key_list=(0, 1, 2), reverse=True),
+            [('GA', 'GA', 'GA', 'CT', 'CT', 'CT'),
+             ('May', 'May', 'Aug.', 'June', 'July', 'July'),
+             (100, 97, 20, 70, 100, 20)])
+
+    def test_uneven_iterables(self):
+        """tests trimming of iterables to the shortest length before sorting"""
+        iterables = [['GA', 'GA', 'GA', 'CT', 'CT', 'CT', 'MA'],
+                     ['May', 'Aug.', 'May', 'June', 'July', 'July'],
+                     [97, 20, 100, 70, 100, 20, 0]]
+
+        eq_(sort_together(iterables),
+            [('CT', 'CT', 'CT', 'GA', 'GA', 'GA'),
+             ('June', 'July', 'July', 'May', 'Aug.', 'May'),
+             (70, 100, 20, 97, 20, 100)])


### PR DESCRIPTION
This builds on PR #101, fixing the merge conflicts and updating the docstring.

I added a note to the docstring comparing this function to the sorting available in spreadsheets. There it's familiar to sort multiple columns of data by one of them.

I also simplified the examples and added `sort_together()` to the docs.

@clintval, I'll merge this unless you have some objection. And I'll add you to the credits for the next release!