### PR TITLE
Add optional arguments for side_effect()

### DIFF
--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -126,8 +126,8 @@ class peekable(object):
         >>> list(p)
         [11, 12, 1, 2, 3]
 
-    Prepended items are treated by other peekable methods exactly as if they had
-    come from the source iterator.
+    Prepended items are treated by other peekable methods exactly as if they
+    had come from the source iterator.
 
     You may index the peekable to look ahead by more than one item.
     The values up to the index you specified will be cached.
@@ -200,7 +200,8 @@ class peekable(object):
 
     def prepend(self, *items):
         """Stack up items to be the next ones returned from ``next()`` or
-        ``self.peek()``. The items will be returned in first-in first-out order:
+        ``self.peek()``. The items will be returned in
+        first in, first out order::
 
             >>> p = peekable([1, 2, 3])
             >>> p.prepend(10, 11, 12)
@@ -780,9 +781,7 @@ def side_effect(func, iterable, chunk_size=None, file_obj=None):
         >>> f = StringIO()
         >>> func = lambda x: print(x, file=f)
         >>> it = [u'a', u'b', u'c']
-        >>> consume(
-        ...     side_effect(func, it, file_obj=f)
-        ... )
+        >>> consume(side_effect(func, it, file_obj=f))
         >>> f.closed
         True
 

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -743,21 +743,12 @@ def collapse(iterable, base_type=None, levels=None):
         yield x
 
 
-def side_effect(
-    func,
-    iterable,
-    chunk_size=None,
-    func_args=None,
-    func_kwargs=None,
-    file_obj=None,
-):
+def side_effect(func, iterable, chunk_size=None, file_obj=None):
     """Invoke *func* on each item in *iterable* (or on each *chunk_size* group
     of items) before yielding the item.
 
-    `func` must be a function that takes an item from the iterable as its first
-    argument. Specify subsequent arguments by passing an
-    *func_args* (an iterable) and *func_kwargs* (a mapping).
-    Any returned values are discarded.
+    `func` must be a function that takes a single argument. Its return value
+    will be discarded.
 
     If *file_obj* is given, it will be closed after iterating. This can be
     useful if the side effect is operating on files.
@@ -786,25 +777,24 @@ def side_effect(
 
         >>> from io import StringIO
         >>> from more_itertools import consume
-        >>> it = [u'a', u'b', u'c']
         >>> f = StringIO()
+        >>> func = lambda x: print(x, file=f)
+        >>> it = [u'a', u'b', u'c']
         >>> consume(
-        ...     side_effect(print, it, func_kwargs={'file': f}, file_obj=f)
+        ...     side_effect(func, it, file_obj=f)
         ... )
         >>> f.closed
         True
 
     """
-    func_args = [] if func_args is None else func_args
-    func_kwargs = {} if func_kwargs is None else func_kwargs
     try:
         if chunk_size is None:
             for item in iterable:
-                func(item, *func_args, **func_kwargs)
+                func(item)
                 yield item
         else:
             for chunk in chunked(iterable, chunk_size):
-                func(chunk, *func_args, **func_kwargs)
+                func(chunk)
                 for item in chunk:
                     yield item
     finally:

--- a/more_itertools/tests/test_more.py
+++ b/more_itertools/tests/test_more.py
@@ -1,4 +1,4 @@
-from __future__ import division, unicode_literals
+from __future__ import division, print_function, unicode_literals
 
 from contextlib import closing
 from functools import reduce
@@ -616,6 +616,31 @@ class SideEffectTests(TestCase):
         result = list(side_effect(func, range(10), 2))
         eq_(result, list(range(10)))
         eq_(counter[0], 5)
+
+    def test_optional_args(self):
+        collector = []
+
+        def func(item, x, y=0):
+            collector.append((item, x, y))
+
+        it = [1, 2]
+        func_args = ['X']
+        func_kwargs = {'y': 'Y'}
+        result = list(
+            side_effect(func, it, func_args=func_args, func_kwargs=func_kwargs)
+        )
+
+        self.assertEqual(result, it)
+        self.assertEqual(collector, [(1, 'X', 'Y'), (2, 'X', 'Y')])
+
+    def test_file_obj(self):
+        """File objects should be closed after iterating"""
+        f = StringIO()
+        it = [u'a', u'b']
+        func_kwargs = {'file': f}
+        consume(side_effect(print, it, func_kwargs=func_kwargs, file_obj=f))
+        self.assertTrue(f.closed)
+
 
 
 class SlicedTests(TestCase):

--- a/more_itertools/tests/test_more.py
+++ b/more_itertools/tests/test_more.py
@@ -617,30 +617,19 @@ class SideEffectTests(TestCase):
         eq_(result, list(range(10)))
         eq_(counter[0], 5)
 
-    def test_optional_args(self):
-        collector = []
-
-        def func(item, x, y=0):
-            collector.append((item, x, y))
-
-        it = [1, 2]
-        func_args = ['X']
-        func_kwargs = {'y': 'Y'}
-        result = list(
-            side_effect(func, it, func_args=func_args, func_kwargs=func_kwargs)
-        )
-
-        self.assertEqual(result, it)
-        self.assertEqual(collector, [(1, 'X', 'Y'), (2, 'X', 'Y')])
-
     def test_file_obj(self):
         """File objects should be closed after iterating"""
         f = StringIO()
-        it = [u'a', u'b']
-        func_kwargs = {'file': f}
-        consume(side_effect(print, it, func_kwargs=func_kwargs, file_obj=f))
-        self.assertTrue(f.closed)
+        collector = []
 
+        def func(item):
+            print(item, file=f)
+            collector.append(f.getvalue())
+
+        it = [u'a', u'b']
+        consume(side_effect(func, it, file_obj=f))
+        self.assertEqual(collector, [u'a\n', u'a\nb\n'])
+        self.assertTrue(f.closed)
 
 
 class SlicedTests(TestCase):


### PR DESCRIPTION
Re: PR #112, this adds some new optional keyword arguments to `side_effect()`.

~~Previously the function passed in was only allowed to accept a single argument. It now must accept an item from the iterable as the first argument, and a fixed set of other arguments can be passed in. Additionally, keyword arguments can be specified.~~

Also added is `file_obj`, which is a hint that the function will operate on a file object that should be closed after iterating. See the tests, docstring, and the older PR for motivating use cases.

---

~~I could be persuaded to get rid of the argument / keyword argument and just give examples with lambdas or partials. Anybody feel strongly?~~

Many thanks to @yardsale8 for the suggestion.
