### PR TITLE
Add context() helper

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -15,6 +15,7 @@ New Routines
 .. autofunction:: collapse
 .. autofunction:: collate(*iterables, key=lambda a: a, reverse=False)
 .. autofunction:: consumer
+.. autofunction:: context
 .. autofunction:: distinct_permutations
 .. autofunction:: distribute
 .. autofunction:: divide

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -780,7 +780,7 @@ def side_effect(func, iterable, chunk_size=None):
         >>> from io import StringIO
         >>> from more_itertools import consume
         >>> with StringIO() as f:
-        ...     func = lambda x: print(x, end=',', file=f)
+        ...     func = lambda x: print(x, end=u',', file=f)
         ...     it = [u'a', u'b', u'c']
         ...     consume(side_effect(func, it))
         ...     print(f.getvalue())

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -1214,6 +1214,19 @@ def context(obj):
         >>> file_obj.closed
         True
 
+    Be sure to iterate over the returned context manager in the outermost
+    loop of a nested loop structure::
+
+        >>> # Right
+        >>> file_obj = StringIO()
+        >>> consume(print(x, file=f) for f in context(file_obj) for x in it)
+
+        >>> # Wrong
+        >>> file_obj = StringIO()
+        >>> consume(print(x, file=f) for x in it for f in context(file_obj))
+        Traceback (most recent call last):
+        ...
+        ValueError: I/O operation on closed file.
     """
     with obj as context_obj:
         yield context_obj

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -20,6 +20,7 @@ __all__ = [
     'collapse',
     'collate',
     'consumer',
+    'context',
     'distinct_permutations',
     'distribute',
     'divide',
@@ -1193,3 +1194,26 @@ def groupby_transform(iterable, keyfunc=None, valuefunc=None):
     valuefunc = (lambda x: x) if valuefunc is None else valuefunc
     for key, group in groupby(iterable, keyfunc):
         yield key, map(valuefunc, group)
+
+
+def context(obj):
+    """Wrap *obj*, an object that supports the context manager protocol,
+    in a ``with`` statement and then yield the resultant object.
+
+    The object's ``__enter__()`` method runs before this function yields, and
+    its ``__exit__()`` method runs after control returns to this function.
+
+    This can be used to operate on objects that can close automatically when
+    using a ``with`` statement, like IO objects:
+
+        >>> from io import StringIO
+        >>> from more_itertools import consume
+        >>> it = [u'1', u'2', u'3']
+        >>> file_obj = StringIO()
+        >>> consume(print(x, file=f) for f in context(file_obj) for x in it)
+        >>> file_obj.closed
+        True
+
+    """
+    with obj as context_obj:
+        yield context_obj

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -1215,7 +1215,7 @@ def context(obj):
         True
 
     Be sure to iterate over the returned context manager in the outermost
-    loop of a nested loop structure::
+    loop of a nested loop structure so it only enters and exits once::
 
         >>> # Right
         >>> file_obj = StringIO()

--- a/more_itertools/tests/test_more.py
+++ b/more_itertools/tests/test_more.py
@@ -1,6 +1,6 @@
 from __future__ import division, print_function, unicode_literals
 
-from contextlib import closing
+from contextlib import closing, contextmanager
 from functools import reduce
 from io import StringIO
 from itertools import chain, count, groupby, permutations, repeat
@@ -1095,3 +1095,21 @@ class GroupByTransformTests(TestCase):
         actual = groupby_transform(iterable, key) # default valuefunc
         expected = groupby(iterable, key)
         self.assertAllGroupsEqual(actual, expected)
+
+
+class ContextTestCase(TestCase):
+    def test_basic(self):
+        before = []
+        after = []
+
+        @contextmanager
+        def managed():
+            before.append(1)
+            yield 1
+            after.append(1)
+
+        actual = [(c, x) for c in context(managed()) for x in range(3)]
+        expected = [(1, 0), (1, 1), (1, 2)]
+        self.assertEqual(actual, expected)
+        self.assertEqual(before, [1])
+        self.assertEqual(after, [1])

--- a/more_itertools/tests/test_more.py
+++ b/more_itertools/tests/test_more.py
@@ -625,20 +625,6 @@ class SideEffectTests(TestCase):
         eq_(result, list(range(10)))
         eq_(counter[0], 5)
 
-    def test_file_obj(self):
-        """File objects should be closed after iterating"""
-        f = StringIO()
-        collector = []
-
-        def func(item):
-            print(item, file=f)
-            collector.append(f.getvalue())
-
-        it = [u'a', u'b']
-        consume(side_effect(func, it, file_obj=f))
-        self.assertEqual(collector, [u'a\n', u'a\nb\n'])
-        self.assertTrue(f.closed)
-
 
 class SlicedTests(TestCase):
     """Tests for ``sliced()``"""

--- a/more_itertools/tests/test_more.py
+++ b/more_itertools/tests/test_more.py
@@ -1104,12 +1104,12 @@ class ContextTestCase(TestCase):
 
         @contextmanager
         def managed():
-            before.append(1)
-            yield 2
-            after.append(3)
+            before.append('open')
+            yield 'running'
+            after.append('close')
 
         actual = [(c, x) for c in context(managed()) for x in range(3)]
-        expected = [(2, 0), (2, 1), (2, 2)]
+        expected = [('running', 0), ('running', 1), ('running', 2)]
         self.assertEqual(actual, expected)
-        self.assertEqual(before, [1])
-        self.assertEqual(after, [3])
+        self.assertEqual(before, ['open'])
+        self.assertEqual(after, ['close'])

--- a/more_itertools/tests/test_more.py
+++ b/more_itertools/tests/test_more.py
@@ -1105,11 +1105,11 @@ class ContextTestCase(TestCase):
         @contextmanager
         def managed():
             before.append(1)
-            yield 1
-            after.append(1)
+            yield 2
+            after.append(3)
 
         actual = [(c, x) for c in context(managed()) for x in range(3)]
-        expected = [(1, 0), (1, 1), (1, 2)]
+        expected = [(2, 0), (2, 1), (2, 2)]
         self.assertEqual(actual, expected)
         self.assertEqual(before, [1])
-        self.assertEqual(after, [1])
+        self.assertEqual(after, [3])


### PR DESCRIPTION
This is #112 with a new name, docstring, and test. It also removes the `file_obj` argument to `side_effect()`. See #114 for the discussion.

Many thanks to @yardsale8 for the idea that sparked all this, and @erikrose for making the call.