### PR TITLE
Add locate()

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -113,7 +113,7 @@ These tools combine multiple iterables.
 Summarizing
 ===========
 
-These tools return summarized or aggregate data from an iterable.
+These tools return summarized or aggregated data from an iterable.
 
 ----
 
@@ -123,6 +123,9 @@ These tools return summarized or aggregate data from an iterable.
 .. autofunction:: first(iterable[, default])
 .. autofunction:: one
 .. autofunction:: unique_to_each
+.. autofunction:: item_index
+.. autofunction:: sub_index
+.. autofunction:: locate
 
 ----
 
@@ -200,7 +203,6 @@ Others
 .. autofunction:: numeric_range(start, stop, step)
 .. autofunction:: side_effect
 .. autofunction:: iterate
-.. autofunction:: sub_index
 
 ----
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -200,6 +200,7 @@ Others
 .. autofunction:: numeric_range(start, stop, step)
 .. autofunction:: side_effect
 .. autofunction:: iterate
+.. autofunction:: sub_index
 
 ----
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -123,8 +123,6 @@ These tools return summarized or aggregated data from an iterable.
 .. autofunction:: first(iterable[, default])
 .. autofunction:: one
 .. autofunction:: unique_to_each
-.. autofunction:: item_index
-.. autofunction:: sub_index
 .. autofunction:: locate
 
 ----

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -40,7 +40,6 @@ __all__ = [
     'interleave',
     'intersperse',
     'iterate',
-    'item_index',
     'locate',
     'numeric_range',
     'one',
@@ -53,7 +52,6 @@ __all__ = [
     'split_before',
     'spy',
     'stagger',
-    'sub_index',
     'unique_to_each',
     'windowed',
     'with_iter',
@@ -1304,65 +1302,6 @@ def count_cycle(iterable, n=None):
         return iter(())
     counter = count() if n is None else range(n)
     return ((i, item) for i in counter for item in iterable)
-
-
-def item_index(iterable, item, start=0, end=None):
-    """An extension of :func:`list.index` for iterables that returns the index
-    of *item* in *iterable*. Raises ``ValueError`` if it is not present.
-
-        >>> item_index(['mercury', 'venus', 'earth', 'mars'], 'earth')
-        2
-
-    Specify *start* and/or *end* to restrict the search:
-
-        >>> iterable = ['a', 'b', 'c', 'd', 'a', 'b', 'c', 'd']
-        >>> item = 'b'
-        >>> item_index(iterable, item, start=3, end=6)
-        5
-
-    Unlike its list-based counterpart, this function does not accept negative
-    *start* or *stop* values.
-
-    To search for a sub-sequence, see :func:`sub_index`.
-
-    """
-    it = filter(
-        lambda x: x[1] == item,
-        enumerate(islice(iterable, start, end), start),
-    )
-    return first(it)[0]
-
-
-def sub_index(iterable, sub, start=0, end=None):
-    """An extension of :func:`str.index` for iterables that returns the index
-    of sub-sequence *sub* in *iterable*. Raises ``ValueError`` if it is not
-    present.
-
-        >>> iterable = ['george', 'lucille', 'gob', 'michael', 'lindsay']
-        >>> sub = ['michael', 'lindsay']
-        >>> sub_index(iterable, sub)
-        3
-
-    Specify *start* and/or *end* to restrict the search:
-
-        >>> iterable = ['a', 'b', 'c', 'd', 'a', 'b', 'c', 'd']
-        >>> sub = ['a', 'b']
-        >>> sub_index(iterable, sub, start=1, end=6)
-        4
-
-    Unlike its str-based counterpart, this function does not accept negative
-    *start* or *stop* values.
-
-    Note that *sub* more be an iterable. It will be exhausted. To search for a
-    single item instead of a sub-sequence, see :func:`item_index`.
-
-    """
-    sub = tuple(sub)
-    it = filter(
-        lambda x: x[1] == sub,
-        enumerate(windowed(islice(iterable, start, end), len(sub)), start)
-    )
-    return first(it)[0]
 
 
 def locate(iterable, pred=bool, n=0):

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -10,7 +10,7 @@ from sys import version_info
 from six import binary_type, string_types, text_type
 from six.moves import filter, map, range, zip, zip_longest
 
-from .recipes import flatten, take
+from .recipes import flatten, nth, take
 
 __all__ = [
     'adjacent',
@@ -32,6 +32,7 @@ __all__ = [
     'intersperse',
     'iterate',
     'item_index',
+    'locate',
     'numeric_range',
     'one',
     'padded',
@@ -1353,3 +1354,30 @@ def sub_index(iterable, sub, start=0, end=None):
         enumerate(windowed(islice(iterable, start, end), len(sub)), start)
     )
     return first(it)[0]
+
+
+def locate(iterable, pred=bool, n=0):
+    """Return the index of the first item for which callable *pred* returns
+    ``True``, optionally skipping the first *n* such items.
+    Returns ``None`` if there are no such items.
+
+    *pred* defaults to ``bool``, which will select truthy items:
+
+        >>> iterable = [0, 1, 1, 0, 1, 0, 0]
+        >>> locate(iterable)
+        1
+        >>> locate(iterable, n=1)  # Skip the first match
+        2
+
+    This function can be used to determine the index `n`-th occurrence of an
+    item in an iterable, if we consider `n` to be  zero-based:
+
+        >>> iterable = '_a_aaaa'
+        >>> pred = lambda x: x == 'a'
+        >>> locate(iterable, pred, 0)  # The index of the 0th instance of 'a'
+        1
+        >>> locate(iterable, pred, 4)  # The index of the 4th instance of 'a'
+        6
+
+    """
+    return nth((i for i, item in enumerate(iterable) if pred(item)), n)

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -31,6 +31,7 @@ __all__ = [
     'interleave',
     'intersperse',
     'iterate',
+    'item_index',
     'numeric_range',
     'one',
     'padded',
@@ -42,6 +43,7 @@ __all__ = [
     'split_before',
     'spy',
     'stagger',
+    'sub_index',
     'unique_to_each',
     'windowed',
     'with_iter',
@@ -1292,3 +1294,62 @@ def count_cycle(iterable, n=None):
         return iter(())
     counter = count() if n is None else range(n)
     return ((i, item) for i in counter for item in iterable)
+
+
+def item_index(iterable, item, start=0, end=None):
+    """An extension of :func:`list.index` for iterables that returns the index
+    of *item* in *iterable*. Raises ``ValueError`` if it is not present.
+
+        >>> item_index(['mercury', 'venus', 'earth', 'mars'], 'earth')
+        2
+
+    Specify *start* and/or *end* to restrict the search:
+
+        >>> iterable = ['a', 'b', 'c', 'd', 'a', 'b', 'c', 'd']
+        >>> item = 'b'
+        >>> item_index(iterable, item, start=3, end=6)
+        5
+
+    Unlike its list-based counterpart, this function does not accept negative
+    *start* or *stop* values.
+
+    To search for a sub-sequence, see :func:`sub_index`.
+
+    """
+    it = filter(
+        lambda x: x[1] == item,
+        enumerate(islice(iterable, start, end), start),
+    )
+    return first(it)[0]
+
+
+def sub_index(iterable, sub, start=0, end=None):
+    """An extension of :func:`str.index` for iterables that returns the index
+    of sub-sequence *sub* in *iterable*. Raises ``ValueError`` if it is not
+    present.
+
+        >>> iterable = ['george', 'lucille', 'gob', 'michael', 'lindsay']
+        >>> sub = ['michael', 'lindsay']
+        >>> sub_index(iterable, sub)
+        3
+
+    Specify *start* and/or *end* to restrict the search:
+
+        >>> iterable = ['a', 'b', 'c', 'd', 'a', 'b', 'c', 'd']
+        >>> sub = ['a', 'b']
+        >>> sub_index(iterable, sub, start=1, end=6)
+        4
+
+    Unlike its str-based counterpart, this function does not accept negative
+    *start* or *stop* values.
+
+    Note that *sub* more be an iterable. It will be exhausted. To search for a
+    single item instead of a sub-sequence, see :func:`item_index`.
+
+    """
+    sub = tuple(sub)
+    it = filter(
+        lambda x: x[1] == sub,
+        enumerate(windowed(islice(iterable, start, end), len(sub)), start)
+    )
+    return first(it)[0]

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -3,7 +3,16 @@ from __future__ import print_function
 from collections import Counter, defaultdict, deque
 from functools import partial, wraps
 from heapq import merge
-from itertools import chain, count, groupby, islice, repeat, takewhile, tee
+from itertools import (
+    chain,
+    compress,
+    count,
+    groupby,
+    islice,
+    repeat,
+    takewhile,
+    tee
+)
 from operator import itemgetter, lt, gt
 from sys import version_info
 
@@ -1380,4 +1389,4 @@ def locate(iterable, pred=bool, n=0):
         6
 
     """
-    return nth((i for i, item in enumerate(iterable) if pred(item)), n)
+    return nth(compress(count(), map(pred, iterable)), n)

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -1310,9 +1310,14 @@ def locate(iterable, pred=bool):
 
     *pred* defaults to ``bool``, which will select truthy items:
 
-        >>> iterable = [0, 1, 1, 0, 1, 0, 0]
-        >>> list(locate(iterable))
+        >>> list(locate([0, 1, 1, 0, 1, 0, 0]))
         [1, 2, 4]
+
+    Set *pred* to a custom function to, e.g., find the indexes for a particular
+    item.
+
+        >>> list(locate(['a', 'b', 'c', 'b'], lambda x: x == 'b'))
+        [1, 3]
 
     """
     return compress(count(), map(pred, iterable))

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -554,24 +554,37 @@ def windowed(seq, n, fillvalue=None, step=1):
         [(1, 2, 3), (3, 4, 5), (5, 6, '!')]
 
     """
-    from fractions import gcd
-
-    def lcm(a, b):
-        return abs(a * b) // gcd(a, b)
     if n < 0:
         raise ValueError('n must be >= 0')
     if n == 0:
-        return iter([tuple()])
+        yield tuple()
+        return
     if step < 1:
         raise ValueError('step must be >= 1')
 
-    longest = step > n
     it = iter(seq)
-    # it = padded(seq, fillvalue=fillvalue, n=lcm(n, step))
-    it = stagger(it, offsets=range(n), longest=longest, fillvalue=fillvalue)
-    it = islice(it, None, None, step)
-    return it
+    window = deque([], n)
+    append = window.append
 
+    # Initial deque fill
+    for _ in range(n):
+        append(next(it, fillvalue))
+    yield tuple(window)
+
+    # Appending new items to the right causes old items to fall off the left
+    i = 0
+    for item in it:
+        append(item)
+        i = (i + 1) % step
+        if i % step == 0:
+            yield tuple(window)
+
+    # If there are items from the iterable in the window, pad with the given
+    # value and emit them.
+    if (i % step) and (step - i < n):
+        for _ in range(step - i):
+            append(fillvalue)
+        yield tuple(window)
 
 
 class bucket(object):
@@ -1295,13 +1308,13 @@ def locate(iterable, pred=bool):
     """Yield the index of each item in *iterable* for which *pred* returns
     ``True``.
 
-    *pred* defaults to :func:`bool`, which will select truthy items:
+    *pred* defaults to ``bool``, which will select truthy items:
 
         >>> list(locate([0, 1, 1, 0, 1, 0, 0]))
         [1, 2, 4]
 
     Set *pred* to a custom function to, e.g., find the indexes for a particular
-    item:
+    item.
 
         >>> list(locate(['a', 'b', 'c', 'b'], lambda x: x == 'b'))
         [1, 3]

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -1305,7 +1305,7 @@ def count_cycle(iterable, n=None):
 
 
 def locate(iterable, pred=bool):
-    """Yield the index of each item in *iterable* for whic *pred* returns
+    """Yield the index of each item in *iterable* for which *pred* returns
     ``True``.
 
     *pred* defaults to ``bool``, which will select truthy items:

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -1308,13 +1308,13 @@ def locate(iterable, pred=bool):
     """Yield the index of each item in *iterable* for which *pred* returns
     ``True``.
 
-    *pred* defaults to ``bool``, which will select truthy items:
+    *pred* defaults to :func:`bool`, which will select truthy items:
 
         >>> list(locate([0, 1, 1, 0, 1, 0, 0]))
         [1, 2, 4]
 
     Set *pred* to a custom function to, e.g., find the indexes for a particular
-    item.
+    item:
 
         >>> list(locate(['a', 'b', 'c', 'b'], lambda x: x == 'b'))
         [1, 3]

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -19,7 +19,7 @@ from sys import version_info
 from six import binary_type, string_types, text_type
 from six.moves import filter, map, range, zip, zip_longest
 
-from .recipes import flatten, nth, take
+from .recipes import flatten, take
 
 __all__ = [
     'adjacent',

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -1304,28 +1304,15 @@ def count_cycle(iterable, n=None):
     return ((i, item) for i in counter for item in iterable)
 
 
-def locate(iterable, pred=bool, n=0):
-    """Return the index of the first item for which callable *pred* returns
-    ``True``, optionally skipping the first *n* such items.
-    Returns ``None`` if there are no such items.
+def locate(iterable, pred=bool):
+    """Yield the index of each item in *iterable* for whic *pred* returns
+    ``True``.
 
     *pred* defaults to ``bool``, which will select truthy items:
 
         >>> iterable = [0, 1, 1, 0, 1, 0, 0]
-        >>> locate(iterable)
-        1
-        >>> locate(iterable, n=1)  # Skip the first match
-        2
-
-    This function can be used to determine the index `n`-th occurrence of an
-    item in an iterable, if we consider `n` to be  zero-based:
-
-        >>> iterable = '_a_aaaa'
-        >>> pred = lambda x: x == 'a'
-        >>> locate(iterable, pred, 0)  # The index of the 0th instance of 'a'
-        1
-        >>> locate(iterable, pred, 4)  # The index of the 4th instance of 'a'
-        6
+        >>> list(locate(iterable))
+        [1, 2, 4]
 
     """
-    return nth(compress(count(), map(pred, iterable)), n)
+    return compress(count(), map(pred, iterable))

--- a/more_itertools/tests/test_more.py
+++ b/more_itertools/tests/test_more.py
@@ -1217,16 +1217,18 @@ class CountCycleTests(TestCase):
 class LocateTests(TestCase):
     def test_default_pred(self):
         iterable = [0, 1, 1, 0, 1, 0, 0]
-        self.assertEqual(locate(iterable), 1)
-        self.assertEqual(locate(iterable, n=1), 2)
-        self.assertEqual(locate(iterable, n=2), 4)
-        self.assertEqual(locate(iterable, n=3), None)
+        actual = list(locate(iterable))
+        expected = [1, 2, 4]
+        self.assertEqual(actual, expected)
+
+    def test_no_matches(self):
+        iterable = [0, 0, 0]
+        actual = list(locate(iterable))
+        expected = []
 
     def test_custom_pred(self):
-        iterable = [0, 1, 1, 0, 1, 0, 0]
-        pred = lambda x: bool(x) == False
-        self.assertEqual(locate(iterable, pred), 0)
-        self.assertEqual(locate(iterable, pred, 1), 3)
-        self.assertEqual(locate(iterable, pred, 2), 5)
-        self.assertEqual(locate(iterable, pred, 3), 6)
-        self.assertEqual(locate(iterable, pred, 4), None)
+        iterable = ['0', 1, 1, '0', 1, '0', '0']
+        pred = lambda x: x == '0'
+        actual = list(locate(iterable, pred))
+        expected = [0, 3, 5, 6]
+        self.assertEqual(actual, expected)

--- a/more_itertools/tests/test_more.py
+++ b/more_itertools/tests/test_more.py
@@ -1234,6 +1234,7 @@ class ItemIndexTests(TestCase):
         with self.assertRaises(ValueError):
             item_index('abcd', 'a', start=-1)
 
+
 class SubIndexTests(TestCase):
     def test_basic(self):
         for sub, kwargs, expected in [
@@ -1253,3 +1254,21 @@ class SubIndexTests(TestCase):
     def test_invalid_index(self):
         with self.assertRaises(ValueError):
             sub_index(['a', 'b', 'c', 'd'], ['a', 'b'], start=-1)
+
+
+class LocateTests(TestCase):
+    def test_default_pred(self):
+        iterable = [0, 1, 1, 0, 1, 0, 0]
+        self.assertEqual(locate(iterable), 1)
+        self.assertEqual(locate(iterable, n=1), 2)
+        self.assertEqual(locate(iterable, n=2), 4)
+        self.assertEqual(locate(iterable, n=3), None)
+
+    def test_custom_pred(self):
+        iterable = [0, 1, 1, 0, 1, 0, 0]
+        pred = lambda x: bool(x) == False
+        self.assertEqual(locate(iterable, pred), 0)
+        self.assertEqual(locate(iterable, pred, 1), 3)
+        self.assertEqual(locate(iterable, pred, 2), 5)
+        self.assertEqual(locate(iterable, pred, 3), 6)
+        self.assertEqual(locate(iterable, pred, 4), None)

--- a/more_itertools/tests/test_more.py
+++ b/more_itertools/tests/test_more.py
@@ -1214,48 +1214,6 @@ class CountCycleTests(TestCase):
         self.assertEqual(list(count_cycle('abc', -3)), [])
 
 
-class ItemIndexTests(TestCase):
-    def test_basic(self):
-        for item, kwargs, expected in [
-            ('a', {}, 0),
-            ('a', {'start': 1}, 8),
-            ('D', {'start': 8, 'end': 15}, None),
-            ('E', {'end': 16}, None),
-        ]:
-            iterable = (x for x in 'abcdABCDabcdABCDE')
-            try:
-                actual = item_index(iterable, item, **kwargs)
-            except ValueError:
-                actual = None
-
-            self.assertEqual(actual, expected)
-
-    def test_invalid_index(self):
-        with self.assertRaises(ValueError):
-            item_index('abcd', 'a', start=-1)
-
-
-class SubIndexTests(TestCase):
-    def test_basic(self):
-        for sub, kwargs, expected in [
-            ('abc', {}, 0),
-            ('abc', {'start': 1}, 8),
-            ('DE', {'start': 8, 'end': 15}, None),
-            ('E', {'end': 16}, None),
-        ]:
-            iterable = (x for x in 'abcdABCDabcdABCDE')
-            try:
-                actual = sub_index(iterable, sub, **kwargs)
-            except ValueError:
-                actual = None
-
-            self.assertEqual(actual, expected)
-
-    def test_invalid_index(self):
-        with self.assertRaises(ValueError):
-            sub_index(['a', 'b', 'c', 'd'], ['a', 'b'], start=-1)
-
-
 class LocateTests(TestCase):
     def test_default_pred(self):
         iterable = [0, 1, 1, 0, 1, 0, 0]

--- a/more_itertools/tests/test_more.py
+++ b/more_itertools/tests/test_more.py
@@ -1212,3 +1212,44 @@ class CountCycleTests(TestCase):
 
     def test_negative(self):
         self.assertEqual(list(count_cycle('abc', -3)), [])
+
+
+class ItemIndexTests(TestCase):
+    def test_basic(self):
+        for item, kwargs, expected in [
+            ('a', {}, 0),
+            ('a', {'start': 1}, 8),
+            ('D', {'start': 8, 'end': 15}, None),
+            ('E', {'end': 16}, None),
+        ]:
+            iterable = (x for x in 'abcdABCDabcdABCDE')
+            try:
+                actual = item_index(iterable, item, **kwargs)
+            except ValueError:
+                actual = None
+
+            self.assertEqual(actual, expected)
+
+    def test_invalid_index(self):
+        with self.assertRaises(ValueError):
+            item_index('abcd', 'a', start=-1)
+
+class SubIndexTests(TestCase):
+    def test_basic(self):
+        for sub, kwargs, expected in [
+            ('abc', {}, 0),
+            ('abc', {'start': 1}, 8),
+            ('DE', {'start': 8, 'end': 15}, None),
+            ('E', {'end': 16}, None),
+        ]:
+            iterable = (x for x in 'abcdABCDabcdABCDE')
+            try:
+                actual = sub_index(iterable, sub, **kwargs)
+            except ValueError:
+                actual = None
+
+            self.assertEqual(actual, expected)
+
+    def test_invalid_index(self):
+        with self.assertRaises(ValueError):
+            sub_index(['a', 'b', 'c', 'd'], ['a', 'b'], start=-1)


### PR DESCRIPTION
Re: issue #139, this PR adds ~three~ one new tool~s~:
* `locate(iterable, pred, n)` - Returns the ~first index~ indexes where `pred` returns `True`, ~skipping the first `n` matches.~
* ~`item_index(iterable, item, start, end)` - Like `list.index()`, but for iterables. Returns the first index of `item` in `iterable`, restricting the search between `start` and `end`.~
* ~`sub_index(iterable, sub, start, end)` - List `str.index()`, but for iterables. Returns the first index where sub-sequence `sub` starts, restricting the search between `start` and `end`.~

`locate()` is a generalization of what was requested in the issue; the docstring has an example of how to look for a particular item.

~`item_index()` could be rolled into `sub_index()`, but it would be slower.~

I like these because they fit the of "easy to specify, seem like itertools should be applicable, tricky to get right" criteria we aim for.

CC: @pylang