### PR TITLE
With file

### DIFF
--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -40,6 +40,7 @@ __all__ = [
     'stagger',
     'unique_to_each',
     'windowed',
+    'with_file',
     'with_iter',
     'zip_offset',
 ]
@@ -380,6 +381,21 @@ def iterate(func, start):
         yield start
         start = func(start)
 
+
+def with_file(file_handle):
+    """Wrap a file context manager in a ``with`` statement, so it closes once consumed.
+
+    For example, this will close the file when the iterator is consumed::
+
+        >>> from more_itertools import consume
+        >>> consume(print(line, file=outfile)
+                    for outfile in with_file(open("temp.tmp", "w"))
+                    for line in range(3))
+
+
+    """
+    with file_handle as f:
+        yield f
 
 def with_iter(context_manager):
     """Wrap an iterable in a ``with`` statement, so it closes once exhausted.

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -387,10 +387,10 @@ def with_file(file_handle):
 
     For example, this will close the file when the iterator is consumed::
 
-        >>> from more_itertools import consume
-        >>> consume(print(line, file=outfile)
-                    for outfile in with_file(open("temp.tmp", "w"))
-                    for line in range(3))
+        from more_itertools import consume
+        consume(print(line, file=outfile)
+                for outfile in with_file(open("temp.tmp", "w"))
+                for line in range(3))
 
 
     """

--- a/more_itertools/tests/test_more.py
+++ b/more_itertools/tests/test_more.py
@@ -1,8 +1,8 @@
-from __future__ import division, unicode_literals
+from __future__ import division, unicode_literals, print_function
 
 from contextlib import closing
 from functools import reduce
-from io import StringIO
+from io import StringIO, BytesIO
 from itertools import chain, count, permutations
 from unittest import TestCase
 
@@ -11,7 +11,8 @@ import six
 from six.moves import filter, range
 
 from more_itertools import *  # Test all the symbols are in __all__.
-
+import sys
+PY3 = sys.version_info[0] == 3
 
 class CollateTests(TestCase):
     """Unit tests for ``collate()``"""
@@ -364,11 +365,17 @@ def test_ilen():
 
 def test_with_file():
     """Make sure ``with_file`` write to the file and closes things correctly."""
-    s = StringIO('')
+    if PY3:
+        s = StringIO('')
+    else:
+        s = BytesIO(b'')
     output = [(print(i, file=s),s.getvalue())[1] 
               for s in with_file(closing(s)) 
               for i in range(3)]
-    eq_(output, ['0\n', '0\n1\n', '0\n1\n2\n'])
+    if PY3:
+        eq_(output, ['0\n', '0\n1\n', '0\n1\n2\n'])
+    else:
+        eq_(output, [b'0\n', b'0\n1\n', b'0\n1\n2\n'])
 
     # Make sure closing happened:
     try:

--- a/more_itertools/tests/test_more.py
+++ b/more_itertools/tests/test_more.py
@@ -362,6 +362,22 @@ def test_ilen():
     eq_(ilen(filter(lambda x: x % 10 == 0, range(101))), 11)
 
 
+def test_with_file():
+    """Make sure ``with_file`` write to the file and closes things correctly."""
+    s = StringIO('')
+    output = [(print(i, file=s),s.getvalue())[1] 
+              for s in with_file(closing(s)) 
+              for i in range(3)]
+    eq_(output, ['0\n', '0\n1\n', '0\n1\n2\n'])
+
+    # Make sure closing happened:
+    try:
+        list(s)
+    except ValueError:  # "I/O operation on closed file"
+        pass
+    else:
+        raise AssertionError('StringIO object was not closed.')
+
 def test_with_iter():
     """Make sure ``with_iter`` iterates over and closes things correctly."""
     s = StringIO('One fish\nTwo fish')


### PR DESCRIPTION
In the spirit of ``with_iter`` and ``side_effect``, I have implemented ``with_file`` to handle context management of output files.  

For example, you can wrap a file handler in an iterator to log output to a file.

     from more_itertools import consume, with_file
     consume(print(x, file=output) for output in with_file(open("temp.tmp","w")) for x in range(3))

The pull request includes a ``nose`` test that passes under versions 2.7.12, 3.2.6, 3.3.6, 3.4.5, 3.5.2.