### PR TITLE
adjacent() and groupby_transform()

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -8,6 +8,7 @@ API Reference
 New Routines
 ============
 
+.. autofunction:: adjacent
 .. autofunction:: always_iterable
 .. autofunction:: bucket
 .. autofunction:: chunked
@@ -18,6 +19,7 @@ New Routines
 .. autofunction:: distribute
 .. autofunction:: divide
 .. autofunction:: first(iterable[, default])
+.. autofunction:: groupby_transform
 .. autofunction:: ilen
 .. autofunction:: interleave
 .. autofunction:: interleave_longest

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -1178,12 +1178,13 @@ def groupby_transform(iterable, keyfunc=None, valuefunc=None):
     If ``None`` or an identity function is passed for *valuefunc*, the behavior
     is identical to ``itertools.groupby()``.
     """
-    if valuefunc is None:
-        if keyfunc is None:
+    if valuefunc is None and keyfunc is not None:
+        for key, group in groupby(iterable, keyfunc):
+            yield key, group
+    else:
+        if valuefunc is None and keyfunc is None:
             # itemgetter is about 2.2x as fast as lambda functions in some tests
             keyfunc = itemgetter(0)
             valuefunc = itemgetter(1)
-        else:
-            return groupby(iterable, keyfunc)
-    for key, group in groupby(iterable, keyfunc):
-        yield key, map(valuefunc, group)
+        for key, group in groupby(iterable, keyfunc):
+            yield key, map(valuefunc, group)

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -1180,8 +1180,9 @@ def groupby_transform(iterable, keyfunc=None, valuefunc=None):
     """
     if valuefunc is None:
         if keyfunc is None:
-            keyfunc = lambda t: t[0]
-            valuefunc = lambda t: t[1]
+            # itemgetter is about 2.2x as fast as lambda functions in some tests
+            keyfunc = itemgetter(0)
+            valuefunc = itemgetter(1)
         else:
             return groupby(iterable, keyfunc)
     for key, group in groupby(iterable, keyfunc):

--- a/more_itertools/tests/test_more.py
+++ b/more_itertools/tests/test_more.py
@@ -8,7 +8,7 @@ from unittest import TestCase
 
 from nose.tools import eq_, assert_raises
 import six
-from six.moves import filter, range
+from six.moves import filter, range, zip
 
 from more_itertools import *  # Test all the symbols are in __all__.
 
@@ -1024,10 +1024,15 @@ class AdjacentTests(TestCase):
         self.assertEqual(actual, expected)
 
 class GroupByTransformTests(TestCase):
-    def assertAllEqual(self, iterable1, iterable2, msg=None):
-        """Compare two iterables element-by-element for equality"""
-        for a, b in zip(iterable1, iterable2):
-            self.assertEqual(a, b, msg)
+    def assertAllGroupsEqual(self, groupby1, groupby2):
+        """Compare two groupby objects for equality, both keys and groups."""
+        for a, b in zip(groupby1, groupby2):
+            key1, group1 = a
+            key2, group2 = b
+            self.assertEqual(key1, key2)
+            self.assertListEqual(list(group1), list(group2))
+        self.assertRaises(StopIteration, lambda: next(groupby1))
+        self.assertRaises(StopIteration, lambda: next(groupby2))
 
     def test_default_funcs(self):
         iterable = [(int(x / 5), x) for x in range(10)]
@@ -1061,8 +1066,8 @@ class GroupByTransformTests(TestCase):
 
         actual = groupby_transform(iterable, key, valuefunc=None)
         expected = groupby(iterable, key)
-        self.assertAllEqual(actual, expected)
+        self.assertAllGroupsEqual(actual, expected)
 
         actual = groupby_transform(iterable, key) # default valuefunc
         expected = groupby(iterable, key)
-        self.assertAllEqual(actual, expected)
+        self.assertAllGroupsEqual(actual, expected)


### PR DESCRIPTION
From issue #109, this PR implements `adjacent()` and `groupby_transform()`.

It's mostly straightforward, except that the one possibly-contentious design decision I made was to have `groupby_transform()` use default key and value transformations of `itemgetter(0)` and `itemgetter(1)` respectively, so you can call
```python
groupby_transform(zip(keys, values))
```
to group one iterable by the elements of another. That seems like the use case where this tool is going to be by far the most useful. And it's not like we lose any functionality, since without this special case, the only sensible behavior for default arguments (as far as I can imagine) is to just pass through to `groupby()`, in which case people should just use `groupby()` directly.

That being said, it does seem rather weird, especially given the name of the function. And it's not unimaginable that this special-case behavior could complicate things in some cases. And yes, "explicit is better than implicit", though I could counter with "practicality beats purity" ;-) Anyway, the point is, I'm fine with it if you think it's better to omit this special case and just have the default arguments emulate `groupby()`, and make people explicitly pass `itemgetter(0)` and `itemgetter(1)` whenever they want to group one iterable by another. I just think if we do that, it's a missed opportunity to simplify potentially a lot of client code.

Oh, and I'm also not thrilled with the test coverage, though I couldn't really think of any other useful tests to add.

(I'm also not attached to either of these function names.)