### PR TITLE
Add ".idea" folder to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ _build
 
 # Environment
 .env
+
+# IDE files
+.idea


### PR DESCRIPTION
This folder is typically used by PyCharm to store project related settings and probably can be ignored by default.