### PR TITLE
Use six.moves.range in more module

### DIFF
--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -8,7 +8,7 @@ from operator import itemgetter
 from sys import version_info
 
 from six import binary_type, string_types, text_type
-from six.moves import filter, map, zip, zip_longest
+from six.moves import filter, map, range, zip, zip_longest
 
 from .recipes import flatten, take
 


### PR DESCRIPTION
Several functions in `more.py` use `range` so ensuring it's `xrange` on python2 might speed them up and reduce the memory overhead.