### PR TITLE
use operators instead of lambdas when possible

### DIFF
--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -4,7 +4,7 @@ from collections import Counter, defaultdict, deque
 from functools import partial, wraps
 from heapq import merge
 from itertools import chain, count, groupby, islice, repeat, takewhile, tee
-from operator import itemgetter
+from operator import itemgetter, lt, gt
 from sys import version_info
 
 from six import binary_type, string_types, text_type
@@ -286,7 +286,7 @@ def _collate(*iterables, **kwargs):
     key = kwargs.pop('key', lambda a: a)
     reverse = kwargs.pop('reverse', False)
 
-    min_or_max = partial(max if reverse else min, key=lambda a_b: a_b[0])
+    min_or_max = partial(max if reverse else min, key=itemgetter(0))
     peekables = [peekable(it) for it in iterables]
     peekables = [p for p in peekables if p]  # Kill empties.
     while peekables:
@@ -1273,9 +1273,9 @@ def numeric_range(*args):
 
     values = (start + (step * n) for n in count())
     if step > 0:
-        return takewhile(lambda x: x < stop, values)
+        return takewhile(partial(gt, stop), values)
     elif step < 0:
-        return takewhile(lambda x: x > stop, values)
+        return takewhile(partial(lt, stop), values)
     else:
         raise ValueError('numeric_range arg 3 must not be zero')
 


### PR DESCRIPTION
The functions from the operator module are generally a bit faster than custom lambdas. 

In case of `numeric_range` this speed up the code by a (admittedly rather insignificant) 10%:

```
%timeit list(numeric_range(0., 200000, 1))  # old 
405 ms ± 8.16 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
%timeit list(numeric_range(0., 200000, 1))  # new
356 ms ± 5.19 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```

and the overhead of creating a `partial` object compared to a `lambda` function is even for very short ranges almost negligable:

```
%timeit list(numeric_range(0., 2, 1))  # old
19.3 µs ± 119 ns per loop (mean ± std. dev. of 7 runs, 10000 loops each)
%timeit list(numeric_range(0., 2, 1))  # new
20.6 µs ± 203 ns per loop (mean ± std. dev. of 7 runs, 10000 loops each)
```
