### PR TITLE
lstrip, rstrip, and strip functions

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -142,6 +142,13 @@ These yools yield certain items from an iterable.
 
 ----
 
+**New itertools**
+
+.. autofunction:: lstrip
+.. autofunction:: rstrip
+
+----
+
 **Itertools recipes**
 
 .. autofunction:: take

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -144,6 +144,7 @@ These yools yield certain items from an iterable.
 
 **New itertools**
 
+.. autofunction:: strip
 .. autofunction:: lstrip
 .. autofunction:: rstrip
 

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -1336,49 +1336,41 @@ def locate(iterable, pred=bool):
     return compress(count(), map(pred, iterable))
 
 
-def lstrip(iterable, skip_items):
-    """Yield the items from *iterable*, but strip any that match *skip_items*
-    from the beginning.
+def lstrip(iterable, pred):
+    """Yield the items from *iterable*, but strip any from the beginning
+    for which *pred* returns ``True``.
+
+    For example, to remove a set of items from the start of an iterable:
 
         >>> iterable = (None, False, None, 1, 2, None, 3, False, None)
-        >>> list(lstrip(iterable, (None, False, '')))
+        >>> pred = lambda x: x in {None, False, ''}
+        >>> list(lstrip(iterable, pred))
         [1, 2, None, 3, False, None]
 
-    This function is analagous to :func:`str.lstrip`.
-    Note that the *skip_items* argument is not a prefix; any items that it
-    contains will be stripped.
+    This function is analagous to to :func:`str.lstrip`.
 
     """
-    try:
-        skip_items = set(skip_items)
-    except TypeError:
-        skip_items = list(skip_items)
-
-    return dropwhile(skip_items.__contains__, iterable)
+    return dropwhile(pred, iterable)
 
 
-def rstrip(iterable, skip_items):
-    """Yield the items from *iterable*, but strip any that match *skip_items*
-    from the end.
+def rstrip(iterable, pred):
+    """Yield the items from *iterable*, but strip any from the end
+    for which *pred* returns ``True```.
+
+    For example, to remove a set of items from the end of an iterable:
 
         >>> iterable = (None, False, None, 1, 2, None, 3, False, None)
-        >>> list(rstrip(iterable, (None, False, '')))
+        >>> pred = lambda x: x in {None, False, ''}
+        >>> list(rstrip(iterable, pred))
         [None, False, None, 1, 2, None, 3]
 
     This function is analagous to :func:`str.rstrip`.
-    Note that the *skip_items* argument is not a suffix; any items that it
-    contains will be stripped.
 
     """
-    try:
-        skip_items = set(skip_items)
-    except TypeError:
-        skip_items = list(skip_items)
-
     cache = []
     cache_append = cache.append
     for x in iterable:
-        if x in skip_items:
+        if pred(x):
             cache_append(x)
         else:
             for y in cache:
@@ -1387,17 +1379,18 @@ def rstrip(iterable, skip_items):
             yield x
 
 
-def strip(iterable, skip_items):
-    """Yield the items from *iterable*, but strip any that match *skip_items*
-    from the beginning and end.
+def strip(iterable, pred):
+    """Yield the items from *iterable*, but strip from the beginning and end
+    for which *pred* returns ``True``.
+
+    For example, to remove a set of items from both ends of an iterable:
 
         >>> iterable = (None, False, None, 1, 2, None, 3, False, None)
-        >>> list(strip(iterable, (None, False, '')))
+        >>> pred = lambda x: x in {None, False, ''}
+        >>> list(strip(iterable, pred))
         [1, 2, None, 3]
 
     This function is analagous to :func:`str.strip`.
-    Note that the *skip_items* argument is not a prefix or suffix; any items
-    that it contains will be stripped.
 
     """
-    return rstrip(lstrip(iterable, skip_items), skip_items)
+    return rstrip(lstrip(iterable, pred), pred)

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -1323,6 +1323,15 @@ def locate(iterable, pred=bool):
         >>> list(locate(['a', 'b', 'c', 'b'], lambda x: x == 'b'))
         [1, 3]
 
+    Use with :func:`windowed` to find the indexes of a sub-sequence:
+
+        >>> from more_itertools import windowed
+        >>> iterable = [0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3]
+        >>> sub = [1, 2, 3]
+        >>> pred = lambda w: w == tuple(sub)  # windowed() returns tuples
+        >>> list(locate(windowed(iterable, len(sub)), pred=pred))
+        [1, 5, 9]
+
     """
     return compress(count(), map(pred, iterable))
 

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -7,13 +7,14 @@ from itertools import (
     chain,
     compress,
     count,
+    dropwhile,
     groupby,
     islice,
     repeat,
     takewhile,
     tee
 )
-from operator import itemgetter, lt, gt
+from operator import contains, itemgetter, lt, gt
 from sys import version_info
 
 from six import binary_type, string_types, text_type
@@ -41,10 +42,12 @@ __all__ = [
     'intersperse',
     'iterate',
     'locate',
+    'lstrip',
     'numeric_range',
     'one',
     'padded',
     'peekable',
+    'rstrip',
     'side_effect',
     'sliced',
     'sort_together',
@@ -1321,3 +1324,44 @@ def locate(iterable, pred=bool):
 
     """
     return compress(count(), map(pred, iterable))
+
+
+def lstrip(iterable, skip_items):
+    """Yield the items from *iterable*, but strip any that match *skip_items*
+    from the beginning.
+
+        >>> iterable = (None, False, None, 1, 2, None, 3, False, None)
+        >>> list(lstrip(iterable, (None, False, '')))
+        [1, 2, None, 3, False, None]
+
+    This function is analagous to :func:`str.lstrip`.
+    Note that the *skip_items* argument is not a prefix; any items that it
+    contains will be stripped.
+
+    """
+    return dropwhile(partial(contains, set(skip_items)), iterable)
+
+
+def rstrip(iterable, skip_items):
+    """Yield the items from *iterable*, but strip any that match *skip_items*
+    from the end.
+
+        >>> iterable = (None, False, None, 1, 2, None, 3, False, None)
+        >>> list(rstrip(iterable, (None, False, '')))
+        [None, False, None, 1, 2, None, 3]
+
+    This function is analagous to :func:`str.rstrip`.
+    Note that the *skip_items* argument is not a suffix; any items that it
+    contains will be stripped.
+
+    """
+    skip_items = set(skip_items)
+    cache = []
+    for x in iterable:
+        if x in skip_items:
+            cache.append(x)
+        else:
+            for y in cache:
+                yield y
+            cache = []
+            yield x

--- a/more_itertools/tests/test_more.py
+++ b/more_itertools/tests/test_more.py
@@ -1232,3 +1232,29 @@ class LocateTests(TestCase):
         actual = list(locate(iterable, pred))
         expected = [0, 3, 5, 6]
         self.assertEqual(actual, expected)
+
+
+class StripFunctionTests(TestCase):
+    def test_hashable(self):
+        iterable = list('www.example.com')
+        skip_items = list('cmowz.')
+
+        self.assertEqual(
+            list(lstrip(iterable, skip_items)), list('example.com')
+        )
+        self.assertEqual(
+            list(rstrip(iterable, skip_items)), list('www.example')
+        )
+        self.assertEqual(
+            list(strip(iterable, skip_items)), list('example')
+        )
+
+    def test_not_hashable(self):
+        iterable = [
+            list('http://'), list('www'), list('.example'), list('.com')
+        ]
+        skip_items = [list('http://'), list('www'), list('.com')]
+
+        self.assertEqual(list(lstrip(iterable, skip_items)), iterable[2:])
+        self.assertEqual(list(rstrip(iterable, skip_items)), iterable[:3])
+        self.assertEqual(list(strip(iterable, skip_items)), iterable[2: 3])

--- a/more_itertools/tests/test_more.py
+++ b/more_itertools/tests/test_more.py
@@ -1237,24 +1237,26 @@ class LocateTests(TestCase):
 class StripFunctionTests(TestCase):
     def test_hashable(self):
         iterable = list('www.example.com')
-        skip_items = list('cmowz.')
+        pred = lambda x: x in set('cmowz.')
 
-        self.assertEqual(
-            list(lstrip(iterable, skip_items)), list('example.com')
-        )
-        self.assertEqual(
-            list(rstrip(iterable, skip_items)), list('www.example')
-        )
-        self.assertEqual(
-            list(strip(iterable, skip_items)), list('example')
-        )
+        self.assertEqual(list(lstrip(iterable, pred)), list('example.com'))
+        self.assertEqual(list(rstrip(iterable, pred)), list('www.example'))
+        self.assertEqual(list(strip(iterable, pred)), list('example'))
 
     def test_not_hashable(self):
         iterable = [
             list('http://'), list('www'), list('.example'), list('.com')
         ]
-        skip_items = [list('http://'), list('www'), list('.com')]
+        pred = lambda x: x in [list('http://'), list('www'), list('.com')]
 
-        self.assertEqual(list(lstrip(iterable, skip_items)), iterable[2:])
-        self.assertEqual(list(rstrip(iterable, skip_items)), iterable[:3])
-        self.assertEqual(list(strip(iterable, skip_items)), iterable[2: 3])
+        self.assertEqual(list(lstrip(iterable, pred)), iterable[2:])
+        self.assertEqual(list(rstrip(iterable, pred)), iterable[:3])
+        self.assertEqual(list(strip(iterable, pred)), iterable[2: 3])
+
+    def test_math(self):
+        iterable = [0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2]
+        pred = lambda x: x <= 2
+
+        self.assertEqual(list(lstrip(iterable, pred)), iterable[3:])
+        self.assertEqual(list(rstrip(iterable, pred)), iterable[:-3])
+        self.assertEqual(list(strip(iterable, pred)), iterable[3:-3])


### PR DESCRIPTION
I needed to do something like `str.rstrip` to an iterable the other day, and thought the implementation might be worthwhile to include here.

I'm not married to this - Watchers, what do you think? I'll write tests if we think it's cromulent.