### PR TITLE
Add count_cycle()

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -15,6 +15,7 @@ New Routines
 .. autofunction:: collapse
 .. autofunction:: collate(*iterables, key=lambda a: a, reverse=False)
 .. autofunction:: consumer
+.. autofunction:: count_cycle
 .. autofunction:: distinct_permutations
 .. autofunction:: distribute
 .. autofunction:: divide

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -20,6 +20,7 @@ __all__ = [
     'collapse',
     'collate',
     'consumer',
+    'count_cycle',
     'distinct_permutations',
     'distribute',
     'divide',
@@ -1277,3 +1278,19 @@ def numeric_range(*args):
         return takewhile(lambda x: x > stop, values)
     else:
         raise ValueError('numeric_range arg 3 must not be zero')
+
+
+def count_cycle(iterable, n=None):
+    """Cycle through the items from *iterable* up to *n* times, yielding
+    the number of completed cycles along with each item. If *n* is omitted the
+    process repeats indefinitely.
+
+    >>> list(count_cycle('AB', 3))
+    [(0, 'A'), (0, 'B'), (1, 'A'), (1, 'B'), (2, 'A'), (2, 'B')]
+
+    """
+    iterable = tuple(iterable)
+    if not iterable:
+        return iter(())
+    counter = count() if n is None else range(n)
+    return ((i, item) for i in counter for item in iterable)

--- a/more_itertools/tests/test_more.py
+++ b/more_itertools/tests/test_more.py
@@ -1186,3 +1186,24 @@ class ArithmeticSequenceTests(TestCase):
         self.assertRaises(
             ValueError, lambda: list(numeric_range(1, 2, 0))
         )
+
+
+class CountCycleTests(TestCase):
+    def test_basic(self):
+        expected = [
+            (0, 'a'), (0, 'b'), (0, 'c'),
+            (1, 'a'), (1, 'b'), (1, 'c'),
+            (2, 'a'), (2, 'b'), (2, 'c'),
+        ]
+        for actual in [
+            take(9, count_cycle('abc')),  # n=None
+            list(count_cycle('abc', 3)),  # n=3
+        ]:
+            self.assertEqual(actual, expected)
+
+    def test_empty(self):
+        self.assertEqual(list(count_cycle('')), [])
+        self.assertEqual(list(count_cycle('', 2)), [])
+
+    def test_negative(self):
+        self.assertEqual(list(count_cycle('abc', -3)), [])


### PR DESCRIPTION
Re: issue #125, this PR adds `count_cycle()`. This is an extension of `ncycles` that includes how many cycles have been completed so far.