### PR TITLE
Switch away from nose

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ python:
 
 install:
     - "pip install ."
-    - "pip install -U coveralls nose"
+    - "pip install -U coveralls"
 
 script:
     - "coverage run --include='more_itertools/*.py' --omit='more_itertools/tests/*' -m unittest discover -v"

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ install:
     - "pip install -U coveralls nose"
 
 script:
-    - "coverage run --include='more_itertools/*.py' --omit='more_itertools/tests/*' -m nose more_itertools -v --with-doctest"
+    - "coverage run --include='more_itertools/*.py' --omit='more_itertools/tests/*' -m unittest discover -v"
 
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ install:
     - "pip install -U coveralls"
 
 script:
-    - "coverage run --include='more_itertools/*.py' --omit='more_itertools/tests/*' -m unittest discover -v"
+    - "coverage run --include='more_itertools/*.py' --omit='more_itertools/tests/*' setup.py test"
 
 notifications:
   email: false

--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -2,14 +2,9 @@
 Testing
 =======
 
-more-itertools uses nose for its tests. First, install nose::
+To run install dependencies and run tests, use this command::
 
-    pip install nose
-
-Then, run the tests like this::
-
-    nosetests --with-doctest
-
+    python setup.py test
 
 Multiple Python Versions
 ========================

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -1358,7 +1358,8 @@ def lstrip(iterable, pred):
         >>> list(lstrip(iterable, pred))
         [1, 2, None, 3, False, None]
 
-    This function is analogous to to :func:`str.lstrip`.
+    This function is analogous to to :func:`str.lstrip`, and is essentially
+    an wrapper for :func:`itertools.dropwhile`.
 
     """
     return dropwhile(pred, iterable)

--- a/more_itertools/tests/test_more.py
+++ b/more_itertools/tests/test_more.py
@@ -1,17 +1,25 @@
 from __future__ import division, print_function, unicode_literals
 
 from decimal import Decimal
+from doctest import DocTestSuite
 from fractions import Fraction
 from functools import reduce
 from io import StringIO
 from itertools import chain, count, groupby, permutations, product, repeat
 from operator import itemgetter
-from unittest import TestCase
+from unittest import skip, TestCase
 
 import six
 from six.moves import filter, range, zip
 
 from more_itertools import *  # Test all the symbols are in __all__.
+
+
+@skip("This isn't a test")
+def load_tests(loader, tests, ignore):
+    # Add the doctests
+    tests.addTests(DocTestSuite('more_itertools.more'))
+    return tests
 
 
 class CollateTests(TestCase):

--- a/more_itertools/tests/test_more.py
+++ b/more_itertools/tests/test_more.py
@@ -8,7 +8,7 @@ from itertools import chain, count, groupby, permutations, product, repeat
 from operator import itemgetter
 from unittest import TestCase
 
-from nose.tools import eq_, assert_raises
+from nose.tools import assert_raises
 import six
 from six.moves import filter, range, zip
 
@@ -22,8 +22,10 @@ class CollateTests(TestCase):
     def test_default(self):
         """Test with the default `key` function."""
         iterables = [range(4), range(7), range(3, 6)]
-        eq_(sorted(reduce(list.__add__, [list(it) for it in iterables])),
-            list(collate(*iterables)))
+        self.assertEqual(
+            sorted(reduce(list.__add__, [list(it) for it in iterables])),
+            list(collate(*iterables))
+        )
 
     def test_key(self):
         """Test using a custom `key` function."""
@@ -32,22 +34,25 @@ class CollateTests(TestCase):
             reduce(list.__add__, [list(it) for it in iterables]), reverse=True
         )
         expected = list(collate(*iterables, key=lambda x: -x))
-        eq_(actual, expected)
+        self.assertEqual(actual, expected)
 
     def test_empty(self):
         """Be nice if passed an empty list of iterables."""
-        eq_([], list(collate()))
+        self.assertEqual([], list(collate()))
 
     def test_one(self):
         """Work when only 1 iterable is passed."""
-        eq_([0, 1], list(collate(range(2))))
+        self.assertEqual([0, 1], list(collate(range(2))))
 
     def test_reverse(self):
         """Test the `reverse` kwarg."""
         iterables = [range(4, 0, -1), range(7, 0, -1), range(3, 6, -1)]
-        eq_(sorted(reduce(list.__add__, [list(it) for it in iterables]),
-                   reverse=True),
-            list(collate(*iterables, reverse=True)))
+
+        actual = sorted(
+            reduce(list.__add__, [list(it) for it in iterables]), reverse=True
+        )
+        expected = list(collate(*iterables, reverse=True))
+        self.assertEqual(actual, expected)
 
 
 class ChunkedTests(TestCase):
@@ -55,14 +60,18 @@ class ChunkedTests(TestCase):
 
     def test_even(self):
         """Test when ``n`` divides evenly into the length of the iterable."""
-        eq_(list(chunked('ABCDEF', 3)), [['A', 'B', 'C'], ['D', 'E', 'F']])
+        self.assertEqual(
+            list(chunked('ABCDEF', 3)), [['A', 'B', 'C'], ['D', 'E', 'F']]
+        )
 
     def test_odd(self):
         """Test when ``n`` does not divide evenly into the length of the
         iterable.
 
         """
-        eq_(list(chunked('ABCDE', 3)), [['A', 'B', 'C'], ['D', 'E']])
+        self.assertEqual(
+            list(chunked('ABCDE', 3)), [['A', 'B', 'C'], ['D', 'E']]
+        )
 
 
 class FirstTests(TestCase):
@@ -72,11 +81,11 @@ class FirstTests(TestCase):
         """Test that it works on many-item iterables."""
         # Also try it on a generator expression to make sure it works on
         # whatever those return, across Python versions.
-        eq_(first(x for x in range(4)), 0)
+        self.assertEqual(first(x for x in range(4)), 0)
 
     def test_one(self):
         """Test that it doesn't raise StopIteration prematurely."""
-        eq_(first([3]), 3)
+        self.assertEqual(first([3]), 3)
 
     def test_empty_stop_iteration(self):
         """It should raise StopIteration for empty iterables."""
@@ -84,7 +93,7 @@ class FirstTests(TestCase):
 
     def test_default(self):
         """It should return the provided default arg for empty iterables."""
-        eq_(first([], 'boo'), 'boo')
+        self.assertEqual(first([], 'boo'), 'boo')
 
 
 class PeekableTests(TestCase):
@@ -95,7 +104,7 @@ class PeekableTests(TestCase):
     def test_peek_default(self):
         """Make sure passing a default into ``peek()`` works."""
         p = peekable([])
-        eq_(p.peek(7), 7)
+        self.assertEqual(p.peek(7), 7)
 
     def test_truthiness(self):
         """Make sure a ``peekable`` tests true iff there are items remaining in
@@ -113,9 +122,9 @@ class PeekableTests(TestCase):
 
         """
         p = peekable(range(10))
-        eq_(next(p), 0)
-        eq_(p.peek(), 1)
-        eq_(next(p), 1)
+        self.assertEqual(next(p), 0)
+        self.assertEqual(p.peek(), 1)
+        self.assertEqual(next(p), 1)
 
     def test_indexing(self):
         """
@@ -124,23 +133,23 @@ class PeekableTests(TestCase):
         p = peekable('abcdefghijkl')
 
         # The 0th index is what ``next()`` will return
-        eq_(p[0], 'a')
-        eq_(next(p), 'a')
+        self.assertEqual(p[0], 'a')
+        self.assertEqual(next(p), 'a')
 
         # Indexing further into the peekable shouldn't advance the itertor
-        eq_(p[2], 'd')
-        eq_(next(p), 'b')
+        self.assertEqual(p[2], 'd')
+        self.assertEqual(next(p), 'b')
 
         # The 0th index moves up with the iterator; the last index follows
-        eq_(p[0], 'c')
-        eq_(p[9], 'l')
+        self.assertEqual(p[0], 'c')
+        self.assertEqual(p[9], 'l')
 
-        eq_(next(p), 'c')
-        eq_(p[8], 'l')
+        self.assertEqual(next(p), 'c')
+        self.assertEqual(p[8], 'l')
 
         # Negative indexing should work too
-        eq_(p[-2], 'k')
-        eq_(p[-9], 'd')
+        self.assertEqual(p[-2], 'k')
+        self.assertEqual(p[-9], 'd')
         self.assertRaises(IndexError, lambda: p[-10])
 
     def test_slicing(self):
@@ -149,22 +158,22 @@ class PeekableTests(TestCase):
         p = peekable(seq)
 
         # Slicing the peekable should just be like slicing a re-iterable
-        eq_(p[1:4], seq[1:4])
+        self.assertEqual(p[1:4], seq[1:4])
 
         # Advancing the iterator moves the slices up also
-        eq_(next(p), 'a')
-        eq_(p[1:4], seq[1:][1:4])
+        self.assertEqual(next(p), 'a')
+        self.assertEqual(p[1:4], seq[1:][1:4])
 
         # Implicit starts and stop should work
-        eq_(p[:5], seq[1:][:5])
-        eq_(p[:], seq[1:][:])
+        self.assertEqual(p[:5], seq[1:][:5])
+        self.assertEqual(p[:], seq[1:][:])
 
         # Indexing past the end should work
-        eq_(p[:100], seq[1:][:100])
+        self.assertEqual(p[:100], seq[1:][:100])
 
         # Steps should work, including negative
-        eq_(p[::2], seq[1:][::2])
-        eq_(p[::-1], seq[1:][::-1])
+        self.assertEqual(p[::2], seq[1:][::2])
+        self.assertEqual(p[::-1], seq[1:][::-1])
 
     def test_slicing_reset(self):
         """Test slicing on a fresh iterable each time"""
@@ -202,7 +211,7 @@ class PeekableTests(TestCase):
         useful to set a baseline in case something goes wrong)"""
         expected = [1, 2, 3, 4, 5]
         actual = list(peekable(expected))
-        eq_(actual, expected)
+        self.assertEqual(actual, expected)
 
     # prepend() behavior tests
 
@@ -224,7 +233,7 @@ class PeekableTests(TestCase):
         actual += [next(it)]
 
         expected = [10, 0, 11, 1, 12]
-        eq_(actual, expected)
+        self.assertEqual(actual, expected)
 
     def test_multi_prepend(self):
         """Tests prepending multiple items and getting them in proper order"""
@@ -234,7 +243,7 @@ class PeekableTests(TestCase):
         it.prepend(20, 21)
         actual += list(it)
         expected = [0, 1, 20, 21, 10, 11, 12, 2, 3, 4]
-        eq_(actual, expected)
+        self.assertEqual(actual, expected)
 
     def test_empty(self):
         """Tests prepending in front of an empty iterable"""
@@ -242,7 +251,7 @@ class PeekableTests(TestCase):
         it.prepend(10)
         actual = list(it)
         expected = [10]
-        eq_(actual, expected)
+        self.assertEqual(actual, expected)
 
     def test_prepend_truthiness(self):
         """Tests that ``__bool__()`` or ``__nonzero__()`` works properly
@@ -256,30 +265,30 @@ class PeekableTests(TestCase):
         actual += [next(it)]
         self.assertFalse(it)
         expected = [0, 1, 2, 3, 4, 10]
-        eq_(actual, expected)
+        self.assertEqual(actual, expected)
 
     def test_multi_prepend_peek(self):
         """Tests prepending multiple elements and getting them in reverse order
         while peeking"""
         it = peekable(range(5))
         actual = [next(it), next(it)]
-        eq_(it.peek(), 2)
+        self.assertEqual(it.peek(), 2)
         it.prepend(10, 11, 12)
-        eq_(it.peek(), 10)
+        self.assertEqual(it.peek(), 10)
         it.prepend(20, 21)
-        eq_(it.peek(), 20)
+        self.assertEqual(it.peek(), 20)
         actual += list(it)
         self.assertFalse(it)
         expected = [0, 1, 20, 21, 10, 11, 12, 2, 3, 4]
-        eq_(actual, expected)
+        self.assertEqual(actual, expected)
 
     def test_prepend_after_stop(self):
         """Test resuming iteration after a previous exhaustion"""
         it = peekable(range(3))
-        eq_(list(it), [0, 1, 2])
+        self.assertEqual(list(it), [0, 1, 2])
         self.assertRaises(StopIteration, lambda: next(it))
         it.prepend(10)
-        eq_(next(it), 10)
+        self.assertEqual(next(it), 10)
         self.assertRaises(StopIteration, lambda: next(it))
 
     def test_prepend_slicing(self):
@@ -291,14 +300,14 @@ class PeekableTests(TestCase):
         pseq = [30, 40, 50] + seq  # pseq for prepended_seq
 
         # adapt the specific tests from test_slicing
-        eq_(p[0], 30)
-        eq_(p[1:8], pseq[1:8])
-        eq_(p[1:], pseq[1:])
-        eq_(p[:5], pseq[:5])
-        eq_(p[:], pseq[:])
-        eq_(p[:100], pseq[:100])
-        eq_(p[::2], pseq[::2])
-        eq_(p[::-1], pseq[::-1])
+        self.assertEqual(p[0], 30)
+        self.assertEqual(p[1:8], pseq[1:8])
+        self.assertEqual(p[1:], pseq[1:])
+        self.assertEqual(p[:5], pseq[:5])
+        self.assertEqual(p[:], pseq[:])
+        self.assertEqual(p[:100], pseq[:100])
+        self.assertEqual(p[::2], pseq[::2])
+        self.assertEqual(p[::-1], pseq[::-1])
 
     def test_prepend_indexing(self):
         """Tests interaction between prepending and indexing"""
@@ -307,16 +316,16 @@ class PeekableTests(TestCase):
 
         p.prepend(30, 40, 50)
 
-        eq_(p[0], 30)
-        eq_(next(p), 30)
-        eq_(p[2], 0)
-        eq_(next(p), 40)
-        eq_(p[0], 50)
-        eq_(p[9], 8)
-        eq_(next(p), 50)
-        eq_(p[8], 8)
-        eq_(p[-2], 18)
-        eq_(p[-9], 11)
+        self.assertEqual(p[0], 30)
+        self.assertEqual(next(p), 30)
+        self.assertEqual(p[2], 0)
+        self.assertEqual(next(p), 40)
+        self.assertEqual(p[0], 50)
+        self.assertEqual(p[9], 8)
+        self.assertEqual(next(p), 50)
+        self.assertEqual(p[8], 8)
+        self.assertEqual(p[-2], 18)
+        self.assertEqual(p[-9], 11)
         self.assertRaises(IndexError, lambda: p[-21])
 
     def test_prepend_iterable(self):
@@ -327,7 +336,7 @@ class PeekableTests(TestCase):
         it.prepend(*(x for x in range(5)))
         actual = list(it)
         expected = list(chain(range(5), range(5)))
-        eq_(actual, expected)
+        self.assertEqual(actual, expected)
 
     def test_prepend_many(self):
         """Tests that prepending a huge number of elements works"""
@@ -337,7 +346,7 @@ class PeekableTests(TestCase):
         it.prepend(*(x for x in range(20000)))
         actual = list(it)
         expected = list(chain(range(20000), range(5)))
-        eq_(actual, expected)
+        self.assertEqual(actual, expected)
 
     def test_prepend_reversed(self):
         """Tests prepending from a reversed iterable"""
@@ -345,7 +354,7 @@ class PeekableTests(TestCase):
         it.prepend(*reversed((10, 11, 12)))
         actual = list(it)
         expected = [12, 11, 10, 0, 1, 2]
-        eq_(actual, expected)
+        self.assertEqual(actual, expected)
 
 
 class ConsumerTests(TestCase):
@@ -361,46 +370,49 @@ class ConsumerTests(TestCase):
         e.send('hi')  # without @consumer, would raise TypeError
 
 
-def test_distinct_permutations():
-    """Make sure the output for ``distinct_permutations()`` is the same as
-    set(permutations(it)).
+class DistinctPermutationsTests(TestCase):
+    def test_distinct_permutations(self):
+        """Make sure the output for ``distinct_permutations()`` is the same as
+        set(permutations(it)).
 
-    """
-    iterable = ['z', 'a', 'a', 'q', 'q', 'q', 'y']
-    test_output = sorted(distinct_permutations(iterable))
-    ref_output = sorted(set(permutations(iterable)))
-    eq_(test_output, ref_output)
-
-
-def test_ilen():
-    """Sanity-checks for ``ilen()``."""
-    # Non-empty
-    eq_(ilen(filter(lambda x: x % 10 == 0, range(101))), 11)
-
-    # Empty
-    eq_(ilen((x for x in range(0))), 0)
-
-    # Iterable with __len__
-    eq_(ilen(list(range(6))), 6)
+        """
+        iterable = ['z', 'a', 'a', 'q', 'q', 'q', 'y']
+        test_output = sorted(distinct_permutations(iterable))
+        ref_output = sorted(set(permutations(iterable)))
+        self.assertEqual(test_output, ref_output)
 
 
-def test_with_iter():
-    """Make sure ``with_iter`` iterates over and closes things correctly."""
-    s = StringIO('One fish\nTwo fish')
-    initial_words = [line.split()[0] for line in with_iter(s)]
+class IlenTests(TestCase):
+    def test_ilen(self):
+        """Sanity-checks for ``ilen()``."""
+        # Non-empty
+        self.assertEqual(ilen(filter(lambda x: x % 10 == 0, range(101))), 11)
 
-    # Iterable's items should be faithfully represented
-    eq_(initial_words, ['One', 'Two'])
-    # The file object should be closed
-    eq_(s.closed, True)
+        # Empty
+        self.assertEqual(ilen((x for x in range(0))), 0)
+
+        # Iterable with __len__
+        self.assertEqual(ilen(list(range(6))), 6)
 
 
-def test_one():
-    """Test the ``one()`` cases that aren't covered by its doctests."""
-    # Infinite iterables
-    numbers = count()
-    assert_raises(ValueError, one, numbers)  # burn 0 and 1
-    eq_(next(numbers), 2)
+class WithIterTests(TestCase):
+    def test_with_iter(self):
+        s = StringIO('One fish\nTwo fish')
+        initial_words = [line.split()[0] for line in with_iter(s)]
+
+        # Iterable's items should be faithfully represented
+        self.assertEqual(initial_words, ['One', 'Two'])
+        # The file object should be closed
+        self.assertEqual(s.closed, True)
+
+
+class OneTests(TestCase):
+    def test_one(self):
+        """Test the ``one()`` cases that aren't covered by its doctests."""
+        # Infinite iterables
+        numbers = count()
+        assert_raises(ValueError, one, numbers)  # burn 0 and 1
+        self.assertEqual(next(numbers), 2)
 
 
 class IntersperseTest(TestCase):
@@ -408,18 +420,20 @@ class IntersperseTest(TestCase):
 
     def test_even(self):
         iterable = (x for x in '01')
-        eq_(list(intersperse(None, iterable)), ['0', None, '1'])
+        self.assertEqual(list(intersperse(None, iterable)), ['0', None, '1'])
 
     def test_odd(self):
         iterable = (x for x in '012')
-        eq_(list(intersperse(None, iterable)), ['0', None, '1', None, '2'])
+        self.assertEqual(
+            list(intersperse(None, iterable)), ['0', None, '1', None, '2']
+        )
 
     def test_nested(self):
         element = ('a', 'b')
         iterable = (x for x in '012')
         actual = list(intersperse(element, iterable))
         expected = ['0', ('a', 'b'), '1', ('a', 'b'), '2']
-        eq_(actual, expected)
+        self.assertEqual(actual, expected)
 
     def test_not_iterable(self):
         assert_raises(TypeError, lambda: intersperse('x', 1))
@@ -430,17 +444,18 @@ class IntersperseTest(TestCase):
             (2, '_', ['0', '1', '_', '2', '3', '_', '4', '5']),
             (3, '_', ['0', '1', '2', '_', '3', '4', '5']),
             (4, '_', ['0', '1', '2', '3', '_', '4', '5']),
-            (5, '_' , ['0', '1', '2', '3', '4', '_', '5']),
-            (6, '_' , ['0', '1', '2', '3', '4', '5']),
-            (7, '_' , ['0', '1', '2', '3', '4', '5']),
+            (5, '_', ['0', '1', '2', '3', '4', '_', '5']),
+            (6, '_', ['0', '1', '2', '3', '4', '5']),
+            (7, '_', ['0', '1', '2', '3', '4', '5']),
             (3, ['a', 'b'], ['0', '1', '2', ['a', 'b'], '3', '4', '5']),
         ]:
             iterable = (x for x in '012345')
             actual = list(intersperse(element, iterable, n=n))
-            eq_(actual, expected)
+            self.assertEqual(actual, expected)
 
     def test_n_zero(self):
         assert_raises(ValueError, lambda: list(intersperse('x', '012', n=0)))
+
 
 class UniqueToEachTests(TestCase):
     """Tests for ``unique_to_each()``"""
@@ -449,19 +464,21 @@ class UniqueToEachTests(TestCase):
         """When all the input iterables are unique the output should match
         the input."""
         iterables = [[1, 2], [3, 4, 5], [6, 7, 8]]
-        eq_(unique_to_each(*iterables), iterables)
+        self.assertEqual(unique_to_each(*iterables), iterables)
 
     def test_duplicates(self):
         """When there are duplicates in any of the input iterables that aren't
         in the rest, those duplicates should be emitted."""
         iterables = ["mississippi", "missouri"]
-        eq_(unique_to_each(*iterables), [['p', 'p'], ['o', 'u', 'r']])
+        self.assertEqual(
+            unique_to_each(*iterables), [['p', 'p'], ['o', 'u', 'r']]
+        )
 
     def test_mixed(self):
         """When the input iterables contain different types the function should
         still behave properly"""
         iterables = ['x', (i for i in range(3)), [1, 2, 3], tuple()]
-        eq_(unique_to_each(*iterables), [['x'], [0], [3], []])
+        self.assertEqual(unique_to_each(*iterables), [['x'], [0], [3], []])
 
 
 class WindowedTests(TestCase):
@@ -470,7 +487,7 @@ class WindowedTests(TestCase):
     def test_basic(self):
         actual = list(windowed([1, 2, 3, 4, 5], 3))
         expected = [(1, 2, 3), (2, 3, 4), (3, 4, 5)]
-        eq_(actual, expected)
+        self.assertEqual(actual, expected)
 
     def test_large_size(self):
         """
@@ -479,7 +496,7 @@ class WindowedTests(TestCase):
         """
         actual = list(windowed([1, 2, 3, 4, 5], 6))
         expected = [(1, 2, 3, 4, 5, None)]
-        eq_(actual, expected)
+        self.assertEqual(actual, expected)
 
     def test_fillvalue(self):
         """
@@ -492,13 +509,13 @@ class WindowedTests(TestCase):
             (3, {'step': 3}, [(1, 2, 3), (4, 5, '!')]),  # using ``step``
         ]:
             actual = list(windowed(iterable, n, fillvalue='!', **kwargs))
-            eq_(actual, expected)
+            self.assertEqual(actual, expected)
 
     def test_zero(self):
         """When the window size is zero, an empty tuple should be emitted."""
         actual = list(windowed([1, 2, 3, 4, 5], 0))
         expected = [tuple()]
-        eq_(actual, expected)
+        self.assertEqual(actual, expected)
 
     def test_negative(self):
         """When the window size is negative, ValueError should be raised."""
@@ -518,7 +535,7 @@ class WindowedTests(TestCase):
             (7, 8, [(1, 2, 3, 4, 5, 6, 7)]),  # step > len(iterable)
         ]:
             actual = list(windowed(iterable, n, step=step))
-            eq_(actual, expected)
+            self.assertEqual(actual, expected)
 
         # Step must be greater than or equal to 1
         with self.assertRaises(ValueError):
@@ -533,13 +550,13 @@ class BucketTests(TestCase):
         D = bucket(iterable, key=lambda x: 10 * (x // 10))
 
         # In-order access
-        eq_(list(D[10]), [10, 11, 12])
+        self.assertEqual(list(D[10]), [10, 11, 12])
 
         # Out of order access
-        eq_(list(D[30]), [30, 31, 33])
-        eq_(list(D[20]), [20, 21, 22, 23])
+        self.assertEqual(list(D[30]), [30, 31, 33])
+        self.assertEqual(list(D[20]), [20, 21, 22, 23])
 
-        eq_(list(D[40]), [])  # Nothing in here!
+        self.assertEqual(list(D[40]), [])  # Nothing in here!
 
     def test_in(self):
         iterable = [10, 20, 30, 11, 21, 31, 12, 22, 23, 33]
@@ -551,7 +568,7 @@ class BucketTests(TestCase):
         self.assertFalse(21 in D)
 
         # Checking in-ness shouldn't advance the iterator
-        eq_(next(D[10]), 10)
+        self.assertEqual(next(D[10]), 10)
 
 
 class SpyTests(TestCase):
@@ -560,28 +577,32 @@ class SpyTests(TestCase):
     def test_basic(self):
         original_iterable = iter('abcdefg')
         head, new_iterable = spy(original_iterable)
-        eq_(head, ['a'])
-        eq_(list(new_iterable), ['a', 'b', 'c', 'd', 'e', 'f', 'g'])
+        self.assertEqual(head, ['a'])
+        self.assertEqual(
+            list(new_iterable), ['a', 'b', 'c', 'd', 'e', 'f', 'g']
+        )
 
     def test_unpacking(self):
         original_iterable = iter('abcdefg')
         (first, second, third), new_iterable = spy(original_iterable, 3)
-        eq_(first, 'a')
-        eq_(second, 'b')
-        eq_(third, 'c')
-        eq_(list(new_iterable), ['a', 'b', 'c', 'd', 'e', 'f', 'g'])
+        self.assertEqual(first, 'a')
+        self.assertEqual(second, 'b')
+        self.assertEqual(third, 'c')
+        self.assertEqual(
+            list(new_iterable), ['a', 'b', 'c', 'd', 'e', 'f', 'g']
+        )
 
     def test_too_many(self):
         original_iterable = iter('abc')
         head, new_iterable = spy(original_iterable, 4)
-        eq_(head, ['a', 'b', 'c'])
-        eq_(list(new_iterable), ['a', 'b', 'c'])
+        self.assertEqual(head, ['a', 'b', 'c'])
+        self.assertEqual(list(new_iterable), ['a', 'b', 'c'])
 
     def test_zero(self):
         original_iterable = iter('abc')
         head, new_iterable = spy(original_iterable, 0)
-        eq_(head, [])
-        eq_(list(new_iterable), ['a', 'b', 'c'])
+        self.assertEqual(head, [])
+        self.assertEqual(list(new_iterable), ['a', 'b', 'c'])
 
 
 class TestInterleave(TestCase):
@@ -589,19 +610,25 @@ class TestInterleave(TestCase):
 
     def test_interleave(self):
         l = [[1, 2, 3], [4, 5], [6, 7, 8]]
-        eq_(list(interleave(*l)), [1, 4, 6, 2, 5, 7])
+        self.assertEqual(list(interleave(*l)), [1, 4, 6, 2, 5, 7])
         l = [[1, 2], [3, 4, 5], [6, 7, 8]]
-        eq_(list(interleave(*l)), [1, 3, 6, 2, 4, 7])
+        self.assertEqual(list(interleave(*l)), [1, 3, 6, 2, 4, 7])
         l = [[1, 2, 3], [4, 5, 6], [7, 8]]
-        eq_(list(interleave(*l)), [1, 4, 7, 2, 5, 8])
+        self.assertEqual(list(interleave(*l)), [1, 4, 7, 2, 5, 8])
 
     def test_interleave_longest(self):
         l = [[1, 2, 3], [4, 5], [6, 7, 8]]
-        eq_(list(interleave_longest(*l)), [1, 4, 6, 2, 5, 7, 3, 8])
+        self.assertEqual(
+            list(interleave_longest(*l)), [1, 4, 6, 2, 5, 7, 3, 8]
+        )
         l = [[1, 2], [3, 4, 5], [6, 7, 8]]
-        eq_(list(interleave_longest(*l)), [1, 3, 6, 2, 4, 7, 5, 8])
+        self.assertEqual(
+            list(interleave_longest(*l)), [1, 3, 6, 2, 4, 7, 5, 8]
+        )
         l = [[1, 2, 3], [4, 5, 6], [7, 8]]
-        eq_(list(interleave_longest(*l)), [1, 4, 7, 2, 5, 8, 3, 6])
+        self.assertEqual(
+            list(interleave_longest(*l)), [1, 4, 7, 2, 5, 8, 3, 6]
+        )
 
 
 class TestCollapse(TestCase):
@@ -609,27 +636,29 @@ class TestCollapse(TestCase):
 
     def test_collapse(self):
         l = [[1], 2, [[3], 4], [[[5]]]]
-        eq_(list(collapse(l)), [1, 2, 3, 4, 5])
+        self.assertEqual(list(collapse(l)), [1, 2, 3, 4, 5])
 
     def test_collapse_to_string(self):
         l = [["s1"], "s2", [["s3"], "s4"], [[["s5"]]]]
-        eq_(list(collapse(l)), ["s1", "s2", "s3", "s4", "s5"])
+        self.assertEqual(list(collapse(l)), ["s1", "s2", "s3", "s4", "s5"])
 
     def test_collapse_flatten(self):
         l = [[1], [2], [[3], 4], [[[5]]]]
-        eq_(list(collapse(l, levels=1)), list(flatten(l)))
+        self.assertEqual(list(collapse(l, levels=1)), list(flatten(l)))
 
     def test_collapse_to_level(self):
         l = [[1], 2, [[3], 4], [[[5]]]]
-        eq_(list(collapse(l, levels=2)), [1, 2, 3, 4, [5]])
-        eq_(list(collapse(collapse(l, levels=1), levels=1)),
-            list(collapse(l, levels=2)))
+        self.assertEqual(list(collapse(l, levels=2)), [1, 2, 3, 4, [5]])
+        self.assertEqual(
+            list(collapse(collapse(l, levels=1), levels=1)),
+            list(collapse(l, levels=2))
+        )
 
     def test_collapse_to_list(self):
         l = (1, [2], (3, [4, (5,)], 'ab'))
         actual = list(collapse(l, base_type=list))
         expected = [1, [2], 3, [4, (5,)], 'ab']
-        eq_(actual, expected)
+        self.assertEqual(actual, expected)
 
 
 class SideEffectTests(TestCase):
@@ -643,8 +672,8 @@ class SideEffectTests(TestCase):
             counter[0] += 1
 
         result = list(side_effect(func, range(10)))
-        eq_(result, list(range(10)))
-        eq_(counter[0], 10)
+        self.assertEqual(result, list(range(10)))
+        self.assertEqual(counter[0], 10)
 
     def test_chunked(self):
         # The function increments the counter for each call
@@ -654,8 +683,8 @@ class SideEffectTests(TestCase):
             counter[0] += 1
 
         result = list(side_effect(func, range(10), 2))
-        eq_(result, list(range(10)))
-        eq_(counter[0], 5)
+        self.assertEqual(result, list(range(10)))
+        self.assertEqual(counter[0], 5)
 
     def test_before_after(self):
         f = StringIO()
@@ -707,12 +736,12 @@ class SlicedTests(TestCase):
     def test_even(self):
         """Test when the length of the sequence is divisible by *n*"""
         seq = 'ABCDEFGHI'
-        eq_(list(sliced(seq, 3)), ['ABC', 'DEF', 'GHI'])
+        self.assertEqual(list(sliced(seq, 3)), ['ABC', 'DEF', 'GHI'])
 
     def test_odd(self):
         """Test when the length of the sequence is not divisible by *n*"""
         seq = 'ABCDEFGHI'
-        eq_(list(sliced(seq, 4)), ['ABCD', 'EFGH', 'I'])
+        self.assertEqual(list(sliced(seq, 4)), ['ABCD', 'EFGH', 'I'])
 
     def test_not_sliceable(self):
         seq = (x for x in 'ABCDEFGHI')
@@ -727,17 +756,17 @@ class SplitBeforeTest(TestCase):
     def test_starts_with_sep(self):
         actual = list(split_before('xooxoo', lambda c: c == 'x'))
         expected = [['x', 'o', 'o'], ['x', 'o', 'o']]
-        eq_(actual, expected)
+        self.assertEqual(actual, expected)
 
     def test_ends_with_sep(self):
         actual = list(split_before('ooxoox', lambda c: c == 'x'))
         expected = [['o', 'o'], ['x', 'o', 'o'], ['x']]
-        eq_(actual, expected)
+        self.assertEqual(actual, expected)
 
     def test_no_sep(self):
         actual = list(split_before('ooo', lambda c: c == 'x'))
         expected = [['o', 'o', 'o']]
-        eq_(actual, expected)
+        self.assertEqual(actual, expected)
 
 
 class SplitAfterTest(TestCase):
@@ -746,17 +775,17 @@ class SplitAfterTest(TestCase):
     def test_starts_with_sep(self):
         actual = list(split_after('xooxoo', lambda c: c == 'x'))
         expected = [['x'], ['o', 'o', 'x'], ['o', 'o']]
-        eq_(actual, expected)
+        self.assertEqual(actual, expected)
 
     def test_ends_with_sep(self):
         actual = list(split_after('ooxoox', lambda c: c == 'x'))
         expected = [['o', 'o', 'x'], ['o', 'o', 'x']]
-        eq_(actual, expected)
+        self.assertEqual(actual, expected)
 
     def test_no_sep(self):
         actual = list(split_after('ooo', lambda c: c == 'x'))
         expected = [['o', 'o', 'o']]
-        eq_(actual, expected)
+        self.assertEqual(actual, expected)
 
 
 class PaddedTest(TestCase):
@@ -838,11 +867,13 @@ class DistributeTest(TestCase):
             (3, [[1, 4, 7, 10], [2, 5, 8], [3, 6, 9]]),
             (10, [[n] for n in range(1, 10 + 1)]),
         ]:
-            eq_([list(x) for x in distribute(n, iterable)], expected)
+            self.assertEqual(
+                [list(x) for x in distribute(n, iterable)], expected
+            )
 
     def test_large_n(self):
         iterable = [1, 2, 3, 4]
-        eq_(
+        self.assertEqual(
             [list(x) for x in distribute(6, iterable)],
             [[1], [2], [3], [4], [], []]
         )
@@ -855,7 +886,7 @@ class StaggerTest(TestCase):
         iterable = [0, 1, 2, 3]
         actual = list(stagger(iterable))
         expected = [(None, 0, 1), (0, 1, 2), (1, 2, 3)]
-        eq_(actual, expected)
+        self.assertEqual(actual, expected)
 
     def test_offsets(self):
         iterable = [0, 1, 2, 3]
@@ -865,7 +896,7 @@ class StaggerTest(TestCase):
             ((1, 2), [(1, 2), (2, 3)]),
         ]:
             all_groups = stagger(iterable, offsets=offsets, fillvalue='')
-            eq_(list(all_groups), expected)
+            self.assertEqual(list(all_groups), expected)
 
     def test_longest(self):
         iterable = [0, 1, 2, 3]
@@ -880,28 +911,28 @@ class StaggerTest(TestCase):
             all_groups = stagger(
                 iterable, offsets=offsets, fillvalue='', longest=True
             )
-            eq_(list(all_groups), expected)
+            self.assertEqual(list(all_groups), expected)
 
 
 class ZipOffsetTest(TestCase):
     """Tests for ``zip_offset()``"""
 
     def test_shortest(self):
-        seq_1 = [0, 1, 2, 3]
-        seq_2 = [0, 1, 2, 3, 4, 5]
-        seq_3 = [0, 1, 2, 3, 4, 5, 6, 7]
+        a_1 = [0, 1, 2, 3]
+        a_2 = [0, 1, 2, 3, 4, 5]
+        a_3 = [0, 1, 2, 3, 4, 5, 6, 7]
         actual = list(
-            zip_offset(seq_1, seq_2, seq_3, offsets=(-1, 0, 1), fillvalue='')
+            zip_offset(a_1, a_2, a_3, offsets=(-1, 0, 1), fillvalue='')
         )
         expected = [('', 0, 1), (0, 1, 2), (1, 2, 3), (2, 3, 4), (3, 4, 5)]
-        eq_(actual, expected)
+        self.assertEqual(actual, expected)
 
     def test_longest(self):
-        seq_1 = [0, 1, 2, 3]
-        seq_2 = [0, 1, 2, 3, 4, 5]
-        seq_3 = [0, 1, 2, 3, 4, 5, 6, 7]
+        a_1 = [0, 1, 2, 3]
+        a_2 = [0, 1, 2, 3, 4, 5]
+        a_3 = [0, 1, 2, 3, 4, 5, 6, 7]
         actual = list(
-            zip_offset(seq_1, seq_2, seq_3, offsets=(-1, 0, 1), longest=True)
+            zip_offset(a_1, a_2, a_3, offsets=(-1, 0, 1), longest=True)
         )
         expected = [
             (None, 0, 1),
@@ -912,7 +943,7 @@ class ZipOffsetTest(TestCase):
             (None, 5, 6),
             (None, None, 7),
         ]
-        eq_(actual, expected)
+        self.assertEqual(actual, expected)
 
     def test_mismatch(self):
         iterables = [0, 1, 2], [2, 3, 4]
@@ -927,49 +958,74 @@ class SortTogetherTest(TestCase):
 
     def test_key_list(self):
         """tests `key_list` including default, iterables include duplicates"""
-        iterables = [['GA', 'GA', 'GA', 'CT', 'CT', 'CT'],
-                     ['May', 'Aug.', 'May', 'June', 'July', 'July'],
-                     [97, 20, 100, 70, 100, 20]]
+        iterables = [
+            ['GA', 'GA', 'GA', 'CT', 'CT', 'CT'],
+            ['May', 'Aug.', 'May', 'June', 'July', 'July'],
+            [97, 20, 100, 70, 100, 20]
+        ]
 
-        eq_(sort_together(iterables),
-            [('CT', 'CT', 'CT', 'GA', 'GA', 'GA'),
-             ('June', 'July', 'July', 'May', 'Aug.', 'May'),
-             (70, 100, 20, 97, 20, 100)])
+        self.assertEqual(
+            sort_together(iterables),
+            [
+                ('CT', 'CT', 'CT', 'GA', 'GA', 'GA'),
+                ('June', 'July', 'July', 'May', 'Aug.', 'May'),
+                (70, 100, 20, 97, 20, 100)
+            ]
+        )
 
-        eq_(sort_together(iterables, key_list=(0, 1)),
-            [('CT', 'CT', 'CT', 'GA', 'GA', 'GA'),
-             ('July', 'July', 'June', 'Aug.', 'May', 'May'),
-             (100, 20, 70, 20, 97, 100)])
+        self.assertEqual(
+            sort_together(iterables, key_list=(0, 1)),
+            [
+                ('CT', 'CT', 'CT', 'GA', 'GA', 'GA'),
+                ('July', 'July', 'June', 'Aug.', 'May', 'May'),
+                (100, 20, 70, 20, 97, 100)
+            ]
+        )
 
-        eq_(sort_together(iterables, key_list=(0, 1, 2)),
-            [('CT', 'CT', 'CT', 'GA', 'GA', 'GA'),
-             ('July', 'July', 'June', 'Aug.', 'May', 'May'),
-             (20, 100, 70, 20, 97, 100)])
+        self.assertEqual(
+            sort_together(iterables, key_list=(0, 1, 2)),
+            [
+                ('CT', 'CT', 'CT', 'GA', 'GA', 'GA'),
+                ('July', 'July', 'June', 'Aug.', 'May', 'May'),
+                (20, 100, 70, 20, 97, 100)
+            ]
+        )
 
-        eq_(sort_together(iterables, key_list=(2,)),
-            [('GA', 'CT', 'CT', 'GA', 'GA', 'CT'),
-             ('Aug.', 'July', 'June', 'May', 'May', 'July'),
-             (20, 20, 70, 97, 100, 100)])
+        self.assertEqual(
+            sort_together(iterables, key_list=(2,)),
+            [
+                ('GA', 'CT', 'CT', 'GA', 'GA', 'CT'),
+                ('Aug.', 'July', 'June', 'May', 'May', 'July'),
+                (20, 20, 70, 97, 100, 100)
+            ]
+        )
 
     def test_invalid_key_list(self):
         """tests `key_list` for indexes not available in `iterables`"""
-        iterables = [['GA', 'GA', 'GA', 'CT', 'CT', 'CT'],
-                     ['May', 'Aug.', 'May', 'June', 'July', 'July'],
-                     [97, 20, 100, 70, 100, 20]]
+        iterables = [
+            ['GA', 'GA', 'GA', 'CT', 'CT', 'CT'],
+            ['May', 'Aug.', 'May', 'June', 'July', 'July'],
+            [97, 20, 100, 70, 100, 20]
+        ]
 
-        self.assertRaises(IndexError,
-                          lambda: sort_together(iterables, key_list=(5,)))
+        self.assertRaises(
+            IndexError, lambda: sort_together(iterables, key_list=(5,))
+        )
 
     def test_reverse(self):
         """tests `reverse` to ensure a reverse sort for `key_list` iterables"""
-        iterables = [['GA', 'GA', 'GA', 'CT', 'CT', 'CT'],
-                     ['May', 'Aug.', 'May', 'June', 'July', 'July'],
-                     [97, 20, 100, 70, 100, 20]]
+        iterables = [
+            ['GA', 'GA', 'GA', 'CT', 'CT', 'CT'],
+            ['May', 'Aug.', 'May', 'June', 'July', 'July'],
+            [97, 20, 100, 70, 100, 20]
+        ]
 
-        eq_(sort_together(iterables, key_list=(0, 1, 2), reverse=True),
+        self.assertEqual(
+            sort_together(iterables, key_list=(0, 1, 2), reverse=True),
             [('GA', 'GA', 'GA', 'CT', 'CT', 'CT'),
              ('May', 'May', 'Aug.', 'June', 'July', 'July'),
-             (100, 97, 20, 70, 100, 20)])
+             (100, 97, 20, 70, 100, 20)]
+        )
 
     def test_uneven_iterables(self):
         """tests trimming of iterables to the shortest length before sorting"""
@@ -977,10 +1033,14 @@ class SortTogetherTest(TestCase):
                      ['May', 'Aug.', 'May', 'June', 'July', 'July'],
                      [97, 20, 100, 70, 100, 20, 0]]
 
-        eq_(sort_together(iterables),
-            [('CT', 'CT', 'CT', 'GA', 'GA', 'GA'),
-             ('June', 'July', 'July', 'May', 'Aug.', 'May'),
-             (70, 100, 20, 97, 20, 100)])
+        self.assertEqual(
+            sort_together(iterables),
+            [
+                ('CT', 'CT', 'CT', 'GA', 'GA', 'GA'),
+                ('June', 'July', 'July', 'May', 'Aug.', 'May'),
+                (70, 100, 20, 97, 20, 100)
+            ]
+        )
 
 
 class DivideTest(TestCase):
@@ -999,11 +1059,11 @@ class DivideTest(TestCase):
             (3, [[1, 2, 3, 4], [5, 6, 7], [8, 9, 10]]),
             (10, [[n] for n in range(1, 10 + 1)]),
         ]:
-            eq_([list(x) for x in divide(n, iterable)], expected)
+            self.assertEqual([list(x) for x in divide(n, iterable)], expected)
 
     def test_large_n(self):
         iterable = [1, 2, 3, 4]
-        eq_(
+        self.assertEqual(
             [list(x) for x in divide(6, iterable)],
             [[1], [2], [3], [4], [], []]
         )

--- a/more_itertools/tests/test_more.py
+++ b/more_itertools/tests/test_more.py
@@ -8,7 +8,6 @@ from itertools import chain, count, groupby, permutations, product, repeat
 from operator import itemgetter
 from unittest import TestCase
 
-from nose.tools import assert_raises
 import six
 from six.moves import filter, range, zip
 
@@ -89,7 +88,7 @@ class FirstTests(TestCase):
 
     def test_empty_stop_iteration(self):
         """It should raise StopIteration for empty iterables."""
-        assert_raises(ValueError, first, [])
+        self.assertRaises(ValueError, lambda: first([]))
 
     def test_default(self):
         """It should return the provided default arg for empty iterables."""
@@ -411,7 +410,7 @@ class OneTests(TestCase):
         """Test the ``one()`` cases that aren't covered by its doctests."""
         # Infinite iterables
         numbers = count()
-        assert_raises(ValueError, one, numbers)  # burn 0 and 1
+        self.assertRaises(ValueError, lambda: one(numbers))  # burn 0 and 1
         self.assertEqual(next(numbers), 2)
 
 
@@ -436,7 +435,7 @@ class IntersperseTest(TestCase):
         self.assertEqual(actual, expected)
 
     def test_not_iterable(self):
-        assert_raises(TypeError, lambda: intersperse('x', 1))
+        self.assertRaises(TypeError, lambda: intersperse('x', 1))
 
     def test_n(self):
         for n, element, expected in [
@@ -454,7 +453,9 @@ class IntersperseTest(TestCase):
             self.assertEqual(actual, expected)
 
     def test_n_zero(self):
-        assert_raises(ValueError, lambda: list(intersperse('x', '012', n=0)))
+        self.assertRaises(
+            ValueError, lambda: list(intersperse('x', '012', n=0))
+        )
 
 
 class UniqueToEachTests(TestCase):

--- a/more_itertools/tests/test_more.py
+++ b/more_itertools/tests/test_more.py
@@ -7,7 +7,7 @@ from functools import reduce
 from io import StringIO
 from itertools import chain, count, groupby, permutations, product, repeat
 from operator import itemgetter
-from unittest import skip, TestCase
+from unittest import TestCase
 
 import six
 from six.moves import filter, range, zip
@@ -15,7 +15,6 @@ from six.moves import filter, range, zip
 from more_itertools import *  # Test all the symbols are in __all__.
 
 
-@skip("This isn't a test")
 def load_tests(loader, tests, ignore):
     # Add the doctests
     tests.addTests(DocTestSuite('more_itertools.more'))

--- a/more_itertools/tests/test_recipes.py
+++ b/more_itertools/tests/test_recipes.py
@@ -9,7 +9,7 @@ from more_itertools import *
 
 def load_tests(loader, tests, ignore):
     # Add the doctests
-    tests.addTests(DocTestSuite('more_itertools.more'))
+    tests.addTests(DocTestSuite('more_itertools.recipes'))
     return tests
 
 

--- a/more_itertools/tests/test_recipes.py
+++ b/more_itertools/tests/test_recipes.py
@@ -1,13 +1,17 @@
+from doctest import DocTestSuite
 from random import seed
-from unittest import TestCase
+from unittest import skip, TestCase
 
 from six.moves import range
 
 from more_itertools import *
 
 
-def setup_module():
-    seed(1337)
+@skip("This isn't a test")
+def load_tests(loader, tests, ignore):
+    # Add the doctests
+    tests.addTests(DocTestSuite('more_itertools.more'))
+    return tests
 
 
 class AccumulateTests(TestCase):

--- a/more_itertools/tests/test_recipes.py
+++ b/more_itertools/tests/test_recipes.py
@@ -1,13 +1,12 @@
 from doctest import DocTestSuite
 from random import seed
-from unittest import skip, TestCase
+from unittest import TestCase
 
 from six.moves import range
 
 from more_itertools import *
 
 
-@skip("This isn't a test")
 def load_tests(loader, tests, ignore):
     # Add the doctests
     tests.addTests(DocTestSuite('more_itertools.more'))

--- a/more_itertools/tests/test_recipes.py
+++ b/more_itertools/tests/test_recipes.py
@@ -1,7 +1,6 @@
 from random import seed
 from unittest import TestCase
 
-from nose.tools import eq_, assert_raises, ok_
 from six.moves import range
 
 from more_itertools import *
@@ -16,11 +15,11 @@ class AccumulateTests(TestCase):
 
     def test_empty(self):
         """Test that an empty input returns an empty output"""
-        eq_(list(accumulate([])), [])
+        self.assertEqual(list(accumulate([])), [])
 
     def test_default(self):
         """Test accumulate with the default function (addition)"""
-        eq_(list(accumulate([1, 2, 3])), [1, 3, 6])
+        self.assertEqual(list(accumulate([1, 2, 3])), [1, 3, 6])
 
     def test_bogus_function(self):
         """Test accumulate with an invalid function"""
@@ -29,7 +28,9 @@ class AccumulateTests(TestCase):
 
     def test_custom_function(self):
         """Test accumulate with a custom function"""
-        eq_(list(accumulate((1, 2, 3, 2, 1), func=max)), [1, 2, 3, 3, 3])
+        self.assertEqual(
+            list(accumulate((1, 2, 3, 2, 1), func=max)), [1, 2, 3, 3, 3]
+        )
 
 
 class TakeTests(TestCase):
@@ -38,16 +39,16 @@ class TakeTests(TestCase):
     def test_simple_take(self):
         """Test basic usage"""
         t = take(5, range(10))
-        eq_(t, [0, 1, 2, 3, 4])
+        self.assertEqual(t, [0, 1, 2, 3, 4])
 
     def test_null_take(self):
         """Check the null case"""
         t = take(0, range(10))
-        eq_(t, [])
+        self.assertEqual(t, [])
 
     def test_negative_take(self):
         """Make sure taking negative items results in a ValueError"""
-        assert_raises(ValueError, take, -3, range(10))
+        self.assertRaises(ValueError, lambda: take(-3, range(10)))
 
     def test_take_too_much(self):
         """Taking more than an iterator has remaining should return what the
@@ -55,7 +56,7 @@ class TakeTests(TestCase):
 
         """
         t = take(10, range(5))
-        eq_(t, [0, 1, 2, 3, 4])
+        self.assertEqual(t, [0, 1, 2, 3, 4])
 
 
 class TabulateTests(TestCase):
@@ -65,13 +66,13 @@ class TabulateTests(TestCase):
         """Test the happy path"""
         t = tabulate(lambda x: x)
         f = tuple([next(t) for _ in range(3)])
-        eq_(f, (0, 1, 2))
+        self.assertEqual(f, (0, 1, 2))
 
     def test_count(self):
         """Ensure tabulate accepts specific count"""
         t = tabulate(lambda x: 2 * x, -1)
         f = (next(t), next(t), next(t))
-        eq_(f, (-2, 0, 2))
+        self.assertEqual(f, (-2, 0, 2))
 
 
 class TailTests(TestCase):
@@ -79,15 +80,19 @@ class TailTests(TestCase):
 
     def test_greater(self):
         """Length of iterable is greather than requested tail"""
-        eq_(list(tail(3, 'ABCDEFG')), ['E', 'F', 'G'])
+        self.assertEqual(list(tail(3, 'ABCDEFG')), ['E', 'F', 'G'])
 
     def test_equal(self):
         """Length of iterable is equal to the requested tail"""
-        eq_(list(tail(7, 'ABCDEFG')), ['A', 'B', 'C', 'D', 'E', 'F', 'G'])
+        self.assertEqual(
+            list(tail(7, 'ABCDEFG')), ['A', 'B', 'C', 'D', 'E', 'F', 'G']
+        )
 
     def test_less(self):
         """Length of iterable is less than requested tail"""
-        eq_(list(tail(8, 'ABCDEFG')), ['A', 'B', 'C', 'D', 'E', 'F', 'G'])
+        self.assertEqual(
+            list(tail(8, 'ABCDEFG')), ['A', 'B', 'C', 'D', 'E', 'F', 'G']
+        )
 
 
 class ConsumeTests(TestCase):
@@ -97,24 +102,24 @@ class ConsumeTests(TestCase):
         """Test basic functionality"""
         r = (x for x in range(10))
         consume(r, 3)
-        eq_(3, next(r))
+        self.assertEqual(3, next(r))
 
     def test_null_consume(self):
         """Check the null case"""
         r = (x for x in range(10))
         consume(r, 0)
-        eq_(0, next(r))
+        self.assertEqual(0, next(r))
 
     def test_negative_consume(self):
         """Check that negative consumsion throws an error"""
         r = (x for x in range(10))
-        assert_raises(ValueError, consume, r, -1)
+        self.assertRaises(ValueError, lambda: consume(r, -1))
 
     def test_total_consume(self):
         """Check that iterator is totally consumed by default"""
         r = (x for x in range(10))
         consume(r)
-        assert_raises(StopIteration, next, r)
+        self.assertRaises(StopIteration, lambda: next(r))
 
 
 class NthTests(TestCase):
@@ -124,16 +129,16 @@ class NthTests(TestCase):
         """Make sure the nth item is returned"""
         l = range(10)
         for i, v in enumerate(l):
-            eq_(nth(l, i), v)
+            self.assertEqual(nth(l, i), v)
 
     def test_default(self):
         """Ensure a default value is returned when nth item not found"""
         l = range(3)
-        eq_(nth(l, 100, "zebra"), "zebra")
+        self.assertEqual(nth(l, 100, "zebra"), "zebra")
 
     def test_negative_item_raises(self):
         """Ensure asking for a negative item raises an exception"""
-        assert_raises(ValueError, nth, range(10), -3)
+        self.assertRaises(ValueError, lambda: nth(range(10), -3))
 
 
 class AllEqualTests(TestCase):
@@ -171,12 +176,12 @@ class QuantifyTests(TestCase):
     def test_happy_path(self):
         """Make sure True count is returned"""
         q = [True, False, True]
-        eq_(quantify(q), 2)
+        self.assertEqual(quantify(q), 2)
 
     def test_custom_predicate(self):
         """Ensure non-default predicates return as expected"""
         q = range(10)
-        eq_(quantify(q, lambda x: x % 2 == 0), 5)
+        self.assertEqual(quantify(q, lambda x: x % 2 == 0), 5)
 
 
 class PadnoneTests(TestCase):
@@ -186,7 +191,7 @@ class PadnoneTests(TestCase):
         """wrapper iterator should return None indefinitely"""
         r = range(2)
         p = padnone(r)
-        eq_([0, 1, None, None], [next(p) for _ in range(4)])
+        self.assertEqual([0, 1, None, None], [next(p) for _ in range(4)])
 
 
 class NcyclesTests(TestCase):
@@ -196,18 +201,20 @@ class NcyclesTests(TestCase):
         """cycle a sequence three times"""
         r = ["a", "b", "c"]
         n = ncycles(r, 3)
-        eq_(["a", "b", "c", "a", "b", "c", "a", "b", "c"],
-            list(n))
+        self.assertEqual(
+            ["a", "b", "c", "a", "b", "c", "a", "b", "c"],
+            list(n)
+        )
 
     def test_null_case(self):
         """asking for 0 cycles should return an empty iterator"""
         n = ncycles(range(100), 0)
-        assert_raises(StopIteration, next, n)
+        self.assertRaises(StopIteration, lambda: next(n))
 
     def test_pathalogical_case(self):
         """asking for negative cycles should return an empty iterator"""
         n = ncycles(range(100), -10)
-        assert_raises(StopIteration, next, n)
+        self.assertRaises(StopIteration, lambda: next(n))
 
 
 class DotproductTests(TestCase):
@@ -215,7 +222,7 @@ class DotproductTests(TestCase):
 
     def test_happy_path(self):
         """simple dotproduct example"""
-        eq_(400, dotproduct([10, 10], [20, 20]))
+        self.assertEqual(400, dotproduct([10, 10], [20, 20]))
 
 
 class FlattenTests(TestCase):
@@ -224,12 +231,12 @@ class FlattenTests(TestCase):
     def test_basic_usage(self):
         """ensure list of lists is flattened one level"""
         f = [[0, 1, 2], [3, 4, 5]]
-        eq_(list(range(6)), list(flatten(f)))
+        self.assertEqual(list(range(6)), list(flatten(f)))
 
     def test_single_level(self):
         """ensure list of lists is flattened only one level"""
         f = [[0, [1, 2]], [[3, 4], 5]]
-        eq_([0, [1, 2], [3, 4], 5], list(flatten(f)))
+        self.assertEqual([0, [1, 2], [3, 4], 5], list(flatten(f)))
 
 
 class RepeatfuncTests(TestCase):
@@ -238,22 +245,22 @@ class RepeatfuncTests(TestCase):
     def test_simple_repeat(self):
         """test simple repeated functions"""
         r = repeatfunc(lambda: 5)
-        eq_([5, 5, 5, 5, 5], [next(r) for _ in range(5)])
+        self.assertEqual([5, 5, 5, 5, 5], [next(r) for _ in range(5)])
 
     def test_finite_repeat(self):
         """ensure limited repeat when times is provided"""
         r = repeatfunc(lambda: 5, times=5)
-        eq_([5, 5, 5, 5, 5], list(r))
+        self.assertEqual([5, 5, 5, 5, 5], list(r))
 
     def test_added_arguments(self):
         """ensure arguments are applied to the function"""
         r = repeatfunc(lambda x: x, 2, 3)
-        eq_([3, 3], list(r))
+        self.assertEqual([3, 3], list(r))
 
     def test_null_times(self):
         """repeat 0 should return an empty iterator"""
         r = repeatfunc(range, 0, 3)
-        assert_raises(StopIteration, next, r)
+        self.assertRaises(StopIteration, lambda: next(r))
 
 
 class PairwiseTests(TestCase):
@@ -262,12 +269,12 @@ class PairwiseTests(TestCase):
     def test_base_case(self):
         """ensure an iterable will return pairwise"""
         p = pairwise([1, 2, 3])
-        eq_([(1, 2), (2, 3)], list(p))
+        self.assertEqual([(1, 2), (2, 3)], list(p))
 
     def test_short_case(self):
         """ensure an empty iterator if there's not enough values to pair"""
         p = pairwise("a")
-        assert_raises(StopIteration, next, p)
+        self.assertRaises(StopIteration, lambda: next(p))
 
 
 class GrouperTests(TestCase):
@@ -278,18 +285,24 @@ class GrouperTests(TestCase):
         the iterable.
 
         """
-        eq_(list(grouper(3, 'ABCDEF')), [('A', 'B', 'C'), ('D', 'E', 'F')])
+        self.assertEqual(
+            list(grouper(3, 'ABCDEF')), [('A', 'B', 'C'), ('D', 'E', 'F')]
+        )
 
     def test_odd(self):
         """Test when group size does not divide evenly into the length of the
         iterable.
 
         """
-        eq_(list(grouper(3, 'ABCDE')), [('A', 'B', 'C'), ('D', 'E', None)])
+        self.assertEqual(
+            list(grouper(3, 'ABCDE')), [('A', 'B', 'C'), ('D', 'E', None)]
+        )
 
     def test_fill_value(self):
         """Test that the fill value is used to pad the final group"""
-        eq_(list(grouper(3, 'ABCDE', 'x')), [('A', 'B', 'C'), ('D', 'E', 'x')])
+        self.assertEqual(
+            list(grouper(3, 'ABCDE', 'x')), [('A', 'B', 'C'), ('D', 'E', 'x')]
+        )
 
 
 class RoundrobinTests(TestCase):
@@ -297,13 +310,17 @@ class RoundrobinTests(TestCase):
 
     def test_even_groups(self):
         """Ensure ordered output from evenly populated iterables"""
-        eq_(list(roundrobin('ABC', [1, 2, 3], range(3))),
-            ['A', 1, 0, 'B', 2, 1, 'C', 3, 2])
+        self.assertEqual(
+            list(roundrobin('ABC', [1, 2, 3], range(3))),
+            ['A', 1, 0, 'B', 2, 1, 'C', 3, 2]
+        )
 
     def test_uneven_groups(self):
         """Ensure ordered output from unevenly populated iterables"""
-        eq_(list(roundrobin('ABCD', [1, 2], range(0))),
-            ['A', 1, 'B', 2, 'C', 'D'])
+        self.assertEqual(
+            list(roundrobin('ABCD', [1, 2], range(0))),
+            ['A', 1, 'B', 2, 'C', 'D']
+        )
 
 
 class PartitionTests(TestCase):
@@ -312,14 +329,14 @@ class PartitionTests(TestCase):
     def test_bool(self):
         """Test when pred() returns a boolean"""
         lesser, greater = partition(lambda x: x > 5, range(10))
-        eq_(list(lesser), [0, 1, 2, 3, 4, 5])
-        eq_(list(greater), [6, 7, 8, 9])
+        self.assertEqual(list(lesser), [0, 1, 2, 3, 4, 5])
+        self.assertEqual(list(greater), [6, 7, 8, 9])
 
     def test_arbitrary(self):
         """Test when pred() returns an integer"""
         divisibles, remainders = partition(lambda x: x % 3, range(10))
-        eq_(list(divisibles), [0, 3, 6, 9])
-        eq_(list(remainders), [1, 2, 4, 5, 7, 8])
+        self.assertEqual(list(divisibles), [0, 3, 6, 9])
+        self.assertEqual(list(remainders), [1, 2, 4, 5, 7, 8])
 
 
 class PowersetTests(TestCase):
@@ -328,8 +345,10 @@ class PowersetTests(TestCase):
     def test_combinatorics(self):
         """Ensure a proper enumeration"""
         p = powerset([1, 2, 3])
-        eq_(list(p),
-            [(), (1,), (2,), (3,), (1, 2), (1, 3), (2, 3), (1, 2, 3)])
+        self.assertEqual(
+            list(p),
+            [(), (1,), (2,), (3,), (1, 2), (1, 3), (2, 3), (1, 2, 3)]
+        )
 
 
 class UniqueEverseenTests(TestCase):
@@ -338,25 +357,27 @@ class UniqueEverseenTests(TestCase):
     def test_everseen(self):
         """ensure duplicate elements are ignored"""
         u = unique_everseen('AAAABBBBCCDAABBB')
-        eq_(['A', 'B', 'C', 'D'],
-            list(u))
+        self.assertEqual(
+            ['A', 'B', 'C', 'D'],
+            list(u)
+        )
 
     def test_custom_key(self):
         """ensure the custom key comparison works"""
         u = unique_everseen('aAbACCc', key=str.lower)
-        eq_(list('abC'), list(u))
+        self.assertEqual(list('abC'), list(u))
 
     def test_unhashable(self):
         """ensure things work for unhashable items"""
         iterable = ['a', [1, 2, 3], [1, 2, 3], 'a']
         u = unique_everseen(iterable)
-        eq_(list(u), ['a', [1, 2, 3]])
+        self.assertEqual(list(u), ['a', [1, 2, 3]])
 
     def test_unhashable_key(self):
         """ensure things work for unhashable items with a custom key"""
         iterable = ['a', [1, 2, 3], [1, 2, 3], 'a']
         u = unique_everseen(iterable, key=lambda x: x)
-        eq_(list(u), ['a', [1, 2, 3]])
+        self.assertEqual(list(u), ['a', [1, 2, 3]])
 
 
 class UniqueJustseenTests(TestCase):
@@ -365,12 +386,12 @@ class UniqueJustseenTests(TestCase):
     def test_justseen(self):
         """ensure only last item is remembered"""
         u = unique_justseen('AAAABBBCCDABB')
-        eq_(list('ABCDAB'), list(u))
+        self.assertEqual(list('ABCDAB'), list(u))
 
     def test_custom_key(self):
         """ensure the custom key comparison works"""
         u = unique_justseen('AABCcAD', str.lower)
-        eq_(list('ABCAD'), list(u))
+        self.assertEqual(list('ABCAD'), list(u))
 
 
 class IterExceptTests(TestCase):
@@ -380,26 +401,26 @@ class IterExceptTests(TestCase):
         """ensure the exact specified exception is caught"""
         l = [1, 2, 3]
         i = iter_except(l.pop, IndexError)
-        eq_(list(i), [3, 2, 1])
+        self.assertEqual(list(i), [3, 2, 1])
 
     def test_generic_exception(self):
         """ensure the generic exception can be caught"""
         l = [1, 2]
         i = iter_except(l.pop, Exception)
-        eq_(list(i), [2, 1])
+        self.assertEqual(list(i), [2, 1])
 
     def test_uncaught_exception_is_raised(self):
         """ensure a non-specified exception is raised"""
         l = [1, 2, 3]
         i = iter_except(l.pop, KeyError)
-        assert_raises(IndexError, list, i)
+        self.assertRaises(IndexError, lambda: list(i))
 
     def test_first(self):
         """ensure first is run before the function"""
         l = [1, 2, 3]
         f = lambda: 25
         i = iter_except(l.pop, IndexError, f)
-        eq_(list(i), [25, 3, 2, 1])
+        self.assertEqual(list(i), [25, 3, 2, 1])
 
 
 class FirstTrueTests(TestCase):
@@ -407,19 +428,19 @@ class FirstTrueTests(TestCase):
 
     def test_something_true(self):
         """Test with no keywords"""
-        eq_(first_true(range(10)), 1)
+        self.assertEqual(first_true(range(10)), 1)
 
     def test_nothing_true(self):
         """Test default return value."""
-        eq_(first_true([0, 0, 0]), False)
+        self.assertEqual(first_true([0, 0, 0]), False)
 
     def test_default(self):
         """Test with a default keyword"""
-        eq_(first_true([0, 0, 0], default='!'), '!')
+        self.assertEqual(first_true([0, 0, 0], default='!'), '!')
 
     def test_pred(self):
         """Test with a custom predicate"""
-        eq_(first_true([2, 4, 6], pred=lambda x: x % 3 == 0), 6)
+        self.assertEqual(first_true([2, 4, 6], pred=lambda x: x % 3 == 0), 6)
 
 
 class RandomProductTests(TestCase):
@@ -444,10 +465,10 @@ class RandomProductTests(TestCase):
         lets = ['a', 'b', 'c']
         n, m = zip(*[random_product(nums, lets) for _ in range(100)])
         n, m = set(n), set(m)
-        eq_(n, set(nums))
-        eq_(m, set(lets))
-        eq_(len(n), len(nums))
-        eq_(len(m), len(lets))
+        self.assertEqual(n, set(nums))
+        self.assertEqual(m, set(lets))
+        self.assertEqual(len(n), len(nums))
+        self.assertEqual(len(m), len(lets))
 
     def test_list_with_repeat(self):
         """ensure multiple items are chosen, and that they appear to be chosen
@@ -457,12 +478,12 @@ class RandomProductTests(TestCase):
         nums = [1, 2, 3]
         lets = ['a', 'b', 'c']
         r = list(random_product(nums, lets, repeat=100))
-        eq_(2 * 100, len(r))
+        self.assertEqual(2 * 100, len(r))
         n, m = set(r[::2]), set(r[1::2])
-        eq_(n, set(nums))
-        eq_(m, set(lets))
-        eq_(len(n), len(nums))
-        eq_(len(m), len(lets))
+        self.assertEqual(n, set(nums))
+        self.assertEqual(m, set(lets))
+        self.assertEqual(len(n), len(nums))
+        self.assertEqual(len(m), len(lets))
 
 
 class RandomPermutationTests(TestCase):
@@ -477,7 +498,7 @@ class RandomPermutationTests(TestCase):
         """
         i = range(15)
         r = random_permutation(i)
-        eq_(set(i), set(r))
+        self.assertEqual(set(i), set(r))
         if i == r:
             raise AssertionError("Values were not permuted")
 
@@ -497,11 +518,11 @@ class RandomPermutationTests(TestCase):
         all_items = set()
         for _ in range(100):
             permutation = random_permutation(items, 5)
-            eq_(len(permutation), 5)
+            self.assertEqual(len(permutation), 5)
             permutation_set = set(permutation)
-            ok_(permutation_set <= item_set)
+            self.assertLessEqual(permutation_set, item_set)
             all_items |= permutation_set
-        eq_(all_items, item_set)
+        self.assertEqual(all_items, item_set)
 
 
 class RandomCombinationTests(TestCase):
@@ -515,15 +536,17 @@ class RandomCombinationTests(TestCase):
         for _ in range(50):
             combination = random_combination(items, 5)
             all_items |= set(combination)
-        eq_(all_items, set(items))
+        self.assertEqual(all_items, set(items))
 
     def test_no_replacement(self):
         """ensure that elements are sampled without replacement"""
         items = range(15)
         for _ in range(50):
             combination = random_combination(items, len(items))
-            eq_(len(combination), len(set(combination)))
-        assert_raises(ValueError, random_combination, items, len(items) + 1)
+            self.assertEqual(len(combination), len(set(combination)))
+        self.assertRaises(
+            ValueError, lambda: random_combination(items, len(items) + 1)
+        )
 
 
 class RandomCombinationWithReplacementTests(TestCase):
@@ -533,7 +556,7 @@ class RandomCombinationWithReplacementTests(TestCase):
         """ensure that elements are sampled with replacement"""
         items = range(5)
         combo = random_combination_with_replacement(items, len(items) * 2)
-        eq_(2 * len(items), len(combo))
+        self.assertEqual(2 * len(items), len(combo))
         if len(set(combo)) == len(combo):
             raise AssertionError("Combination contained no duplicates")
 
@@ -545,4 +568,4 @@ class RandomCombinationWithReplacementTests(TestCase):
         for _ in range(50):
             combination = random_combination_with_replacement(items, 5)
             all_items |= set(combination)
-        eq_(all_items, set(items))
+        self.assertEqual(all_items, set(items))

--- a/setup.py
+++ b/setup.py
@@ -22,8 +22,7 @@ setup(
     license='MIT',
     packages=find_packages(exclude=['ez_setup']),
     install_requires=['six>=1.0.0,<2.0.0'],
-    tests_require=['nose'],
-    test_suite='nose.collector',
+    test_suite='more_itertools.tests',
     url='https://github.com/erikrose/more-itertools',
     include_package_data=True,
     classifiers=[

--- a/tox.ini
+++ b/tox.ini
@@ -1,13 +1,5 @@
 [tox]
 envlist = py27, py32, py33, py34, py35
 
-[tox:travis]
-2.7 = py27
-3.3 = py33
-3.4 = py34
-3.5 = py35
-
 [testenv]
-commands = nosetests more_itertools --with-doctest
-deps = nose
-changedir = .tox
+commands = {envbindir}/python -m unittest discover -v


### PR DESCRIPTION
Issue #51 attempted to remove `nose`. I [said](https://github.com/erikrose/more-itertools/pull/51#issuecomment-258636373) at the time that I would "get to a place where testing is possible with built-in tools." This PR gets us most of the way to that place.

A few points:
* The test modules have had several authors, some using `nose`'s methods and some using `unittest`'s, some using classes and some using functions, etc. Now everything using `unittest` methods and classes.
* `nose` was being used to run the doctests. I've switched to the [`unittest` + `doctest` method](https://docs.python.org/2/library/doctest.html#unittest-api)
* I'm inclined to remove `tox`, but [I said I wouldn't once before](https://github.com/erikrose/more-itertools/pull/61#issuecomment-258627046). It's confined to manual tests; as of PR #111 it's not used by Travis.

Eventually I will clean up tests a bit more.

__BONUS__: 0732f27 resolves issue #161.