### PR TITLE
Use Counter to count the items in "distinct_permutations".

### DIFF
--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -487,9 +487,7 @@ def distinct_permutations(iterable):
                     yield x
                 item_counts[item] += 1
 
-    item_counts = {}
-    for item in iterable:
-        item_counts[item] = item_counts.get(item, 0) + 1
+    item_counts = Counter(iterable)
 
     return perm_unique_helper(item_counts, [None] * len(iterable),
                               len(iterable) - 1)


### PR DESCRIPTION
In `distinct_permutations` there was a loop that could be replaced by a simple `collections.Counter`. Given #36 it seemed like it was for python 2.6 compatibility. Is that still required (it's not included in the test matrix)?