### PR TITLE
Use a length-1 deque for ilen()

### DIFF
--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -368,6 +368,24 @@ def ilen(iterable):
     This does, of course, consume the iterable, so handle it with care.
 
     """
+    try:
+        return len(iterable)
+    except TypeError:
+        pass
+
+    d = deque(enumerate(iterable, 1), maxlen=1)
+    return d[0][0] if d else 0
+
+
+def ilen_2(iterable):
+    """Return the number of items in ``iterable``.
+
+        >>> ilen(x for x in range(1000000) if x % 3 == 0)
+        333334
+
+    This does, of course, consume the iterable, so handle it with care.
+
+    """
     d = deque(enumerate(iterable, 1), maxlen=1)
     return d[0][0] if d else 0
 

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -365,7 +365,8 @@ def ilen(iterable):
         >>> ilen(x for x in range(1000000) if x % 3 == 0)
         333334
 
-    This does, of course, consume the iterable, so handle it with care.
+    This consumes the iterable (unless it has a ``__len__`` method), so handle
+    with care.
 
     """
     try:

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -365,15 +365,9 @@ def ilen(iterable):
         >>> ilen(x for x in range(1000000) if x % 3 == 0)
         333334
 
-    This consumes the iterable (unless it has a ``__len__`` method), so handle
-    with care.
+    This consumes the iterable, so handle with care.
 
     """
-    try:
-        return len(iterable)
-    except TypeError:
-        pass
-
     d = deque(enumerate(iterable, 1), maxlen=1)
     return d[0][0] if d else 0
 

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -378,19 +378,6 @@ def ilen(iterable):
     return d[0][0] if d else 0
 
 
-def ilen_2(iterable):
-    """Return the number of items in ``iterable``.
-
-        >>> ilen(x for x in range(1000000) if x % 3 == 0)
-        333334
-
-    This does, of course, consume the iterable, so handle it with care.
-
-    """
-    d = deque(enumerate(iterable, 1), maxlen=1)
-    return d[0][0] if d else 0
-
-
 def iterate(func, start):
     """Return ``start``, ``func(start)``, ``func(func(start))``, ...
 

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -368,7 +368,8 @@ def ilen(iterable):
     This does, of course, consume the iterable, so handle it with care.
 
     """
-    return sum(1 for _ in iterable)
+    d = deque(enumerate(iterable, 1), maxlen=1)
+    return d[0][0] if d else 0
 
 
 def iterate(func, start):

--- a/more_itertools/tests/test_more.py
+++ b/more_itertools/tests/test_more.py
@@ -359,8 +359,9 @@ def test_distinct_permutations():
 
 
 def test_ilen():
-    """Sanity-check ``ilen()``."""
+    """Sanity-checks for ``ilen()``."""
     eq_(ilen(filter(lambda x: x % 10 == 0, range(101))), 11)
+    eq_(ilen((x for x in range(0))), 0)
 
 
 def test_with_iter():

--- a/more_itertools/tests/test_more.py
+++ b/more_itertools/tests/test_more.py
@@ -360,8 +360,14 @@ def test_distinct_permutations():
 
 def test_ilen():
     """Sanity-checks for ``ilen()``."""
+    # Non-empty
     eq_(ilen(filter(lambda x: x % 10 == 0, range(101))), 11)
+
+    # Empty
     eq_(ilen((x for x in range(0))), 0)
+
+    # Iterable with __len__
+    eq_(ilen(list(range(6))), 6)
 
 
 def test_with_iter():


### PR DESCRIPTION
Re: Issue #116, this PR borrows @wbolster's trick of feeding an `enumerate()`-wrapped iterable into a length-1 deque to get the length. This buys a slight speed increase.  