### PR TITLE
Some docstring cleanups

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -32,11 +32,12 @@ These tools yield groups of items from a source iterable.
 Lookahead
 =========
 
+These tools peek at an iterable's values without advancing it.
+
 ----
 
 **New itertools**
 
-These tools peek at an iterable's values without advancing it.
 
 .. autofunction:: spy
 .. autoclass:: peekable

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -52,38 +52,44 @@ _marker = object()
 
 
 def chunked(iterable, n):
-    """Break an iterable into lists of a given length::
+    """Break *iterable* into lists of length *n*:
 
-        >>> list(chunked([1, 2, 3, 4, 5, 6, 7], 3))
-        [[1, 2, 3], [4, 5, 6], [7]]
+        >>> list(chunked([1, 2, 3, 4, 5, 6], 3))
+        [[1, 2, 3], [4, 5, 6]]
 
-    If the length of ``iterable`` is not evenly divisible by ``n``, the last
-    returned list will be shorter.
+    If the length of *iterable* is not evenly divisible by *n*, the last
+    returned list will be shorter:
 
-    This is useful for splitting up a computation on a large number of keys
-    into batches, to be pickled and sent off to worker processes. One example
-    is operations on rows in MySQL, which does not implement server-side
-    cursors properly and would otherwise load the entire dataset into RAM on
-    the client.
+        >>> list(chunked([1, 2, 3, 4, 5, 6, 7, 8], 3))
+        [[1, 2, 3], [4, 5, 6], [7, 8]]
+
+    To use a fill-in value instead, see the :func:`grouper` recipe.
+
+    :func:`chunked` is useful for splitting up a computation on a large number
+    of keys into batches, to be pickled and sent off to worker processes. One
+    example is operations on rows in MySQL, which does not implement
+    server-side cursors properly and would otherwise load the entire dataset
+    into RAM on the client.
 
     """
     return iter(partial(take, n, iter(iterable)), [])
 
 
 def first(iterable, default=_marker):
-    """Return the first item of an iterable, ``default`` if there is none.
+    """Return the first item of *iterable*, or *default* if *iterable* is
+    empty.
 
         >>> first([0, 1, 2, 3])
         0
         >>> first([], 'some default')
         'some default'
 
-    If ``default`` is not provided and there are no items in the iterable,
+    If *default* is not provided and there are no items in the iterable,
     raise ``ValueError``.
 
-    ``first()`` is useful when you have a generator of expensive-to-retrieve
+    :func:`first` is useful when you have a generator of expensive-to-retrieve
     values and want any arbitrary one. It is marginally shorter than
-    ``next(iter(...), default)``.
+    ``next(iter(iterable), default)``.
 
     """
     try:
@@ -102,8 +108,8 @@ def first(iterable, default=_marker):
 class peekable(object):
     """Wrap an iterator to allow lookahead and prepending elements.
 
-    Call ``peek()`` on the result to get the value that will next pop out of
-    ``next()``, without advancing the iterator:
+    Call :meth:`peek` on the result to get the value that will be returned
+    by :func:`next`. This won't advance the iterator:
 
         >>> p = peekable(['a', 'b'])
         >>> p.peek()
@@ -111,15 +117,15 @@ class peekable(object):
         >>> next(p)
         'a'
 
-    Pass ``peek()`` a default value to return that instead of raising
+    Pass :meth:`peek` a default value to return that instead of raising
     ``StopIteration`` when the iterator is exhausted.
 
         >>> p = peekable([])
         >>> p.peek('hi')
         'hi'
 
-    peekables also offer a ``prepend()`` method which will insert items before
-    the remaining part of the underlying source iterator.
+    peekables also offer a :meth:`prepend` method, which "inserts" items
+    at the head of the iterable:
 
         >>> p = peekable([1, 2, 3])
         >>> p.prepend(10, 11, 12)
@@ -130,13 +136,9 @@ class peekable(object):
         >>> list(p)
         [11, 12, 1, 2, 3]
 
-    Prepended items are treated by other peekable methods exactly as if they
-    had come from the source iterator.
-
-    You may index the peekable to look ahead by more than one item.
-    The values up to the index you specified will be cached.
-    Index 0 is the item that will be returned by ``next()``, index 1 is the
-    item after that, and so on:
+    peekables can be indexed. Index 0 is the item that will be returned by
+    :func:`next`, index 1 is the item after that, and so on:
+    The values up to the given index will be cached.
 
         >>> p = peekable(['a', 'b', 'c', 'd'])
         >>> p[0]
@@ -145,27 +147,20 @@ class peekable(object):
         'b'
         >>> next(p)
         'a'
-        >>> p.prepend('x')
-        >>> p[1]
-        'b'
-        >>> next(p)
-        'x'
-        >>> next(p)
-        'b'
 
     Negative indexes are supported, but be aware that they will cache the
     remaining items in the source iterator, which may require significant
     storage.
 
-    To test whether there are more items in the iterator, examine the
-    peekable's truth value. If it is truthy, there are more items (which may
-    have been prepended or obtained from the source iterator).
+    To check whether a peekable is exhausted, check its truth value:
 
-        >>> assert peekable([1])
-        >>> p = peekable([])
-        >>> assert not p
-        >>> p.prepend(1)
-        >>> assert p
+        >>> p = peekable(['a', 'b'])
+        >>> if p:  # peekable has items
+        ...     list(p)
+        ['a', 'b']
+        >>> if not p:  # peekable is exhaused
+        ...     list(p)
+        []
 
     """
     def __init__(self, iterable):
@@ -303,7 +298,7 @@ def collate(*iterables, **kwargs):
         ['A', 'A', 'C', 'D', 'J', 'K', 'L', 'Z', 'Z']
 
     Works lazily, keeping only the next value from each iterable in memory. Use
-    ``collate()`` to, for example, perform a n-way mergesort of items that
+    :func:`collate` to, for example, perform a n-way mergesort of items that
     don't fit in memory.
 
     :arg key: A function that returns a comparison value for an item. Defaults
@@ -316,7 +311,7 @@ def collate(*iterables, **kwargs):
     unexpected results.
 
     If neither of the keyword arguments are specified, this function delegates
-    to ``heapq.merge()``.
+    to :func:`heapq.merge`.
 
     """
     if not kwargs:
@@ -362,7 +357,7 @@ def consumer(func):
 
 
 def ilen(iterable):
-    """Return the number of items in ``iterable``.
+    """Return the number of items in *iterable*.
 
         >>> ilen(x for x in range(1000000) if x % 3 == 0)
         333334
@@ -434,7 +429,7 @@ def one(iterable):
 
 
 def distinct_permutations(iterable):
-    """Yield successive distinct permutations of the elements in the iterable.
+    """Yield successive distinct permutations of the elements in *iterable*.
 
         >>> sorted(distinct_permutations([1, 0, 1]))
         [(0, 1, 1), (1, 0, 1), (1, 1, 0)]
@@ -445,8 +440,8 @@ def distinct_permutations(iterable):
 
     Duplicate permutations arise when there are duplicated elements in the
     input iterable. The number of items returned is
-    ``n! / (x_1! * x_2! * ... * x_n!)``, where ``n`` is the total number of
-    items input, and each ``x_i`` is the count of a distinct item in the input
+    `n! / (x_1! * x_2! * ... * x_n!)`, where `n` is the total number of
+    items input, and each `x_i` is the count of a distinct item in the input
     sequence.
 
     """
@@ -482,7 +477,7 @@ def distinct_permutations(iterable):
 
 
 def intersperse(e, iterable):
-    """Intersperse element ``e`` between the elements of *iterable*.
+    """Intersperse object *e* between the items of *iterable*.
 
         >>> list(intersperse('x', 'ABCD'))
         ['A', 'x', 'B', 'x', 'C', 'x', 'D']
@@ -537,13 +532,13 @@ def windowed(seq, n, fillvalue=None, step=1):
         >>> list(all_windows)
         [(1, 2, 3), (2, 3, 4), (3, 4, 5)]
 
-    When the window is larger than the iterable, ``fillvalue`` is used in place
+    When the window is larger than the iterable, *fillvalue* is used in place
     of missing values::
 
         >>> list(windowed([1, 2, 3], 4))
         [(1, 2, 3, None)]
 
-    Each window will advance in increments of *step*::
+    Each window will advance in increments of *step*:
 
         >>> list(windowed([1, 2, 3, 4, 5, 6], 3, fillvalue='!', step=2))
         [(1, 2, 3), (3, 4, 5), (5, 6, '!')]
@@ -583,8 +578,8 @@ def windowed(seq, n, fillvalue=None, step=1):
 
 
 class bucket(object):
-    """Wrap an iterable and return an object that buckets the iterable into
-    child iterables based on a ``key`` function.
+    """Wrap *iterable* and return an object that buckets it iterable into
+    child iterables based on a *key* function.
 
         >>> iterable = ['a1', 'b1', 'c1', 'a2', 'b2', 'c2', 'b3']
         >>> s = bucket(iterable, key=lambda s: s[0])
@@ -598,6 +593,7 @@ class bucket(object):
 
     The original iterable will be advanced and its items will be cached until
     they are used by the child iterables. This may require significant storage.
+
     Be aware that attempting to select a bucket that no items correspond to
     will exhaust the iterable and cache all values.
 
@@ -694,9 +690,8 @@ def interleave(*iterables):
         >>> list(interleave([1, 2, 3], [4, 5], [6, 7, 8]))
         [1, 4, 6, 2, 5, 7]
 
-    Note that this is the same as ``chain(*zip(*iterables))``.
     For a version that doesn't terminate after the shortest iterable is
-    exhausted, see ``interleave_longest()``.
+    exhausted, see :func:`interleave_longest`.
 
     """
     return chain.from_iterable(zip(*iterables))
@@ -709,26 +704,33 @@ def interleave_longest(*iterables):
         >>> list(interleave_longest([1, 2, 3], [4, 5], [6, 7, 8]))
         [1, 4, 6, 2, 5, 7, 3, 8]
 
-    Note that this is an alternate implementation of ``roundrobin()`` from the
-    itertools documentation.
-
     """
     i = chain.from_iterable(zip_longest(*iterables, fillvalue=_marker))
     return filter(lambda x: x is not _marker, i)
 
 
 def collapse(iterable, base_type=None, levels=None):
-    """Flatten an iterable containing some iterables (themselves containing
-    some iterables, etc.) into non-iterable types, strings, elements
-    matching ``isinstance(element, base_type)``, and elements that are
-    ``levels`` levels down.
+    """Flatten an iterable with multiple levels of nesting (e.g., a list of
+    lists of tuples) into non-iterable types.
 
-        >>> list(collapse([[1], 2, [[3], 4], [[[5]]], 'abc']))
-        [1, 2, 3, 4, 5, 'abc']
-        >>> list(collapse([[1], 2, [[3], 4], [[[5]]]], levels=2))
-        [1, 2, 3, 4, [5]]
-        >>> list(collapse((1, [2], (3, [4, (5,)])), list))
-        [1, [2], 3, [4, (5,)]]
+        >>> iterable = [(1, 2), ([3, 4], [[5], [6]])]
+        >>> list(collapse(iterable))
+        [1, 2, 3, 4, 5, 6]
+
+    String types are not considered iterable and will not be collapsed.
+    To avoid collapsing other types, specify *base_type*:
+
+        >>> iterable = ['ab', ('cd', 'ef'), ['gh', 'ij']]
+        >>> list(collapse(iterable, base_type=tuple))
+        ['ab', ('cd', 'ef'), 'gh', 'ij']
+
+    Specify *levels* to stop flattening after a certain level:
+
+    >>> iterable = [('a', ['b']), ('c', ['d'])]
+    >>> list(collapse(iterable))  # Fully flattened
+    ['a', 'b', 'c', 'd']
+    >>> list(collapse(iterable, levels=1))  # Only one level flattened
+    ['a', ['b'], 'c', ['d']]
 
     """
     def walk(node, level):
@@ -829,7 +831,7 @@ def sliced(seq, n):
         [(1, 2, 3), (4, 5, 6), (7, 8)]
 
     This function will only work for iterables that support slicing.
-    For non-sliceable iterables, see ``chunked()``.
+    For non-sliceable iterables, see :func:`chunked`.
 
     """
     return takewhile(bool, (seq[i: i + n] for i in count(0, n)))
@@ -918,23 +920,23 @@ def distribute(n, iterable):
         >>> list(group_2)
         [2, 4, 6]
 
-    If the length of the iterable is not evenly divisible by n, then the
-    length of the smaller iterables will not be identical::
+    If the length of *iterable* is not evenly divisible by *n*, then the
+    length of the returned iterables will not be identical:
 
         >>> children = distribute(3, [1, 2, 3, 4, 5, 6, 7])
         >>> [list(c) for c in children]
         [[1, 4, 7], [2, 5], [3, 6]]
 
-    If the length of the iterable is smaller than n, then the last returned
+    If the length of *iterable* is smaller than *n*, then the last returned
     iterables will be empty:
 
         >>> children = distribute(5, [1, 2, 3])
         >>> [list(c) for c in children]
         [[1], [2], [3], [], []]
 
-    This function uses ``itertools.tee`` and may require significant storage.
-    If you need the order items in the smaller iterables to match the original
-    iterable, see ``divide()``.
+    This function uses :func:`itertools.tee` and may require significant
+    storage. If you need the order items in the smaller iterables to match the
+    original iterable, see :func:`divide`.
 
     """
     if n < 1:
@@ -1058,8 +1060,8 @@ def divide(n, iterable):
         >>> list(group_2)
         [4, 5, 6]
 
-    If the length of the iterable is not evenly divisible by n, then the
-    length of the smaller iterables will not be identical::
+    If the length of *iterable* is not evenly divisible by *n*, then the
+    length of the returned iterables will not be identical:
 
         >>> children = divide(3, [1, 2, 3, 4, 5, 6, 7])
         >>> [list(c) for c in children]
@@ -1073,7 +1075,7 @@ def divide(n, iterable):
         [[1], [2], [3], [], []]
 
     This function will exhaust the iterable before returning and may require
-    significant storage. If order is not important, see ``distribute()``,
+    significant storage. If order is not important, see :func:`distribute`,
     which does not first pull the iterable into memory.
 
     """
@@ -1166,7 +1168,7 @@ def adjacent(predicate, iterable, distance=1):
     The predicate function will only be called once for each item in the
     iterable.
 
-    See also ``groupby_transform()``, which can be used with this function
+    See also :func:`groupby_transform`, which can be used with this function
     to group ranges of items with the same ``bool`` value.
 
     """
@@ -1182,26 +1184,23 @@ def adjacent(predicate, iterable, distance=1):
 
 
 def groupby_transform(iterable, keyfunc=None, valuefunc=None):
-    """Make an iterator that returns consecutive keys and groups from the
-    *iterable*. *keyfunc* is a function used to compute a grouping key for each
-    item. *valuefunc* is a function for transforming the items after grouping.
+    """An extension of :func:`itertools.groupby` that transforms the values of
+    *iterable* after grouping them.
+    *keyfunc* is a function used to compute a grouping key for each item.
+    *valuefunc* is a function for transforming the items after grouping.
+
+        >>> iterable = 'AaaABbBCcA'
+        >>> keyfunc = lambda x: x.upper()
+        >>> valuefunc = lambda x: x.lower()
+        >>> grouper = groupby_transform(iterable, keyfunc, valuefunc)
+        >>> [(k, ''.join(g)) for k, g in grouper]
+        [('A', 'aaaa'), ('B', 'bbb'), ('C', 'cc'), ('A', 'a')]
 
     *keyfunc* and *valuefunc* default to identity functions if they are not
-    specified. When *valuefunc* is not specified, ``groupby_transform`` is the
-    same as ``itertools.groupby()``.
+    specified.
 
-    For example, to group a list of numbers by rounding down to the nearest 10,
-    and then transform them into strings:
-
-        >>> iterable = [0, 1, 12, 13, 23, 24]
-        >>> keyfunc = lambda x: 10 * (x // 10)
-        >>> valuefunc = lambda x: str(x)
-        >>> grouper = groupby_transform(iterable, keyfunc, valuefunc)
-        >>> [(k, list(g)) for k, g in grouper]
-        [(0, ['0', '1']), (10, ['12', '13']), (20, ['23', '24'])]
-
-    ``groupby_transform`` is useful when grouping elements of an iterable using
-    a separate iterable as the key. To do this,  ``zip()`` the iterables
+    :func:`groupby_transform` is useful when grouping elements of an iterable
+    using a separate iterable as the key. To do this, :func:`zip` the iterables
     and pass a *keyfunc* that extracts the first element and a *valuefunc*
     that extracts the second element::
 

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -948,8 +948,8 @@ def distribute(n, iterable):
 
 def stagger(iterable, offsets=(-1, 0, 1), longest=False, fillvalue=None):
     """Yield tuples whose elements are offset from *iterable*.
-    The amount by which the ``i``-th item in each tuple is offset is given by
-    the ``i``-th item in *offsets*.
+    The amount by which the `i`-th item in each tuple is offset is given by
+    the `i`-th item in *offsets*.
 
         >>> list(stagger([0, 1, 2, 3]))
         [(None, 0, 1), (0, 1, 2), (1, 2, 3)]
@@ -975,8 +975,8 @@ def stagger(iterable, offsets=(-1, 0, 1), longest=False, fillvalue=None):
 
 
 def zip_offset(*iterables, **kwargs):
-    """``zip`` the input *iterables* together, but offset the ``i``-th iterable
-    by the ``i``-th item in *offsets*.
+    """``zip`` the input *iterables* together, but offset the `i`-th iterable
+    by the `i`-th item in *offsets*.
 
         >>> list(zip_offset('0123', 'abcdef', offsets=(0, 1)))
         [('0', 'b'), ('1', 'c'), ('2', 'd'), ('3', 'e')]
@@ -1145,8 +1145,8 @@ def always_iterable(obj):
 
 
 def adjacent(predicate, iterable, distance=1):
-    """Return an iterable over ``(bool, item)`` tuples where the ``item`` is
-    drawn from *iterable* and the ``bool`` indicates whether
+    """Return an iterable over `(bool, item)` tuples where the `item` is
+    drawn from *iterable* and the `bool` indicates whether
     that item satisfies the *predicate* or is adjacent to an item that does.
 
     For example, to find whether items are adjacent to a ``3``::
@@ -1169,7 +1169,7 @@ def adjacent(predicate, iterable, distance=1):
     iterable.
 
     See also :func:`groupby_transform`, which can be used with this function
-    to group ranges of items with the same ``bool`` value.
+    to group ranges of items with the same `bool` value.
 
     """
     # Allow distance=0 mainly for testing that it reproduces results with map()

--- a/more_itertools/recipes.py
+++ b/more_itertools/recipes.py
@@ -307,6 +307,7 @@ def powerset(iterable):
 def unique_everseen(iterable, key=None):
     """
     Yield unique elements, preserving order.
+
         >>> list(unique_everseen('AAAABBBCCDAABBB'))
         ['A', 'B', 'C', 'D']
         >>> list(unique_everseen('ABBCcAD', str.lower))

--- a/more_itertools/recipes.py
+++ b/more_itertools/recipes.py
@@ -31,7 +31,7 @@ def accumulate(iterable, func=operator.add):
     """
     Return an iterator whose items are the accumulated results of a function
     (specified by the optional *func* argument) that takes two arguments.
-    By default, returns accumulated sums with ``operator.add()``.
+    By default, returns accumulated sums with :func:`operator.add`.
 
         >>> list(accumulate([1, 2, 3, 4, 5]))  # Running sum
         [1, 3, 6, 10, 15]
@@ -58,7 +58,7 @@ def accumulate(iterable, func=operator.add):
 
 
 def take(n, iterable):
-    """Return first n items of the iterable as a list
+    """Return first *n* items of the iterable as a list.
 
         >>> take(3, range(10))
         [0, 1, 2]
@@ -73,14 +73,18 @@ def take(n, iterable):
 
 
 def tabulate(function, start=0):
-    """Return an iterator mapping the function over linear input.
+    """Return an iterator over the results of ``func(start)``,
+    ``func(start + 1)``, ``func(start + 2)``...
 
-    The start argument will be increased by 1 each time the iterator is called
-    and fed into the function.
+    *func* should be a function that accepts one integer argument.
 
-        >>> t = tabulate(lambda x: x**2, -3)
-        >>> take(3, t)
-        [9, 4, 1]
+    If *start* is not specified it defaults to 0. It will be incremented each
+    time the iterator is advanced.
+
+        >>> square = lambda x: x ** 2
+        >>> iterator = tabulate(square, -3)
+        >>> take(4, iterator)
+        [9, 4, 1, 0]
 
     """
     return map(function, count(start))
@@ -88,7 +92,7 @@ def tabulate(function, start=0):
 
 def tail(n, iterable):
     """
-    Return an iterator over the last n items.
+    Return an iterator over the last *n* items of *iterable*.
 
         >>> t = tail(3, 'ABCDEFG')
         >>> list(t)
@@ -99,7 +103,8 @@ def tail(n, iterable):
 
 
 def consume(iterator, n=None):
-    """Advance the iterator n-steps ahead. If n is none, consume entirely.
+    """Advance *iterable* by *n* steps. If *n* is ``None``, consume it
+    entirely.
 
     Efficiently exhausts an iterator without returning values. Defaults to
     consuming the whole iterator, but an optional second argument may be
@@ -138,7 +143,7 @@ def consume(iterator, n=None):
 
 
 def nth(iterable, n, default=None):
-    """Returns the nth item or a default value
+    """Returns the nth item or a default value.
 
         >>> l = range(10)
         >>> nth(l, 3)
@@ -152,7 +157,7 @@ def nth(iterable, n, default=None):
 
 def all_equal(iterable):
     """
-    Returns True if all the elements are equal to each other.
+    Returns ``True`` if all the elements are equal to each other.
 
         >>> all_equal('aaaa')
         True
@@ -165,7 +170,7 @@ def all_equal(iterable):
 
 
 def quantify(iterable, pred=bool):
-    """Return the how many times the predicate is true
+    """Return the how many times the predicate is true.
 
         >>> quantify([True, False, True])
         2
@@ -175,19 +180,21 @@ def quantify(iterable, pred=bool):
 
 
 def padnone(iterable):
-    """Returns the sequence of elements and then returns None indefinitely.
+    """Returns the sequence of elements and then returns ``None`` indefinitely.
 
         >>> take(5, padnone(range(3)))
         [0, 1, 2, None, None]
 
-    Useful for emulating the behavior of the built-in map() function.
+    Useful for emulating the behavior of the built-in :func:`map` function.
+
+    See also :func:`padded`.
 
     """
     return chain(iterable, repeat(None))
 
 
 def ncycles(iterable, n):
-    """Returns the sequence elements n times
+    """Returns the sequence elements *n* times
 
         >>> list(ncycles(["a", "b"], 3))
         ['a', 'b', 'a', 'b', 'a', 'b']
@@ -197,7 +204,7 @@ def ncycles(iterable, n):
 
 
 def dotproduct(vec1, vec2):
-    """Returns the dot product of the two iterables
+    """Returns the dot product of the two iterables.
 
         >>> dotproduct([10, 10], [20, 20])
         400
@@ -207,22 +214,37 @@ def dotproduct(vec1, vec2):
 
 
 def flatten(listOfLists):
-    """Return an iterator flattening one level of nesting in a list of lists
+    """Return an iterator flattening one level of nesting in a list of lists.
 
         >>> list(flatten([[0, 1], [2, 3]]))
         [0, 1, 2, 3]
+
+    See also :func:`collapse`, which can flatten multiple levels of nesting.
 
     """
     return chain.from_iterable(listOfLists)
 
 
 def repeatfunc(func, times=None, *args):
-    """Repeat calls to func with specified arguments.
+    """Call *func* with *args* repeatedly, returning an iterable over the
+    results.
 
-        >>> list(repeatfunc(lambda: 5, 3))
-        [5, 5, 5]
-        >>> list(repeatfunc(lambda x: x ** 2, 3, 3))
-        [9, 9, 9]
+    If *times* is specified, the iterable will terminate after that many
+    repetitions:
+
+        >>> from operator import add
+        >>> times = 4
+        >>> args = 3, 5
+        >>> list(repeatfunc(add, times, *args))
+        [8, 8, 8, 8]
+
+    If *times* is ``None`` the iterable will not terminate:
+
+        >>> from random import randrange
+        >>> times = None
+        >>> args = 1, 11
+        >>> take(6, repeatfunc(randrange, times, *args))  # doctest:+SKIP
+        [2, 4, 8, 1, 8, 4]
 
     """
     if times is None:
@@ -243,7 +265,7 @@ def pairwise(iterable):
 
 
 def grouper(n, iterable, fillvalue=None):
-    """Collect data into fixed-length chunks or blocks
+    """Collect data into fixed-length chunks or blocks.
 
         >>> list(grouper(3, 'ABCDEFG', 'x'))
         [('A', 'B', 'C'), ('D', 'E', 'F'), ('G', 'x', 'x')]
@@ -254,10 +276,12 @@ def grouper(n, iterable, fillvalue=None):
 
 
 def roundrobin(*iterables):
-    """Yields an item from each iterable, alternating between them
+    """Yields an item from each iterable, alternating between them.
 
         >>> list(roundrobin('ABC', 'D', 'EF'))
         ['A', 'D', 'E', 'B', 'F', 'C']
+
+    See :func:`interleave_longest` for a slightly faster implementation.
 
     """
     # Recipe credited to George Sakkis
@@ -294,7 +318,7 @@ def partition(pred, iterable):
 
 
 def powerset(iterable):
-    """Yields all possible subsets of the iterable
+    """Yields all possible subsets of the iterable.
 
         >>> list(powerset([1,2,3]))
         [(), (1,), (2,), (3,), (1, 2), (1, 3), (2, 3), (1, 2, 3)]
@@ -314,7 +338,7 @@ def unique_everseen(iterable, key=None):
         ['A', 'B', 'C', 'D']
 
     Sequences with a mix of hashable and unhashable items can be used.
-    The function will be slower (i.e., O(N^2)) for unhashable items.
+    The function will be slower (i.e., `O(n^2)`) for unhashable items.
 
     """
     seenset = set()
@@ -360,8 +384,8 @@ def iter_except(func, exception, first=None):
     """Yields results from a function repeatedly until an exception is raised.
 
     Converts a call-until-exception interface to an iterator interface.
-    Like __builtin__.iter(func, sentinel) but uses an exception instead
-    of a sentinel to end the loop.
+    Like ``iter(func, sentinel)``, but uses an exception instead of a sentinel
+    to end the loop.
 
         >>> l = [0, 1, 2]
         >>> list(iter_except(l.pop, IndexError))
@@ -398,13 +422,19 @@ def first_true(iterable, default=False, pred=None):
 
 
 def random_product(*args, **kwds):
-    """Returns a random pairing of items from each iterable argument
+    """Draw an item at random from each of the input iterables.
 
-    If `repeat` is provided as a kwarg, it's value will be used to indicate
-    how many pairings should be chosen.
+        >>> random_product('abc', range(4), 'XYZ')  # doctest:+SKIP
+        ('c', 3, 'Z')
 
-        >>> random_product(['a', 'b', 'c'], [1, 2], repeat=2) # doctest:+SKIP
-        ('b', '2', 'c', '2')
+    If *repeat* is provided as a keyword argument, that many items will be
+    drawn from each iterable.
+
+        >>> random_product('abcd', range(4), repeat=2)  # doctest:+SKIP
+        ('a', 2, 'd', 3)
+
+    This equivalent to taking a random selection from
+    ``itertools.product(*args, **kwarg)``.
 
     """
     pools = [tuple(pool) for pool in args] * kwds.get('repeat', 1)
@@ -412,12 +442,16 @@ def random_product(*args, **kwds):
 
 
 def random_permutation(iterable, r=None):
-    """Returns a random permutation.
+    """Return a random *r* length permutation of the elements in *iterable*.
 
-    If r is provided, the permutation is truncated to length r.
+    If *r* is not specified or is ``None``, then *r* defaults to the length of
+    *iterable*.
 
-        >>> random_permutation(range(5)) # doctest:+SKIP
+        >>> random_permutation(range(5))  # doctest:+SKIP
         (3, 4, 0, 1, 2)
+
+    This equivalent to taking a random selection from
+    ``itertools.permutations(iterable, r)``.
 
     """
     pool = tuple(iterable)
@@ -426,10 +460,13 @@ def random_permutation(iterable, r=None):
 
 
 def random_combination(iterable, r):
-    """Returns a random combination of length r, chosen without replacement.
+    """Return a random *r* length subsequence of the elements in *iterable*.
 
-        >>> random_combination(range(5), 3) # doctest:+SKIP
+        >>> random_combination(range(5), 3)  # doctest:+SKIP
         (2, 3, 4)
+
+    This equivalent to taking a random selection from
+    ``itertools.combinations(iterable, r)``.
 
     """
     pool = tuple(iterable)
@@ -439,10 +476,14 @@ def random_combination(iterable, r):
 
 
 def random_combination_with_replacement(iterable, r):
-    """Returns a random combination of length r, chosen with replacement.
+    """Return a random *r* length subsequence of elements in *iterable*,
+    allowing individual elements to be repeated.
 
-        >>> random_combination_with_replacement(range(3), 5) # # doctest:+SKIP
+        >>> random_combination_with_replacement(range(3), 5) # doctest:+SKIP
         (0, 0, 1, 2, 2)
+
+    This equivalent to taking a random selection from
+    ``itertools.combinations_with_replacement(iterable, r)``.
 
     """
     pool = tuple(iterable)


### PR DESCRIPTION
Building on issue #130, this PR updates and cleans up some docstrings. I focused on:
* Marking up function references such that intra-doc links work
* Consistently styling arguments
* Clarifying examples, especially with some of the recipes (which had one-line comment docstrings originally)

I *think* I fixed more typos than I introduced. You can see the results [here](http://more-itertools.readthedocs.io/en/doc-cleanup/api.html) before I merge.
