### PR TITLE
Add coverage tracking

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ python:
     - "3.6"
 
 install:
-    - "pip install -U coveralls nose"
+    - "pip install -U coveralls nose six"
 
 script:
     - "coverage run --include='more_itertools/*.py' --omit='more_itertools/tests/*' -m nose more_itertools -v --with-doctest"

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,10 +10,13 @@ python:
     - "3.6"
 
 install:
-    - "pip install -U nose tox tox-travis"
+    - "pip install -U coveralls nose"
 
 script:
-    - "tox"
+    - "coverage run --include='more_itertools/*.py' --omit="more_itertools/tests/*" -m nose more_itertools -v --with-doctest"
 
 notifications:
   email: false
+
+after_success:
+    - "coveralls"

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ install:
     - "pip install -U coveralls nose"
 
 script:
-    - "coverage run --include='more_itertools/*.py' --omit="more_itertools/tests/*" -m nose more_itertools -v --with-doctest"
+    - "coverage run --include='more_itertools/*.py' --omit='more_itertools/tests/*' -m nose more_itertools -v --with-doctest"
 
 notifications:
   email: false


### PR DESCRIPTION
This PR adds coverage with Coveralls.io . I've changed the Travis configuration file to use standard testing, since Tox doesn't seem to play nicely (probably something with directories).

Looks like we've got [100%](https://coveralls.io/builds/10112035); I'll add a badge once this is merged.