### PR TITLE
Add before and after functions to side_effect

### DIFF
--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -783,8 +783,8 @@ def side_effect(func, iterable, chunk_size=None, before=None, after=None):
         >>> f = StringIO()
         >>> func = lambda x: print(x, file=f)
         >>> before = lambda: print(u'HEADER', file=f)
+        >>> after = f.close
         >>> it = [u'a', u'b', u'c']
-        >>> after = lambda: f.close()
         >>> consume(side_effect(func, it, before=before, after=after))
         >>> f.closed
         True

--- a/more_itertools/tests/test_more.py
+++ b/more_itertools/tests/test_more.py
@@ -618,8 +618,7 @@ class SideEffectTests(TestCase):
         eq_(result, list(range(10)))
         eq_(counter[0], 5)
 
-    def test_file_obj(self):
-        """File objects should be closed after iterating"""
+    def test_before_after(self):
         f = StringIO()
         collector = []
 
@@ -627,9 +626,23 @@ class SideEffectTests(TestCase):
             print(item, file=f)
             collector.append(f.getvalue())
 
-        it = [u'a', u'b']
-        consume(side_effect(func, it, file_obj=f))
-        self.assertEqual(collector, [u'a\n', u'a\nb\n'])
+        def it():
+            yield u'a'
+            yield u'b'
+            raise Exception('kaboom')
+
+        before = lambda: print('HEADER', file=f)
+        after = lambda: f.close()
+
+        try:
+            consume(side_effect(func, it(), before=before, after=after))
+        except Exception:
+            pass
+
+        # The iterable should have been written to the file
+        self.assertEqual(collector, [u'HEADER\na\n', u'HEADER\na\nb\n'])
+
+        # The file should be closed even though something bad happened
         self.assertTrue(f.closed)
 
 

--- a/more_itertools/tests/test_more.py
+++ b/more_itertools/tests/test_more.py
@@ -632,7 +632,7 @@ class SideEffectTests(TestCase):
             raise Exception('kaboom')
 
         before = lambda: print('HEADER', file=f)
-        after = lambda: f.close()
+        after = f.close
 
         try:
             consume(side_effect(func, it(), before=before, after=after))


### PR DESCRIPTION
Re: Issue #114, this PR takes the suggestion to remove the `file_obj` argument from `side_effect()` and replace it with something more general/powerful.

Instead of `file_obj`, we now have optional `before` and `after` arguments. These are supposed to be functions that don't take any arguments that will operate pre- and post-iteration.

I thought this was crazy at first, but now I'm kind of fond of the idea.