### PR TITLE
New divide() itertool

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -15,6 +15,7 @@ New Routines
 .. autofunction:: consumer
 .. autofunction:: distinct_permutations
 .. autofunction:: distribute
+.. autofunction:: divide
 .. autofunction:: first(iterable[, default])
 .. autofunction:: ilen
 .. autofunction:: interleave

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -1,4 +1,4 @@
-from __future__ import division, print_function
+from __future__ import print_function
 
 from collections import Counter, defaultdict, deque
 from functools import partial, wraps
@@ -846,7 +846,7 @@ def distribute(n, iterable):
         >>> [list(c) for c in children]
         [[1], [2], [3], [], []]
 
-    This function uses ``itertools.tee``, and may require significant storage.
+    This function uses ``itertools.tee`` and may require significant storage.
     If you need the order items in the smaller iterables to match the original
     iterable, see ``divide()``.
 
@@ -986,7 +986,7 @@ def divide(n, iterable):
         >>> [list(c) for c in children]
         [[1], [2], [3], [], []]
 
-    This function will exhaust the iterable before returning, and may require
+    This function will exhaust the iterable before returning and may require
     significant storage.
     If order is not important, see ``distribute()``, which does not first pull
     the iterable into memory.

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -761,7 +761,7 @@ def split_before(iterable, pred):
 
     """
     buf = []
-    for item in iter(iterable):
+    for item in iterable:
         if pred(item) and buf:
             yield buf
             buf = []
@@ -781,7 +781,7 @@ def split_after(iterable, pred):
 
     """
     buf = []
-    for item in iter(iterable):
+    for item in iterable:
         buf.append(item)
         if pred(item) and buf:
             yield buf

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -987,9 +987,8 @@ def divide(n, iterable):
         [[1], [2], [3], [], []]
 
     This function will exhaust the iterable before returning and may require
-    significant storage.
-    If order is not important, see ``distribute()``, which does not first pull
-    the iterable into memory.
+    significant storage. If order is not important, see ``distribute()``,
+    which does not first pull the iterable into memory.
 
     """
     if n < 1:

--- a/more_itertools/tests/test_more.py
+++ b/more_itertools/tests/test_more.py
@@ -743,3 +743,29 @@ class SortTogetherTest(TestCase):
             [('CT', 'CT', 'CT', 'GA', 'GA', 'GA'),
              ('June', 'July', 'July', 'May', 'Aug.', 'May'),
              (70, 100, 20, 97, 20, 100)])
+
+
+class DivideTest(TestCase):
+    """Tests for divide()"""
+
+    def test_invalid_n(self):
+        self.assertRaises(ValueError, lambda: divide(-1, [1, 2, 3]))
+        self.assertRaises(ValueError, lambda: divide(0, [1, 2, 3]))
+
+    def test_basic(self):
+        iterable = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+
+        for n, expected in [
+            (1, [iterable]),
+            (2, [[1, 2, 3, 4, 5], [6, 7, 8, 9, 10]]),
+            (3, [[1, 2, 3, 4], [5, 6, 7], [8, 9, 10]]),
+            (10, [[n] for n in range(1, 10 + 1)]),
+        ]:
+            eq_([list(x) for x in divide(n, iterable)], expected)
+
+    def test_large_n(self):
+        iterable = [1, 2, 3, 4]
+        eq_(
+            [list(x) for x in divide(6, iterable)],
+            [[1], [2], [3], [4], [], []]
+        )


### PR DESCRIPTION
Sort of re: issue #55, this PR adds `divide()` a counterpart to `distribute()` that maintains order.

I thought about doing this along with `distribute()`, but didn't like having to know the length of the input iterable / store the whole thing to find it.

However, I needed "chunk into N parts, maintaining order" yesterday. I found myself reaching for `more-itertools`, and regretted my decision.

I've made this exactly match `distribute()` in that it returns a list of iterables, such that one can be swapped for the other. (If this were on its own I might yield slices instead)