### PR TITLE
Add arithmetic_sequence()

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -10,7 +10,6 @@ New Routines
 
 .. autofunction:: adjacent
 .. autofunction:: always_iterable
-.. autofunction:: arithmetic_sequence(start, stop, step)
 .. autofunction:: bucket
 .. autofunction:: chunked
 .. autofunction:: collapse
@@ -26,6 +25,7 @@ New Routines
 .. autofunction:: interleave_longest
 .. autofunction:: intersperse
 .. autofunction:: iterate
+.. autofunction:: numeric_range(start, stop, step)
 .. autofunction:: one
 .. autofunction:: padded
 .. autoclass:: peekable

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -10,6 +10,7 @@ New Routines
 
 .. autofunction:: adjacent
 .. autofunction:: always_iterable
+.. autofunction:: arithmetic_sequence(start, stop, step)
 .. autofunction:: bucket
 .. autofunction:: chunked
 .. autofunction:: collapse

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -15,7 +15,6 @@ from .recipes import flatten, take
 __all__ = [
     'adjacent',
     'always_iterable',
-    'arithmetic_sequence',
     'bucket',
     'chunked',
     'collapse',
@@ -31,6 +30,7 @@ __all__ = [
     'interleave',
     'intersperse',
     'iterate',
+    'numeric_range',
     'one',
     'padded',
     'peekable',
@@ -1217,7 +1217,7 @@ def groupby_transform(iterable, keyfunc=None, valuefunc=None):
     return ((k, map(valuefunc, g)) for k, g in groupby(iterable, keyfunc))
 
 
-def arithmetic_sequence(*args):
+def numeric_range(*args):
     """An extension of the built-in ``range()`` function whose arguments can
     be any orderable numeric type.
 
@@ -1227,7 +1227,7 @@ def arithmetic_sequence(*args):
 
     With only *stop* specified:
 
-        >>> list(arithmetic_sequence(3.5))
+        >>> list(numeric_range(3.5))
         [0, 1, 2, 3]
 
     With *start* and *stop* specified:
@@ -1235,7 +1235,7 @@ def arithmetic_sequence(*args):
         >>> from decimal import Decimal
         >>> start = Decimal('2.1')
         >>> stop = Decimal('5.1')
-        >>> list(arithmetic_sequence(start, stop))
+        >>> list(numeric_range(start, stop))
         [Decimal('2.1'), Decimal('3.1'), Decimal('4.1')]
 
     With *start*, *stop*, and *step* defined:
@@ -1244,12 +1244,12 @@ def arithmetic_sequence(*args):
         >>> start = Fraction(1, 2)  # Start at 1/2
         >>> stop = Fraction(5, 2)  # End at 5/2
         >>> step = Fraction(1, 2)  # Count by 1/2
-        >>> list(arithmetic_sequence(start, stop, step))
+        >>> list(numeric_range(start, stop, step))
         [Fraction(1, 2), Fraction(1, 1), Fraction(3, 2), Fraction(2, 1)]
 
     Negative steps are supported:
 
-        >>> list(arithmetic_sequence(3, -1, -1.0))
+        >>> list(numeric_range(3, -1, -1.0))
         [3.0, 2.0, 1.0, 0.0]
 
     Be aware of the limitations of floating point numbers; the representation
@@ -1267,7 +1267,7 @@ def arithmetic_sequence(*args):
     elif argc == 3:
         start, stop, step = args
     else:
-        err_msg = 'arithmetic_sequence takes at most 3 arguments, got {}'
+        err_msg = 'numeric_range takes at most 3 arguments, got {}'
         raise TypeError(err_msg.format(argc))
 
     values = (start + (step * n) for n in count())
@@ -1276,4 +1276,4 @@ def arithmetic_sequence(*args):
     elif step < 0:
         return takewhile(lambda x: x > stop, values)
     else:
-        raise ValueError('arithmetic_sequence arg 3 must not be zero')
+        raise ValueError('numeric_range arg 3 must not be zero')

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -15,6 +15,7 @@ from .recipes import flatten, take
 __all__ = [
     'adjacent',
     'always_iterable',
+    'arithmetic_sequence',
     'bucket',
     'chunked',
     'collapse',
@@ -1214,3 +1215,65 @@ def groupby_transform(iterable, keyfunc=None, valuefunc=None):
     """
     valuefunc = (lambda x: x) if valuefunc is None else valuefunc
     return ((k, map(valuefunc, g)) for k, g in groupby(iterable, keyfunc))
+
+
+def arithmetic_sequence(*args):
+    """An extension of the built-in ``range()`` function whose arguments can
+    be any orderable numeric type.
+
+    If the *start* argument is omitted, it defaults to ``0``. If the *step*
+    argument is omitted, it defaults to ``1``. If *step* is zero,
+    ``ValueError`` is rasied.
+
+    With only *stop* specified:
+
+        >>> list(arithmetic_sequence(3.5))
+        [0, 1, 2, 3]
+
+    With *start* and *stop* specified:
+
+        >>> from decimal import Decimal
+        >>> start = Decimal('2.1')
+        >>> stop = Decimal('5.1')
+        >>> list(arithmetic_sequence(start, stop))
+        [Decimal('2.1'), Decimal('3.1'), Decimal('4.1')]
+
+    With *start*, *stop*, and *step* defined:
+
+        >>> from fractions import Fraction
+        >>> start = Fraction(1, 2)  # Start at 1/2
+        >>> stop = Fraction(5, 2)  # End at 5/2
+        >>> step = Fraction(1, 2)  # Count by 1/2
+        >>> list(arithmetic_sequence(start, stop, step))
+        [Fraction(1, 2), Fraction(1, 1), Fraction(3, 2), Fraction(2, 1)]
+
+    Negative steps are supported:
+
+        >>> list(arithmetic_sequence(3, -1, -1.0))
+        [3.0, 2.0, 1.0, 0.0]
+
+    Be aware of the limitations of floating point numbers; the representation
+    of the yielded numbers may be surprising.
+
+    """
+    argc = len(args)
+    if argc == 1:
+        start = 0
+        stop, = args
+        step = 1
+    elif argc == 2:
+        start, stop = args
+        step = 1
+    elif argc == 3:
+        start, stop, step = args
+    else:
+        err_msg = 'arithmetic_sequence takes at most 3 arguments, got {}'
+        raise TypeError(err_msg.format(argc))
+
+    values = (start + (step * n) for n in count())
+    if step > 0:
+        return takewhile(lambda x: x < stop, values)
+    elif step < 0:
+        return takewhile(lambda x: x > stop, values)
+    else:
+        raise ValueError('arithmetic_sequence arg 3 must not be zero')

--- a/more_itertools/tests/test_more.py
+++ b/more_itertools/tests/test_more.py
@@ -1175,3 +1175,14 @@ class ArithmeticSequenceTests(TestCase):
         ]:
             actual = list(arithmetic_sequence(*args))
             self.assertEqual(actual, expected)
+
+    def test_arg_count(self):
+        self.assertRaises(TypeError, lambda: list(arithmetic_sequence()))
+        self.assertRaises(
+            TypeError, lambda: list(arithmetic_sequence(0, 1, 2, 3))
+        )
+
+    def test_zero_step(self):
+        self.assertRaises(
+            ValueError, lambda: list(arithmetic_sequence(1, 2, 0))
+        )

--- a/more_itertools/tests/test_more.py
+++ b/more_itertools/tests/test_more.py
@@ -1,6 +1,7 @@
 from __future__ import division, print_function, unicode_literals
 
-from contextlib import contextmanager
+from decimal import Decimal
+from fractions import Fraction
 from functools import reduce
 from io import StringIO
 from itertools import chain, count, groupby, permutations, repeat
@@ -1150,3 +1151,27 @@ class GroupByTransformTests(TestCase):
         actual = groupby_transform(iterable, key)  # default valuefunc
         expected = groupby(iterable, key)
         self.assertAllGroupsEqual(actual, expected)
+
+
+class ArithmeticSequenceTests(TestCase):
+    def test_basic(self):
+        for args, expected in [
+            ((4,), [0, 1, 2, 3]),
+            ((4.0,), [0.0, 1.0, 2.0, 3.0]),
+            ((1, 4), [1, 2, 3]),
+            ((1.0, 5), [1.0, 2.0, 3.0, 4.0]),
+            ((0, 20, 5), [0, 5, 10, 15]),
+            ((0, 20, 5.0), [0.0, 5.0, 10.0, 15.0]),
+            ((0, 10, 3), [0, 3, 6, 9]),
+            ((0, 10, 3.0), [0.0, 3.0, 6.0, 9.0]),
+            ((0, -5, -1), [0, -1, -2, -3, -4]),
+            ((0.0, -5, -1), [0.0, -1.0, -2.0, -3.0, -4.0]),
+            ((0,), []),
+            ((0.0,), []),
+            ((1, 0), []),
+            ((1.0, 0.0), []),
+            ((Fraction(2, 1),), [Fraction(0, 1), Fraction(1, 1)]),
+            ((Decimal('2.0'),), [Decimal('0.0'), Decimal('1.0')]),
+        ]:
+            actual = list(arithmetic_sequence(*args))
+            self.assertEqual(actual, expected)

--- a/more_itertools/tests/test_more.py
+++ b/more_itertools/tests/test_more.py
@@ -1173,16 +1173,16 @@ class ArithmeticSequenceTests(TestCase):
             ((Fraction(2, 1),), [Fraction(0, 1), Fraction(1, 1)]),
             ((Decimal('2.0'),), [Decimal('0.0'), Decimal('1.0')]),
         ]:
-            actual = list(arithmetic_sequence(*args))
+            actual = list(numeric_range(*args))
             self.assertEqual(actual, expected)
 
     def test_arg_count(self):
-        self.assertRaises(TypeError, lambda: list(arithmetic_sequence()))
+        self.assertRaises(TypeError, lambda: list(numeric_range()))
         self.assertRaises(
-            TypeError, lambda: list(arithmetic_sequence(0, 1, 2, 3))
+            TypeError, lambda: list(numeric_range(0, 1, 2, 3))
         )
 
     def test_zero_step(self):
         self.assertRaises(
-            ValueError, lambda: list(arithmetic_sequence(1, 2, 0))
+            ValueError, lambda: list(numeric_range(1, 2, 0))
         )


### PR DESCRIPTION
Re: Issue #126, this PR adds a new itertools, `arithmetic_sequence()`.

This function works for `float`s (as requested) as well as `Decimal` and `Fraction` types.

I'm happy to include this because we take care not to accumulate round-off errors, as many Stack Overflow implementations of this do.