### PR TITLE
Fix PyPy tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ python:
 
 install:
     - "pip install ."
+    - "pip install cryptography==1.8.2"
     - "pip install -U coveralls nose"
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,12 +8,11 @@ python:
     - "3.4"
     - "3.5"
     - "3.6"
-    - "pypy"
+    - "pypy-5.4.1"
     - "pypy3"
 
 install:
     - "pip install ."
-    - "pip install cryptography==1.8.2"
     - "pip install -U coveralls nose"
 
 script:


### PR DESCRIPTION
The version of PyPy for Python 2 on Travis is old; this was causing failures due to `coveralls`'s dependency on `cryptography`. I've updated to a later version. It looks like Travis may support even later, but I couldn't figure out which versions they support.

Ref: travis-ci/travis-ci#7822.