### PR TITLE
Bump version to 3.1.0

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -50,7 +50,7 @@ copyright = u'2012, Erik Rose'
 # built documents.
 #
 # The short X.Y version.
-version = '3.0.0'
+version = '3.1.0'
 # The full version, including alpha/beta/rc tags.
 release = version
 

--- a/docs/versions.rst
+++ b/docs/versions.rst
@@ -2,6 +2,22 @@
 Version History
 ===============
 
+.. automodule:: more_itertools
+
+3.1.0
+-----
+
+* New itertools:
+    * :func:`numeric_range` (Thanks to BebeSparkelSparkel and MSeifert04)
+    * :func:`count_cycle` (Thanks to BebeSparkelSparkel)
+    * :func:`locate` (Thanks to pylang and MSeifert04)
+* Improvements to existing itertools:
+    * A few itertools are now slightly faster due to some function
+      optimizations. (Thanks to MSeifert04)
+* The docs have been substantially revised with installation notes,
+  categories for library functions, links, and more. (Thanks to pylang)
+
+
 3.0.0
 -----
 

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='more-itertools',
-    version='3.0.0',
+    version='3.1.0',
     description='More routines for operating on iterables, beyond itertools',
     long_description=open('README.rst').read() + '\n\n' +
                      '\n'.join(open('docs/versions.rst').read()


### PR DESCRIPTION
Since we've got three new tools, I think it's time for a release. This PR bumps the version to 3.1.0 and adds release notes.

Many thanks to @BebeSparkelSparkel, @MSeifert04, and @pylang for contributions, as always.