### PR TITLE
Bump version to 3.2.0

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -50,7 +50,7 @@ copyright = u'2012, Erik Rose'
 # built documents.
 #
 # The short X.Y version.
-version = '3.1.0'
+version = '3.2.0'
 # The full version, including alpha/beta/rc tags.
 release = version
 

--- a/docs/versions.rst
+++ b/docs/versions.rst
@@ -4,6 +4,15 @@ Version History
 
 .. automodule:: more_itertools
 
+3.2.0
+-----
+* New itertools:
+    * :func:`lstrip`, :func:`rstrip`, and :func:`strip`
+      (thanks to MSeifert04 and pylang)
+    * :func:`islice_extended`
+* Improvements to existing itertools:
+    * Some bugs with slicing :func:`peekable`-wrapped iterables were fixed
+
 3.1.0
 -----
 

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='more-itertools',
-    version='3.1.0',
+    version='3.2.0',
     description='More routines for operating on iterables, beyond itertools',
     long_description=open('README.rst').read() + '\n\n' +
                      sub(r':func:`([a-zA-Z0-9_]+)`', r'\1', '\n'.join(open('docs/versions.rst').read()


### PR DESCRIPTION
This PR updates the version to 3.2.0. I'd like to get this for the `peekable` slicing fixes, but we have a few new things as well.

Many thanks as always to the contributors.
