### PR TITLE
Adding a prepend() method to peekable

### DIFF
--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -210,12 +210,16 @@ class peekable(object):
 
             >>> p = peekable([])
             >>> next(p)
-            StopIteration:
+            Traceback (most recent call last):
+              ...
+            StopIteration
             >>> p.prepend(1)
             >>> next(p)
             1
             >>> next(p)
-            StopIteration:
+            Traceback (most recent call last):
+              ...
+            StopIteration
 
         """
         self._cache.extendleft(items)

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -175,6 +175,11 @@ class peekable(object):
                 return default
         return self._cache[0]
 
+    def prepend(self, *items):
+        """Schedule items to be the next ones returned from ``next()`` or
+        ``self.peek()``."""
+        self._cache.extendleft(items)
+
     def __next__(self):
         if self._cache:
             return self._cache.popleft()

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -208,25 +208,6 @@ class peekable(object):
             >>> list(p)
             [11, 12, 1, 2, 3]
 
-        If you want to prepend elements such that the last one in the argument
-        list is the first to be returned, use ``reversed()``,
-
-            >>> p = peekable([1, 2, 3])
-            >>> p.prepend(*reversed((10, 11, 12)))
-            >>> list(p)
-            [12, 11, 10, 1, 2, 3]
-
-        or use separate calls to ``prepend()`` with one element each:
-
-            >>> p = peekable([1, 2, 3])
-            >>> p.prepend(10)
-            >>> p.prepend(11)
-            >>> p.prepend(12)
-            >>> list(p)
-            [12, 11, 10, 1, 2, 3]
-
-        This last example could also be wrapped up with a `for` loop.
-
         It is possible, by prepending items, to "resurrect" a peekable that
         previously raised ``StopIteration``.
 

--- a/more_itertools/tests/test_more.py
+++ b/more_itertools/tests/test_more.py
@@ -177,6 +177,71 @@ class PeekableTests(TestCase):
             next(p)
             eq_(p[index], seq[1:][index])
 
+    # pushback behavior tests
+
+    def test_passthrough(self):
+        """Tests passing through an iterable without pushing anything"""
+        expected = [1, 2, 3, 4, 5]
+        actual = list(peekable(expected))
+        eq_(actual, expected)
+
+    def test_first_push(self):
+        """Tests pushing before consuming anything"""
+        it = peekable(range(5))
+        it.prepend(10)
+        actual = list(it)
+        expected = [10, 0, 1, 2, 3, 4]
+
+    def test_second_push(self):
+        """Tests pushing after consuming only one element"""
+        it = peekable(range(5))
+        actual = [next(it)]
+        it.prepend(10)
+        actual += list(it)
+        expected = [0, 10, 1, 2, 3, 4]
+        eq_(actual, expected)
+
+    def test_last_push(self):
+        """Tests pushing after consuming the entire underlying iterable"""
+        it = peekable(range(5))
+        actual = [next(it), next(it), next(it), next(it), next(it)]
+        it.prepend(10)
+        actual += [next(it)]
+        expected = [0, 1, 2, 3, 4, 10]
+        eq_(actual, expected)
+
+    def test_multi_push(self):
+        """Tests pushing multiple elements and getting them in reverse order"""
+        it = peekable(range(5))
+        actual = [next(it), next(it)]
+        it.prepend(10, 11, 12)
+        actual += list(it)
+        expected = [0, 1, 12, 11, 10, 2, 3, 4]
+        eq_(actual, expected)
+
+    def test_interleaved_push(self):
+        """Tests pushes interleaved with consuming from the underlying iterable"""
+        it = peekable(range(5))
+        actual = [next(it)]
+        it.prepend(10)
+        actual += [next(it), next(it)]
+        it.prepend(11)
+        actual += [next(it), next(it)]
+        it.prepend(12)
+        actual += [next(it), next(it)]
+        it.prepend(13)
+        actual += [next(it), next(it)]
+        expected = [0, 10, 1, 11, 2, 12, 3, 13, 4]
+        eq_(actual, expected)
+
+    def test_empty(self):
+        """Tests pushing in front of an empty iterable"""
+        it = peekable([])
+        it.prepend(10)
+        actual = list(it)
+        expected = [10]
+        eq_(actual, expected)
+
 
 class ConsumerTests(TestCase):
     """Tests for ``consumer()``"""

--- a/more_itertools/tests/test_more.py
+++ b/more_itertools/tests/test_more.py
@@ -207,13 +207,13 @@ class PeekableTests(TestCase):
         eq_(actual, expected)
 
     def test_multi_prepend(self):
-        """Tests prepending multiple elements and getting them in reverse order"""
+        """Tests prepending multiple elements and getting them in proper order"""
         it = peekable(range(5))
         actual = [next(it), next(it)]
         it.prepend(10, 11, 12)
-        it.prepend(13, 14)
+        it.prepend(20, 21)
         actual += list(it)
-        expected = [0, 1, 14, 13, 12, 11, 10, 2, 3, 4]
+        expected = [0, 1, 20, 21, 10, 11, 12, 2, 3, 4]
         eq_(actual, expected)
 
     def test_empty(self):
@@ -245,12 +245,12 @@ class PeekableTests(TestCase):
         actual = [next(it), next(it)]
         eq_(it.peek(), 2)
         it.prepend(10, 11, 12)
-        eq_(it.peek(), 12)
-        it.prepend(13, 14)
-        eq_(it.peek(), 14)
+        eq_(it.peek(), 10)
+        it.prepend(20, 21)
+        eq_(it.peek(), 20)
         actual += list(it)
         self.assertFalse(it)
-        expected = [0, 1, 14, 13, 12, 11, 10, 2, 3, 4]
+        expected = [0, 1, 20, 21, 10, 11, 12, 2, 3, 4]
         eq_(actual, expected)
 
     def test_prepend_after_stop(self):
@@ -267,7 +267,7 @@ class PeekableTests(TestCase):
         seq = list(range(20))
         p = peekable(seq)
 
-        p.prepend(50, 40, 30)
+        p.prepend(30, 40, 50)
         pseq = [30, 40, 50] + seq # pseq for prepended_seq
 
         # adapt the specific tests from test_slicing
@@ -285,7 +285,7 @@ class PeekableTests(TestCase):
         seq = list(range(20))
         p = peekable(seq)
 
-        p.prepend(50, 40, 30)
+        p.prepend(30, 40, 50)
         pseq = [30, 40, 50] + seq # pseq for prepended_seq
 
         # adapt the specific tests from test_indexing
@@ -307,7 +307,7 @@ class PeekableTests(TestCase):
         it = peekable(range(5))
         it.prepend(*range(5))
         actual = list(it)
-        expected = list(chain(reversed(range(5)), range(5)))
+        expected = list(chain(range(5), range(5)))
         eq_(actual, expected)
 
     def test_prepend_many(self):
@@ -315,7 +315,7 @@ class PeekableTests(TestCase):
         it = peekable(range(5))
         it.prepend(*range(20000))
         actual = list(it)
-        expected = list(chain(reversed(range(20000)), range(5)))
+        expected = list(chain(range(20000), range(5)))
         eq_(actual, expected)
 
 

--- a/more_itertools/tests/test_more.py
+++ b/more_itertools/tests/test_more.py
@@ -224,7 +224,7 @@ class PeekableTests(TestCase):
         expected = [10]
         eq_(actual, expected)
 
-    def test_prepend_bool(self):
+    def test_prepend_truthiness(self):
         """Tests that ``__bool__()`` or ``__nonzero__()`` works properly
         with ``prepend()``"""
         it = peekable(range(5))
@@ -252,6 +252,54 @@ class PeekableTests(TestCase):
         self.assertFalse(it)
         expected = [0, 1, 14, 13, 12, 11, 10, 2, 3, 4]
         eq_(actual, expected)
+
+    def test_prepend_after_stop(self):
+        """Tests that prepending after StopIteration makes the iterator valid again"""
+        it = peekable(range(3))
+        eq_(list(it), [0, 1, 2])
+        self.assertRaises(StopIteration, lambda: next(it))
+        it.prepend(10)
+        eq_(next(it), 10)
+        self.assertRaises(StopIteration, lambda: next(it))
+
+    def test_prepend_slicing(self):
+        """Tests interaction between prepending and slicing"""
+        seq = list(range(20))
+        p = peekable(seq)
+
+        p.prepend(50, 40, 30)
+        pseq = [30, 40, 50] + seq # pseq for prepended_seq
+
+        # adapt the specific tests from test_slicing
+        eq_(p[0], 30)
+        eq_(p[1:8], pseq[1:8])
+        eq_(p[1:], pseq[1:])
+        eq_(p[:5], pseq[:5])
+        eq_(p[:], pseq[:])
+        eq_(p[:100], pseq[:100])
+        eq_(p[::2], pseq[::2])
+        eq_(p[::-1], pseq[::-1])
+
+    def test_prepend_indexing(self):
+        """Tests interaction between prepending and indexing"""
+        seq = list(range(20))
+        p = peekable(seq)
+
+        p.prepend(50, 40, 30)
+        pseq = [30, 40, 50] + seq # pseq for prepended_seq
+
+        # adapt the specific tests from test_indexing
+        eq_(p[0], 30)
+        eq_(next(p), 30)
+        eq_(p[2], 0)
+        eq_(next(p), 40)
+        eq_(p[0], 50)
+        eq_(p[9], 8)
+        eq_(next(p), 50)
+        eq_(p[8], 8)
+        eq_(p[-2], 18)
+        eq_(p[-9], 11)
+        self.assertRaises(IndexError, lambda: p[-21])
 
     def test_prepend_iterable(self):
         """Tests prepending from an iterable (because if this doesn't work, the


### PR DESCRIPTION
As discussed in #106. This does not use `reversed()`, so `p.prepend(a, b, c)` is equivalent to
```python
p.prepend(c)
p.prepend(b)
p.prepend(a)
```
but that can be changed.