### PR TITLE
Alias next method instead of calling __next__.

### DIFF
--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -249,9 +249,7 @@ class peekable(object):
 
         return next(self._it)
 
-    def next(self):
-        # For Python 2 compatibility
-        return self.__next__()
+    next = __next__  # For Python 2 compatibility
 
     def _get_slice(self, index):
         # Normalize the slice's arguments


### PR DESCRIPTION
That could make calling `next` just a bit faster because it doesn't involve one extra function call.