### PR TITLE
Categorize functions in API docs

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -4,71 +4,190 @@ API Reference
 
 .. automodule:: more_itertools
 
+Grouping
+========
 
-New Routines
-============
+These tools yield groups of items from a source iterable.
 
-.. autofunction:: adjacent
-.. autofunction:: always_iterable
-.. autofunction:: bucket
+----
+
+**New itertools**
+
 .. autofunction:: chunked
-.. autofunction:: collapse
-.. autofunction:: collate(*iterables, key=lambda a: a, reverse=False)
-.. autofunction:: consumer
-.. autofunction:: count_cycle
-.. autofunction:: distinct_permutations
+.. autofunction:: sliced
 .. autofunction:: distribute
 .. autofunction:: divide
-.. autofunction:: first(iterable[, default])
-.. autofunction:: groupby_transform
-.. autofunction:: ilen
-.. autofunction:: interleave
-.. autofunction:: interleave_longest
-.. autofunction:: intersperse
-.. autofunction:: iterate
-.. autofunction:: numeric_range(start, stop, step)
-.. autofunction:: one
-.. autofunction:: padded
-.. autoclass:: peekable
-.. autofunction:: side_effect
-.. autofunction:: sliced
-.. autofunction:: sort_together
-.. autofunction:: split_after
 .. autofunction:: split_before
+.. autofunction:: split_after
+.. autofunction:: bucket
+
+----
+
+**Itertools recipes**
+
+.. autofunction:: grouper
+.. autofunction:: partition
+
+
+Lookahead
+=========
+
+----
+
+**New itertools**
+
+These tools peek at an iterable's values without advancing it.
+
 .. autofunction:: spy
-.. autofunction:: stagger
-.. autofunction:: unique_to_each
+.. autoclass:: peekable
+
+
+Windowing
+=========
+
+These tools yield windows of items from an iterable.
+
+----
+
+**New itertools**
+
 .. autofunction:: windowed
-.. autofunction:: with_iter
-.. autofunction:: zip_offset(*iterables, offsets, longest=False, fillvalue=None)
+.. autofunction:: stagger
+
+----
+
+**Itertools recipes**
+
+.. autofunction:: pairwise
 
 
-Itertools Recipes
-=================
+Augmenting
+==========
 
-.. autofunction:: accumulate
-.. autofunction:: take
-.. autofunction:: tabulate
-.. autofunction:: tail
-.. autofunction:: consume
-.. autofunction:: nth
-.. autofunction:: all_equal
-.. autofunction:: quantify
+These tools yield items from an iterable, plus additional data.
+
+----
+
+**New itertools**
+
+.. autofunction:: count_cycle
+.. autofunction:: intersperse
+.. autofunction:: padded
+.. autofunction:: adjacent
+.. autofunction:: groupby_transform
+
+----
+
+**Itertools recipes**
+
 .. autofunction:: padnone
 .. autofunction:: ncycles
+
+
+Combining
+=========
+
+These tools combine multiple iterables.
+
+----
+
+**New itertools**
+
+.. autofunction:: collapse
+.. autofunction:: sort_together
+.. autofunction:: interleave
+.. autofunction:: interleave_longest
+.. autofunction:: collate(*iterables, key=lambda a: a, reverse=False)
+.. autofunction:: zip_offset(*iterables, offsets, longest=False, fillvalue=None)
+
+----
+
+**Itertools recipes**
+
 .. autofunction:: dotproduct
 .. autofunction:: flatten
-.. autofunction:: repeatfunc
-.. autofunction:: pairwise
-.. autofunction:: grouper
 .. autofunction:: roundrobin
-.. autofunction:: partition
-.. autofunction:: powerset
+
+
+Summarizing
+===========
+
+These tools return summarized or aggregate data from an iterable.
+
+----
+
+**New itertools**
+
+.. autofunction:: ilen
+.. autofunction:: first(iterable[, default])
+.. autofunction:: one
+.. autofunction:: unique_to_each
+
+----
+
+**Itertools recipes**
+
+.. autofunction:: all_equal
+.. autofunction:: first_true
+.. autofunction:: nth
+.. autofunction:: quantify
+
+
+Selecting
+=========
+
+These yools yield certain items from an iterable.
+
+----
+
+**New itertools**
+
+.. autofunction:: take
+.. autofunction:: tail
 .. autofunction:: unique_everseen
 .. autofunction:: unique_justseen
-.. autofunction:: iter_except
-.. autofunction:: first_true
+
+
+Combinatorics
+=============
+
+These tools yield combinatorial arrangements of items from iterables.
+
+----
+
+**New itertools**
+
+.. autofunction:: distinct_permutations
+
+----
+
+**Itertools recipes**
+
+.. autofunction:: powerset
 .. autofunction:: random_product
 .. autofunction:: random_permutation
 .. autofunction:: random_combination
 .. autofunction:: random_combination_with_replacement
+
+
+Others
+======
+
+**New itertools**
+
+.. autofunction:: numeric_range(start, stop, step)
+.. autofunction:: side_effect
+.. autofunction:: always_iterable
+.. autofunction:: consumer
+.. autofunction:: iterate
+.. autofunction:: with_iter
+
+----
+
+**Itertools recipes**
+
+.. autofunction:: consume
+.. autofunction:: accumulate
+.. autofunction:: tabulate
+.. autofunction:: repeatfunc
+.. autofunction:: iter_except

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -140,7 +140,7 @@ These yools yield certain items from an iterable.
 
 ----
 
-**New itertools**
+**Itertools recipes**
 
 .. autofunction:: take
 .. autofunction:: tail

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -170,6 +170,27 @@ These tools yield combinatorial arrangements of items from iterables.
 .. autofunction:: random_combination_with_replacement
 
 
+Wrapping
+========
+
+These tools provide wrappers to smooth working with objects that produce or
+consume iterable.
+
+----
+
+**New itertools**
+
+.. autofunction:: always_iterable
+.. autofunction:: consumer
+.. autofunction:: with_iter
+
+----
+
+**Itertools recipes**
+
+.. autofunction:: iter_except
+
+
 Others
 ======
 
@@ -177,10 +198,7 @@ Others
 
 .. autofunction:: numeric_range(start, stop, step)
 .. autofunction:: side_effect
-.. autofunction:: always_iterable
-.. autofunction:: consumer
 .. autofunction:: iterate
-.. autofunction:: with_iter
 
 ----
 
@@ -190,4 +208,3 @@ Others
 .. autofunction:: accumulate
 .. autofunction:: tabulate
 .. autofunction:: repeatfunc
-.. autofunction:: iter_except

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -174,7 +174,7 @@ Wrapping
 ========
 
 These tools provide wrappers to smooth working with objects that produce or
-consume iterable.
+consume iterables.
 
 ----
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -13,6 +13,8 @@
 
 import sys, os
 
+import sphinx_rtd_theme
+
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
@@ -91,7 +93,7 @@ pygments_style = 'sphinx'
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
-html_theme = 'default'
+html_theme = 'sphinx_rtd_theme'
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
@@ -99,7 +101,7 @@ html_theme = 'default'
 #html_theme_options = {}
 
 # Add any paths that contain custom themes here, relative to this directory.
-#html_theme_path = []
+html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 
 # The name for this set of Sphinx documents.  If None, it defaults to
 # "<project> v<release> documentation".

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -17,9 +17,13 @@ Contents
 ========
 
 .. toctree::
-    :maxdepth: 1
+    :maxdepth: 2
 
     api
+
+.. toctree::
+    :maxdepth: 1
+
     license
     testing
     versions

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -1152,7 +1152,7 @@ def adjacent(predicate, iterable, distance=1):
         >>> list(adjacent(lambda x: x == 3, range(6)))
         [(False, 0), (False, 1), (True, 2), (True, 3), (True, 4), (False, 5)]
 
-    Set *distance* to change what counts as adjacent. For example, To find
+    Set *distance* to change what counts as adjacent. For example, to find
     whether items are two places away from a ``3``:
 
         >>> list(adjacent(lambda x: x == 3, range(6), distance=2))

--- a/more_itertools/recipes.py
+++ b/more_itertools/recipes.py
@@ -88,7 +88,7 @@ def tabulate(function, start=0):
 
 def tail(n, iterable):
     """
-    Return an iterator over the last n items"
+    Return an iterator over the last n items.
 
         >>> t = tail(3, 'ABCDEFG')
         >>> list(t)


### PR DESCRIPTION
Re: issue #130, this PR adds categories to the API docs.

The categories are:
- Grouping
- Lookahead
- Windowing
- Augmenting
- Combining
- Summarizing
- Selecting
- Combinatorics
- Others

I'm loath to add many more categories, but if someone has a good name that describes `consumer`, `with_iter`, `iter_except`, and `always_iterable`, I'd put them together.

![image](https://cloud.githubusercontent.com/assets/1922815/25929462/cc469f9a-35c6-11e7-9dad-71234f319ad7.png)