### PR TITLE
Run flake8 style checker in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ python:
 
 install:
     - "pip install ."
-    - "pip install -U coveralls"
+    - "pip install -U coveralls flake8"
 
 script:
     - "coverage run --include='more_itertools/*.py' --omit='more_itertools/tests/*' setup.py test"

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ install:
 
 script:
     - "coverage run --include='more_itertools/*.py' --omit='more_itertools/tests/*' setup.py test"
+    - "flake8 ."
 
 notifications:
   email: false

--- a/more_itertools/__init__.py
+++ b/more_itertools/__init__.py
@@ -1,2 +1,2 @@
-from more_itertools.more import *
-from more_itertools.recipes import *
+from more_itertools.more import *  # noqa
+from more_itertools.recipes import *  # noqa

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -340,7 +340,7 @@ def collate(*iterables, **kwargs):
 # If using Python version 3.5 or greater, heapq.merge() will be faster than
 # collate - use that instead.
 if version_info >= (3, 5, 0):
-    collate = merge
+    collate = merge  # noqa
 
 
 def consumer(func):

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -1459,7 +1459,7 @@ def islice_extended(iterable, *args):
             if n <= 0:
                 return
 
-            for index, item in islice(cache, None, n, step):
+            for index, item in islice(cache, 0, n, step):
                 yield item
         elif (stop is not None) and (stop < 0):
             # Advance to the start position

--- a/more_itertools/recipes.py
+++ b/more_itertools/recipes.py
@@ -370,7 +370,7 @@ def unique_everseen(iterable, key=None):
                 if element not in seenset:
                     seenset_add(element)
                     yield element
-            except TypeError as e:
+            except TypeError:
                 if element not in seenlist:
                     seenlist_add(element)
                     yield element

--- a/more_itertools/recipes.py
+++ b/more_itertools/recipes.py
@@ -344,7 +344,7 @@ def powerset(iterable):
 
     """
     s = list(iterable)
-    return chain.from_iterable(combinations(s, r) for r in range(len(s)+1))
+    return chain.from_iterable(combinations(s, r) for r in range(len(s) + 1))
 
 
 def unique_everseen(iterable, key=None):

--- a/more_itertools/recipes.py
+++ b/more_itertools/recipes.py
@@ -381,7 +381,7 @@ def unique_everseen(iterable, key=None):
                 if k not in seenset:
                     seenset_add(k)
                     yield element
-            except TypeError as e:
+            except TypeError:
                 if k not in seenlist:
                     seenlist_add(k)
                     yield element

--- a/more_itertools/tests/test_more.py
+++ b/more_itertools/tests/test_more.py
@@ -833,7 +833,9 @@ class PaddedTest(TestCase):
         self.assertEqual(list(mi.padded(seq, n=5)), [1, 2, 3, 4, 5])
 
         # No fillvalue
-        self.assertEqual(list(mi.padded(seq, n=7)), [1, 2, 3, 4, 5, None, None])
+        self.assertEqual(
+            list(mi.padded(seq, n=7)), [1, 2, 3, 4, 5, None, None]
+        )
 
         # With fillvalue
         self.assertEqual(

--- a/more_itertools/tests/test_more.py
+++ b/more_itertools/tests/test_more.py
@@ -371,7 +371,7 @@ class ConsumerTests(TestCase):
         @mi.consumer
         def eater():
             while True:
-                x = yield
+                x = yield  # noqa
 
         e = eater()
         e.send('hi')  # without @consumer, would raise TypeError

--- a/more_itertools/tests/test_more.py
+++ b/more_itertools/tests/test_more.py
@@ -12,7 +12,7 @@ from unittest import TestCase
 import six
 from six.moves import filter, range, zip
 
-from more_itertools import *  # Test all the symbols are in __all__.
+import more_itertools as mi
 
 
 def load_tests(loader, tests, ignore):
@@ -30,7 +30,7 @@ class CollateTests(TestCase):
         iterables = [range(4), range(7), range(3, 6)]
         self.assertEqual(
             sorted(reduce(list.__add__, [list(it) for it in iterables])),
-            list(collate(*iterables))
+            list(mi.collate(*iterables))
         )
 
     def test_key(self):
@@ -39,16 +39,16 @@ class CollateTests(TestCase):
         actual = sorted(
             reduce(list.__add__, [list(it) for it in iterables]), reverse=True
         )
-        expected = list(collate(*iterables, key=lambda x: -x))
+        expected = list(mi.collate(*iterables, key=lambda x: -x))
         self.assertEqual(actual, expected)
 
     def test_empty(self):
         """Be nice if passed an empty list of iterables."""
-        self.assertEqual([], list(collate()))
+        self.assertEqual([], list(mi.collate()))
 
     def test_one(self):
         """Work when only 1 iterable is passed."""
-        self.assertEqual([0, 1], list(collate(range(2))))
+        self.assertEqual([0, 1], list(mi.collate(range(2))))
 
     def test_reverse(self):
         """Test the `reverse` kwarg."""
@@ -57,7 +57,7 @@ class CollateTests(TestCase):
         actual = sorted(
             reduce(list.__add__, [list(it) for it in iterables]), reverse=True
         )
-        expected = list(collate(*iterables, reverse=True))
+        expected = list(mi.collate(*iterables, reverse=True))
         self.assertEqual(actual, expected)
 
 
@@ -67,7 +67,7 @@ class ChunkedTests(TestCase):
     def test_even(self):
         """Test when ``n`` divides evenly into the length of the iterable."""
         self.assertEqual(
-            list(chunked('ABCDEF', 3)), [['A', 'B', 'C'], ['D', 'E', 'F']]
+            list(mi.chunked('ABCDEF', 3)), [['A', 'B', 'C'], ['D', 'E', 'F']]
         )
 
     def test_odd(self):
@@ -76,7 +76,7 @@ class ChunkedTests(TestCase):
 
         """
         self.assertEqual(
-            list(chunked('ABCDE', 3)), [['A', 'B', 'C'], ['D', 'E']]
+            list(mi.chunked('ABCDE', 3)), [['A', 'B', 'C'], ['D', 'E']]
         )
 
 
@@ -87,19 +87,19 @@ class FirstTests(TestCase):
         """Test that it works on many-item iterables."""
         # Also try it on a generator expression to make sure it works on
         # whatever those return, across Python versions.
-        self.assertEqual(first(x for x in range(4)), 0)
+        self.assertEqual(mi.first(x for x in range(4)), 0)
 
     def test_one(self):
         """Test that it doesn't raise StopIteration prematurely."""
-        self.assertEqual(first([3]), 3)
+        self.assertEqual(mi.first([3]), 3)
 
     def test_empty_stop_iteration(self):
         """It should raise StopIteration for empty iterables."""
-        self.assertRaises(ValueError, lambda: first([]))
+        self.assertRaises(ValueError, lambda: mi.first([]))
 
     def test_default(self):
         """It should return the provided default arg for empty iterables."""
-        self.assertEqual(first([], 'boo'), 'boo')
+        self.assertEqual(mi.first([], 'boo'), 'boo')
 
 
 class PeekableTests(TestCase):
@@ -109,7 +109,7 @@ class PeekableTests(TestCase):
     """
     def test_peek_default(self):
         """Make sure passing a default into ``peek()`` works."""
-        p = peekable([])
+        p = mi.peekable([])
         self.assertEqual(p.peek(7), 7)
 
     def test_truthiness(self):
@@ -117,9 +117,10 @@ class PeekableTests(TestCase):
         the iterable.
 
         """
-        p = peekable([])
+        p = mi.peekable([])
         self.assertFalse(p)
-        p = peekable(range(3))
+
+        p = mi.peekable(range(3))
         self.assertTrue(p)
 
     def test_simple_peeking(self):
@@ -127,7 +128,7 @@ class PeekableTests(TestCase):
         iterator, respectively.
 
         """
-        p = peekable(range(10))
+        p = mi.peekable(range(10))
         self.assertEqual(next(p), 0)
         self.assertEqual(p.peek(), 1)
         self.assertEqual(next(p), 1)
@@ -136,7 +137,7 @@ class PeekableTests(TestCase):
         """
         Indexing into the peekable shouldn't advance the iterator.
         """
-        p = peekable('abcdefghijkl')
+        p = mi.peekable('abcdefghijkl')
 
         # The 0th index is what ``next()`` will return
         self.assertEqual(p[0], 'a')
@@ -161,7 +162,7 @@ class PeekableTests(TestCase):
     def test_slicing(self):
         """Slicing the peekable shouldn't advance the iterator."""
         seq = list('abcdefghijkl')
-        p = peekable(seq)
+        p = mi.peekable(seq)
 
         # Slicing the peekable should just be like slicing a re-iterable
         self.assertEqual(p[1:4], seq[1:4])
@@ -188,7 +189,7 @@ class PeekableTests(TestCase):
         steps = [1, 2, 3, 4, -1, -2, -3, 4]
         for slice_args in product(indexes, indexes, steps):
             it = iter(iterable)
-            p = peekable(it)
+            p = mi.peekable(it)
             next(p)
             index = slice(*slice_args)
             actual = p[index]
@@ -197,7 +198,7 @@ class PeekableTests(TestCase):
 
     def test_slicing_error(self):
         iterable = '01234567'
-        p = peekable(iter(iterable))
+        p = mi.peekable(iter(iterable))
 
         # Prime the cache
         p.peek()
@@ -216,14 +217,14 @@ class PeekableTests(TestCase):
         should just give the underlying iterable's elements (a trivial test but
         useful to set a baseline in case something goes wrong)"""
         expected = [1, 2, 3, 4, 5]
-        actual = list(peekable(expected))
+        actual = list(mi.peekable(expected))
         self.assertEqual(actual, expected)
 
     # prepend() behavior tests
 
     def test_prepend(self):
         """Tests intersperesed ``prepend()`` and ``next()`` calls"""
-        it = peekable(range(2))
+        it = mi.peekable(range(2))
         actual = []
 
         # Test prepend() before next()
@@ -243,7 +244,7 @@ class PeekableTests(TestCase):
 
     def test_multi_prepend(self):
         """Tests prepending multiple items and getting them in proper order"""
-        it = peekable(range(5))
+        it = mi.peekable(range(5))
         actual = [next(it), next(it)]
         it.prepend(10, 11, 12)
         it.prepend(20, 21)
@@ -253,7 +254,7 @@ class PeekableTests(TestCase):
 
     def test_empty(self):
         """Tests prepending in front of an empty iterable"""
-        it = peekable([])
+        it = mi.peekable([])
         it.prepend(10)
         actual = list(it)
         expected = [10]
@@ -262,7 +263,7 @@ class PeekableTests(TestCase):
     def test_prepend_truthiness(self):
         """Tests that ``__bool__()`` or ``__nonzero__()`` works properly
         with ``prepend()``"""
-        it = peekable(range(5))
+        it = mi.peekable(range(5))
         self.assertTrue(it)
         actual = list(it)
         self.assertFalse(it)
@@ -276,7 +277,7 @@ class PeekableTests(TestCase):
     def test_multi_prepend_peek(self):
         """Tests prepending multiple elements and getting them in reverse order
         while peeking"""
-        it = peekable(range(5))
+        it = mi.peekable(range(5))
         actual = [next(it), next(it)]
         self.assertEqual(it.peek(), 2)
         it.prepend(10, 11, 12)
@@ -290,7 +291,7 @@ class PeekableTests(TestCase):
 
     def test_prepend_after_stop(self):
         """Test resuming iteration after a previous exhaustion"""
-        it = peekable(range(3))
+        it = mi.peekable(range(3))
         self.assertEqual(list(it), [0, 1, 2])
         self.assertRaises(StopIteration, lambda: next(it))
         it.prepend(10)
@@ -300,7 +301,7 @@ class PeekableTests(TestCase):
     def test_prepend_slicing(self):
         """Tests interaction between prepending and slicing"""
         seq = list(range(20))
-        p = peekable(seq)
+        p = mi.peekable(seq)
 
         p.prepend(30, 40, 50)
         pseq = [30, 40, 50] + seq  # pseq for prepended_seq
@@ -318,7 +319,7 @@ class PeekableTests(TestCase):
     def test_prepend_indexing(self):
         """Tests interaction between prepending and indexing"""
         seq = list(range(20))
-        p = peekable(seq)
+        p = mi.peekable(seq)
 
         p.prepend(30, 40, 50)
 
@@ -336,7 +337,7 @@ class PeekableTests(TestCase):
 
     def test_prepend_iterable(self):
         """Tests prepending from an iterable"""
-        it = peekable(range(5))
+        it = mi.peekable(range(5))
         # Don't directly use the range() object to avoid any range-specific
         # optimizations
         it.prepend(*(x for x in range(5)))
@@ -346,7 +347,7 @@ class PeekableTests(TestCase):
 
     def test_prepend_many(self):
         """Tests that prepending a huge number of elements works"""
-        it = peekable(range(5))
+        it = mi.peekable(range(5))
         # Don't directly use the range() object to avoid any range-specific
         # optimizations
         it.prepend(*(x for x in range(20000)))
@@ -356,7 +357,7 @@ class PeekableTests(TestCase):
 
     def test_prepend_reversed(self):
         """Tests prepending from a reversed iterable"""
-        it = peekable(range(3))
+        it = mi.peekable(range(3))
         it.prepend(*reversed((10, 11, 12)))
         actual = list(it)
         expected = [12, 11, 10, 0, 1, 2]
@@ -367,7 +368,7 @@ class ConsumerTests(TestCase):
     """Tests for ``consumer()``"""
 
     def test_consumer(self):
-        @consumer
+        @mi.consumer
         def eater():
             while True:
                 x = yield
@@ -383,7 +384,7 @@ class DistinctPermutationsTests(TestCase):
 
         """
         iterable = ['z', 'a', 'a', 'q', 'q', 'q', 'y']
-        test_output = sorted(distinct_permutations(iterable))
+        test_output = sorted(mi.distinct_permutations(iterable))
         ref_output = sorted(set(permutations(iterable)))
         self.assertEqual(test_output, ref_output)
 
@@ -392,19 +393,21 @@ class IlenTests(TestCase):
     def test_ilen(self):
         """Sanity-checks for ``ilen()``."""
         # Non-empty
-        self.assertEqual(ilen(filter(lambda x: x % 10 == 0, range(101))), 11)
+        self.assertEqual(
+            mi.ilen(filter(lambda x: x % 10 == 0, range(101))), 11
+        )
 
         # Empty
-        self.assertEqual(ilen((x for x in range(0))), 0)
+        self.assertEqual(mi.ilen((x for x in range(0))), 0)
 
         # Iterable with __len__
-        self.assertEqual(ilen(list(range(6))), 6)
+        self.assertEqual(mi.ilen(list(range(6))), 6)
 
 
 class WithIterTests(TestCase):
     def test_with_iter(self):
         s = StringIO('One fish\nTwo fish')
-        initial_words = [line.split()[0] for line in with_iter(s)]
+        initial_words = [line.split()[0] for line in mi.with_iter(s)]
 
         # Iterable's items should be faithfully represented
         self.assertEqual(initial_words, ['One', 'Two'])
@@ -417,7 +420,7 @@ class OneTests(TestCase):
         """Test the ``one()`` cases that aren't covered by its doctests."""
         # Infinite iterables
         numbers = count()
-        self.assertRaises(ValueError, lambda: one(numbers))  # burn 0 and 1
+        self.assertRaises(ValueError, lambda: mi.one(numbers))  # burn 0 and 1
         self.assertEqual(next(numbers), 2)
 
 
@@ -426,23 +429,25 @@ class IntersperseTest(TestCase):
 
     def test_even(self):
         iterable = (x for x in '01')
-        self.assertEqual(list(intersperse(None, iterable)), ['0', None, '1'])
+        self.assertEqual(
+            list(mi.intersperse(None, iterable)), ['0', None, '1']
+        )
 
     def test_odd(self):
         iterable = (x for x in '012')
         self.assertEqual(
-            list(intersperse(None, iterable)), ['0', None, '1', None, '2']
+            list(mi.intersperse(None, iterable)), ['0', None, '1', None, '2']
         )
 
     def test_nested(self):
         element = ('a', 'b')
         iterable = (x for x in '012')
-        actual = list(intersperse(element, iterable))
+        actual = list(mi.intersperse(element, iterable))
         expected = ['0', ('a', 'b'), '1', ('a', 'b'), '2']
         self.assertEqual(actual, expected)
 
     def test_not_iterable(self):
-        self.assertRaises(TypeError, lambda: intersperse('x', 1))
+        self.assertRaises(TypeError, lambda: mi.intersperse('x', 1))
 
     def test_n(self):
         for n, element, expected in [
@@ -456,12 +461,12 @@ class IntersperseTest(TestCase):
             (3, ['a', 'b'], ['0', '1', '2', ['a', 'b'], '3', '4', '5']),
         ]:
             iterable = (x for x in '012345')
-            actual = list(intersperse(element, iterable, n=n))
+            actual = list(mi.intersperse(element, iterable, n=n))
             self.assertEqual(actual, expected)
 
     def test_n_zero(self):
         self.assertRaises(
-            ValueError, lambda: list(intersperse('x', '012', n=0))
+            ValueError, lambda: list(mi.intersperse('x', '012', n=0))
         )
 
 
@@ -472,28 +477,28 @@ class UniqueToEachTests(TestCase):
         """When all the input iterables are unique the output should match
         the input."""
         iterables = [[1, 2], [3, 4, 5], [6, 7, 8]]
-        self.assertEqual(unique_to_each(*iterables), iterables)
+        self.assertEqual(mi.unique_to_each(*iterables), iterables)
 
     def test_duplicates(self):
         """When there are duplicates in any of the input iterables that aren't
         in the rest, those duplicates should be emitted."""
         iterables = ["mississippi", "missouri"]
         self.assertEqual(
-            unique_to_each(*iterables), [['p', 'p'], ['o', 'u', 'r']]
+            mi.unique_to_each(*iterables), [['p', 'p'], ['o', 'u', 'r']]
         )
 
     def test_mixed(self):
         """When the input iterables contain different types the function should
         still behave properly"""
         iterables = ['x', (i for i in range(3)), [1, 2, 3], tuple()]
-        self.assertEqual(unique_to_each(*iterables), [['x'], [0], [3], []])
+        self.assertEqual(mi.unique_to_each(*iterables), [['x'], [0], [3], []])
 
 
 class WindowedTests(TestCase):
     """Tests for ``windowed()``"""
 
     def test_basic(self):
-        actual = list(windowed([1, 2, 3, 4, 5], 3))
+        actual = list(mi.windowed([1, 2, 3, 4, 5], 3))
         expected = [(1, 2, 3), (2, 3, 4), (3, 4, 5)]
         self.assertEqual(actual, expected)
 
@@ -502,7 +507,7 @@ class WindowedTests(TestCase):
         When the window size is larger than the iterable, and no fill value is
         given,``None`` should be filled in.
         """
-        actual = list(windowed([1, 2, 3, 4, 5], 6))
+        actual = list(mi.windowed([1, 2, 3, 4, 5], 6))
         expected = [(1, 2, 3, 4, 5, None)]
         self.assertEqual(actual, expected)
 
@@ -516,19 +521,19 @@ class WindowedTests(TestCase):
             (6, {}, [(1, 2, 3, 4, 5, '!')]),  # n > len(iterable)
             (3, {'step': 3}, [(1, 2, 3), (4, 5, '!')]),  # using ``step``
         ]:
-            actual = list(windowed(iterable, n, fillvalue='!', **kwargs))
+            actual = list(mi.windowed(iterable, n, fillvalue='!', **kwargs))
             self.assertEqual(actual, expected)
 
     def test_zero(self):
         """When the window size is zero, an empty tuple should be emitted."""
-        actual = list(windowed([1, 2, 3, 4, 5], 0))
+        actual = list(mi.windowed([1, 2, 3, 4, 5], 0))
         expected = [tuple()]
         self.assertEqual(actual, expected)
 
     def test_negative(self):
         """When the window size is negative, ValueError should be raised."""
         with self.assertRaises(ValueError):
-            list(windowed([1, 2, 3, 4, 5], -1))
+            list(mi.windowed([1, 2, 3, 4, 5], -1))
 
     def test_step(self):
         """The window should advance by the number of steps provided"""
@@ -542,12 +547,12 @@ class WindowedTests(TestCase):
             (3, 7, [(1, 2, 3)]),  # step past the end
             (7, 8, [(1, 2, 3, 4, 5, 6, 7)]),  # step > len(iterable)
         ]:
-            actual = list(windowed(iterable, n, step=step))
+            actual = list(mi.windowed(iterable, n, step=step))
             self.assertEqual(actual, expected)
 
         # Step must be greater than or equal to 1
         with self.assertRaises(ValueError):
-            list(windowed(iterable, 3, step=0))
+            list(mi.windowed(iterable, 3, step=0))
 
 
 class BucketTests(TestCase):
@@ -555,7 +560,7 @@ class BucketTests(TestCase):
 
     def test_basic(self):
         iterable = [10, 20, 30, 11, 21, 31, 12, 22, 23, 33]
-        D = bucket(iterable, key=lambda x: 10 * (x // 10))
+        D = mi.bucket(iterable, key=lambda x: 10 * (x // 10))
 
         # In-order access
         self.assertEqual(list(D[10]), [10, 11, 12])
@@ -568,7 +573,7 @@ class BucketTests(TestCase):
 
     def test_in(self):
         iterable = [10, 20, 30, 11, 21, 31, 12, 22, 23, 33]
-        D = bucket(iterable, key=lambda x: 10 * (x // 10))
+        D = mi.bucket(iterable, key=lambda x: 10 * (x // 10))
 
         self.assertTrue(10 in D)
         self.assertFalse(40 in D)
@@ -584,7 +589,7 @@ class SpyTests(TestCase):
 
     def test_basic(self):
         original_iterable = iter('abcdefg')
-        head, new_iterable = spy(original_iterable)
+        head, new_iterable = mi.spy(original_iterable)
         self.assertEqual(head, ['a'])
         self.assertEqual(
             list(new_iterable), ['a', 'b', 'c', 'd', 'e', 'f', 'g']
@@ -592,7 +597,7 @@ class SpyTests(TestCase):
 
     def test_unpacking(self):
         original_iterable = iter('abcdefg')
-        (first, second, third), new_iterable = spy(original_iterable, 3)
+        (first, second, third), new_iterable = mi.spy(original_iterable, 3)
         self.assertEqual(first, 'a')
         self.assertEqual(second, 'b')
         self.assertEqual(third, 'c')
@@ -602,13 +607,13 @@ class SpyTests(TestCase):
 
     def test_too_many(self):
         original_iterable = iter('abc')
-        head, new_iterable = spy(original_iterable, 4)
+        head, new_iterable = mi.spy(original_iterable, 4)
         self.assertEqual(head, ['a', 'b', 'c'])
         self.assertEqual(list(new_iterable), ['a', 'b', 'c'])
 
     def test_zero(self):
         original_iterable = iter('abc')
-        head, new_iterable = spy(original_iterable, 0)
+        head, new_iterable = mi.spy(original_iterable, 0)
         self.assertEqual(head, [])
         self.assertEqual(list(new_iterable), ['a', 'b', 'c'])
 
@@ -618,24 +623,28 @@ class TestInterleave(TestCase):
 
     def test_interleave(self):
         l = [[1, 2, 3], [4, 5], [6, 7, 8]]
-        self.assertEqual(list(interleave(*l)), [1, 4, 6, 2, 5, 7])
+        self.assertEqual(list(mi.interleave(*l)), [1, 4, 6, 2, 5, 7])
+
         l = [[1, 2], [3, 4, 5], [6, 7, 8]]
-        self.assertEqual(list(interleave(*l)), [1, 3, 6, 2, 4, 7])
+        self.assertEqual(list(mi.interleave(*l)), [1, 3, 6, 2, 4, 7])
+
         l = [[1, 2, 3], [4, 5, 6], [7, 8]]
-        self.assertEqual(list(interleave(*l)), [1, 4, 7, 2, 5, 8])
+        self.assertEqual(list(mi.interleave(*l)), [1, 4, 7, 2, 5, 8])
 
     def test_interleave_longest(self):
         l = [[1, 2, 3], [4, 5], [6, 7, 8]]
         self.assertEqual(
-            list(interleave_longest(*l)), [1, 4, 6, 2, 5, 7, 3, 8]
+            list(mi.interleave_longest(*l)), [1, 4, 6, 2, 5, 7, 3, 8]
         )
+
         l = [[1, 2], [3, 4, 5], [6, 7, 8]]
         self.assertEqual(
-            list(interleave_longest(*l)), [1, 3, 6, 2, 4, 7, 5, 8]
+            list(mi.interleave_longest(*l)), [1, 3, 6, 2, 4, 7, 5, 8]
         )
+
         l = [[1, 2, 3], [4, 5, 6], [7, 8]]
         self.assertEqual(
-            list(interleave_longest(*l)), [1, 4, 7, 2, 5, 8, 3, 6]
+            list(mi.interleave_longest(*l)), [1, 4, 7, 2, 5, 8, 3, 6]
         )
 
 
@@ -644,27 +653,27 @@ class TestCollapse(TestCase):
 
     def test_collapse(self):
         l = [[1], 2, [[3], 4], [[[5]]]]
-        self.assertEqual(list(collapse(l)), [1, 2, 3, 4, 5])
+        self.assertEqual(list(mi.collapse(l)), [1, 2, 3, 4, 5])
 
     def test_collapse_to_string(self):
         l = [["s1"], "s2", [["s3"], "s4"], [[["s5"]]]]
-        self.assertEqual(list(collapse(l)), ["s1", "s2", "s3", "s4", "s5"])
+        self.assertEqual(list(mi.collapse(l)), ["s1", "s2", "s3", "s4", "s5"])
 
     def test_collapse_flatten(self):
         l = [[1], [2], [[3], 4], [[[5]]]]
-        self.assertEqual(list(collapse(l, levels=1)), list(flatten(l)))
+        self.assertEqual(list(mi.collapse(l, levels=1)), list(mi.flatten(l)))
 
     def test_collapse_to_level(self):
         l = [[1], 2, [[3], 4], [[[5]]]]
-        self.assertEqual(list(collapse(l, levels=2)), [1, 2, 3, 4, [5]])
+        self.assertEqual(list(mi.collapse(l, levels=2)), [1, 2, 3, 4, [5]])
         self.assertEqual(
-            list(collapse(collapse(l, levels=1), levels=1)),
-            list(collapse(l, levels=2))
+            list(mi.collapse(mi.collapse(l, levels=1), levels=1)),
+            list(mi.collapse(l, levels=2))
         )
 
     def test_collapse_to_list(self):
         l = (1, [2], (3, [4, (5,)], 'ab'))
-        actual = list(collapse(l, base_type=list))
+        actual = list(mi.collapse(l, base_type=list))
         expected = [1, [2], 3, [4, (5,)], 'ab']
         self.assertEqual(actual, expected)
 
@@ -679,7 +688,7 @@ class SideEffectTests(TestCase):
         def func(arg):
             counter[0] += 1
 
-        result = list(side_effect(func, range(10)))
+        result = list(mi.side_effect(func, range(10)))
         self.assertEqual(result, list(range(10)))
         self.assertEqual(counter[0], 10)
 
@@ -690,7 +699,7 @@ class SideEffectTests(TestCase):
         def func(arg):
             counter[0] += 1
 
-        result = list(side_effect(func, range(10), 2))
+        result = list(mi.side_effect(func, range(10), 2))
         self.assertEqual(result, list(range(10)))
         self.assertEqual(counter[0], 5)
 
@@ -705,14 +714,14 @@ class SideEffectTests(TestCase):
         def it():
             yield u'a'
             yield u'b'
-            raise Exception('kaboom')
+            raise RuntimeError('kaboom')
 
         before = lambda: print('HEADER', file=f)
         after = f.close
 
         try:
-            consume(side_effect(func, it(), before=before, after=after))
-        except Exception:
+            mi.consume(mi.side_effect(func, it(), before=before, after=after))
+        except RuntimeError:
             pass
 
         # The iterable should have been written to the file
@@ -726,11 +735,13 @@ class SideEffectTests(TestCase):
         func = lambda x: print(x, file=f)
 
         def before():
-            raise Exception('ouch')
+            raise RuntimeError('ouch')
 
         try:
-            consume(side_effect(func, u'abc', before=before, after=f.close))
-        except Exception:
+            mi.consume(
+                mi.side_effect(func, u'abc', before=before, after=f.close)
+            )
+        except RuntimeError:
             pass
 
         # The file should be closed even though something bad happened in the
@@ -744,35 +755,35 @@ class SlicedTests(TestCase):
     def test_even(self):
         """Test when the length of the sequence is divisible by *n*"""
         seq = 'ABCDEFGHI'
-        self.assertEqual(list(sliced(seq, 3)), ['ABC', 'DEF', 'GHI'])
+        self.assertEqual(list(mi.sliced(seq, 3)), ['ABC', 'DEF', 'GHI'])
 
     def test_odd(self):
         """Test when the length of the sequence is not divisible by *n*"""
         seq = 'ABCDEFGHI'
-        self.assertEqual(list(sliced(seq, 4)), ['ABCD', 'EFGH', 'I'])
+        self.assertEqual(list(mi.sliced(seq, 4)), ['ABCD', 'EFGH', 'I'])
 
     def test_not_sliceable(self):
         seq = (x for x in 'ABCDEFGHI')
 
         with self.assertRaises(TypeError):
-            list(sliced(seq, 3))
+            list(mi.sliced(seq, 3))
 
 
 class SplitBeforeTest(TestCase):
     """Tests for ``split_before()``"""
 
     def test_starts_with_sep(self):
-        actual = list(split_before('xooxoo', lambda c: c == 'x'))
+        actual = list(mi.split_before('xooxoo', lambda c: c == 'x'))
         expected = [['x', 'o', 'o'], ['x', 'o', 'o']]
         self.assertEqual(actual, expected)
 
     def test_ends_with_sep(self):
-        actual = list(split_before('ooxoox', lambda c: c == 'x'))
+        actual = list(mi.split_before('ooxoox', lambda c: c == 'x'))
         expected = [['o', 'o'], ['x', 'o', 'o'], ['x']]
         self.assertEqual(actual, expected)
 
     def test_no_sep(self):
-        actual = list(split_before('ooo', lambda c: c == 'x'))
+        actual = list(mi.split_before('ooo', lambda c: c == 'x'))
         expected = [['o', 'o', 'o']]
         self.assertEqual(actual, expected)
 
@@ -781,17 +792,17 @@ class SplitAfterTest(TestCase):
     """Tests for ``split_after()``"""
 
     def test_starts_with_sep(self):
-        actual = list(split_after('xooxoo', lambda c: c == 'x'))
+        actual = list(mi.split_after('xooxoo', lambda c: c == 'x'))
         expected = [['x'], ['o', 'o', 'x'], ['o', 'o']]
         self.assertEqual(actual, expected)
 
     def test_ends_with_sep(self):
-        actual = list(split_after('ooxoox', lambda c: c == 'x'))
+        actual = list(mi.split_after('ooxoox', lambda c: c == 'x'))
         expected = [['o', 'o', 'x'], ['o', 'o', 'x']]
         self.assertEqual(actual, expected)
 
     def test_no_sep(self):
-        actual = list(split_after('ooo', lambda c: c == 'x'))
+        actual = list(mi.split_after('ooo', lambda c: c == 'x'))
         expected = [['o', 'o', 'o']]
         self.assertEqual(actual, expected)
 
@@ -803,28 +814,30 @@ class PaddedTest(TestCase):
         seq = [1, 2, 3]
 
         # No fillvalue
-        self.assertEqual(take(5, padded(seq)), [1, 2, 3, None, None])
+        self.assertEqual(mi.take(5, mi.padded(seq)), [1, 2, 3, None, None])
 
         # With fillvalue
-        self.assertEqual(take(5, padded(seq, fillvalue='')), [1, 2, 3, '', ''])
+        self.assertEqual(
+            mi.take(5, mi.padded(seq, fillvalue='')), [1, 2, 3, '', '']
+        )
 
     def test_invalid_n(self):
-        self.assertRaises(ValueError, lambda: list(padded([1, 2, 3], n=-1)))
-        self.assertRaises(ValueError, lambda: list(padded([1, 2, 3], n=0)))
+        self.assertRaises(ValueError, lambda: list(mi.padded([1, 2, 3], n=-1)))
+        self.assertRaises(ValueError, lambda: list(mi.padded([1, 2, 3], n=0)))
 
     def test_valid_n(self):
         seq = [1, 2, 3, 4, 5]
 
         # No need for padding: len(seq) <= n
-        self.assertEqual(list(padded(seq, n=4)), [1, 2, 3, 4, 5])
-        self.assertEqual(list(padded(seq, n=5)), [1, 2, 3, 4, 5])
+        self.assertEqual(list(mi.padded(seq, n=4)), [1, 2, 3, 4, 5])
+        self.assertEqual(list(mi.padded(seq, n=5)), [1, 2, 3, 4, 5])
 
         # No fillvalue
-        self.assertEqual(list(padded(seq, n=7)), [1, 2, 3, 4, 5, None, None])
+        self.assertEqual(list(mi.padded(seq, n=7)), [1, 2, 3, 4, 5, None, None])
 
         # With fillvalue
         self.assertEqual(
-            list(padded(seq, fillvalue='', n=7)), [1, 2, 3, 4, 5, '', '']
+            list(mi.padded(seq, fillvalue='', n=7)), [1, 2, 3, 4, 5, '', '']
         )
 
     def test_next_multiple(self):
@@ -832,29 +845,29 @@ class PaddedTest(TestCase):
 
         # No need for padding: len(seq) % n == 0
         self.assertEqual(
-            list(padded(seq, n=3, next_multiple=True)), [1, 2, 3, 4, 5, 6]
+            list(mi.padded(seq, n=3, next_multiple=True)), [1, 2, 3, 4, 5, 6]
         )
 
         # Padding needed: len(seq) < n
         self.assertEqual(
-            list(padded(seq, n=8, next_multiple=True)),
+            list(mi.padded(seq, n=8, next_multiple=True)),
             [1, 2, 3, 4, 5, 6, None, None]
         )
 
         # No padding needed: len(seq) == n
         self.assertEqual(
-            list(padded(seq, n=6, next_multiple=True)), [1, 2, 3, 4, 5, 6]
+            list(mi.padded(seq, n=6, next_multiple=True)), [1, 2, 3, 4, 5, 6]
         )
 
         # Padding needed: len(seq) > n
         self.assertEqual(
-            list(padded(seq, n=4, next_multiple=True)),
+            list(mi.padded(seq, n=4, next_multiple=True)),
             [1, 2, 3, 4, 5, 6, None, None]
         )
 
         # With fillvalue
         self.assertEqual(
-            list(padded(seq, fillvalue='', n=4, next_multiple=True)),
+            list(mi.padded(seq, fillvalue='', n=4, next_multiple=True)),
             [1, 2, 3, 4, 5, 6, '', '']
         )
 
@@ -863,8 +876,8 @@ class DistributeTest(TestCase):
     """Tests for distribute()"""
 
     def test_invalid_n(self):
-        self.assertRaises(ValueError, lambda: distribute(-1, [1, 2, 3]))
-        self.assertRaises(ValueError, lambda: distribute(0, [1, 2, 3]))
+        self.assertRaises(ValueError, lambda: mi.distribute(-1, [1, 2, 3]))
+        self.assertRaises(ValueError, lambda: mi.distribute(0, [1, 2, 3]))
 
     def test_basic(self):
         iterable = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
@@ -876,13 +889,13 @@ class DistributeTest(TestCase):
             (10, [[n] for n in range(1, 10 + 1)]),
         ]:
             self.assertEqual(
-                [list(x) for x in distribute(n, iterable)], expected
+                [list(x) for x in mi.distribute(n, iterable)], expected
             )
 
     def test_large_n(self):
         iterable = [1, 2, 3, 4]
         self.assertEqual(
-            [list(x) for x in distribute(6, iterable)],
+            [list(x) for x in mi.distribute(6, iterable)],
             [[1], [2], [3], [4], [], []]
         )
 
@@ -892,7 +905,7 @@ class StaggerTest(TestCase):
 
     def test_default(self):
         iterable = [0, 1, 2, 3]
-        actual = list(stagger(iterable))
+        actual = list(mi.stagger(iterable))
         expected = [(None, 0, 1), (0, 1, 2), (1, 2, 3)]
         self.assertEqual(actual, expected)
 
@@ -903,7 +916,7 @@ class StaggerTest(TestCase):
             ((-2, -1), [('', ''), ('', 0), (0, 1), (1, 2), (2, 3)]),
             ((1, 2), [(1, 2), (2, 3)]),
         ]:
-            all_groups = stagger(iterable, offsets=offsets, fillvalue='')
+            all_groups = mi.stagger(iterable, offsets=offsets, fillvalue='')
             self.assertEqual(list(all_groups), expected)
 
     def test_longest(self):
@@ -916,7 +929,7 @@ class StaggerTest(TestCase):
             ((-2, -1), [('', ''), ('', 0), (0, 1), (1, 2), (2, 3), (3, '')]),
             ((1, 2), [(1, 2), (2, 3), (3, '')]),
         ]:
-            all_groups = stagger(
+            all_groups = mi.stagger(
                 iterable, offsets=offsets, fillvalue='', longest=True
             )
             self.assertEqual(list(all_groups), expected)
@@ -930,7 +943,7 @@ class ZipOffsetTest(TestCase):
         a_2 = [0, 1, 2, 3, 4, 5]
         a_3 = [0, 1, 2, 3, 4, 5, 6, 7]
         actual = list(
-            zip_offset(a_1, a_2, a_3, offsets=(-1, 0, 1), fillvalue='')
+            mi.zip_offset(a_1, a_2, a_3, offsets=(-1, 0, 1), fillvalue='')
         )
         expected = [('', 0, 1), (0, 1, 2), (1, 2, 3), (2, 3, 4), (3, 4, 5)]
         self.assertEqual(actual, expected)
@@ -940,7 +953,7 @@ class ZipOffsetTest(TestCase):
         a_2 = [0, 1, 2, 3, 4, 5]
         a_3 = [0, 1, 2, 3, 4, 5, 6, 7]
         actual = list(
-            zip_offset(a_1, a_2, a_3, offsets=(-1, 0, 1), longest=True)
+            mi.zip_offset(a_1, a_2, a_3, offsets=(-1, 0, 1), longest=True)
         )
         expected = [
             (None, 0, 1),
@@ -957,7 +970,8 @@ class ZipOffsetTest(TestCase):
         iterables = [0, 1, 2], [2, 3, 4]
         offsets = (-1, 0, 1)
         self.assertRaises(
-            ValueError, lambda: list(zip_offset(*iterables, offsets=offsets))
+            ValueError,
+            lambda: list(mi.zip_offset(*iterables, offsets=offsets))
         )
 
 
@@ -973,7 +987,7 @@ class SortTogetherTest(TestCase):
         ]
 
         self.assertEqual(
-            sort_together(iterables),
+            mi.sort_together(iterables),
             [
                 ('CT', 'CT', 'CT', 'GA', 'GA', 'GA'),
                 ('June', 'July', 'July', 'May', 'Aug.', 'May'),
@@ -982,7 +996,7 @@ class SortTogetherTest(TestCase):
         )
 
         self.assertEqual(
-            sort_together(iterables, key_list=(0, 1)),
+            mi.sort_together(iterables, key_list=(0, 1)),
             [
                 ('CT', 'CT', 'CT', 'GA', 'GA', 'GA'),
                 ('July', 'July', 'June', 'Aug.', 'May', 'May'),
@@ -991,7 +1005,7 @@ class SortTogetherTest(TestCase):
         )
 
         self.assertEqual(
-            sort_together(iterables, key_list=(0, 1, 2)),
+            mi.sort_together(iterables, key_list=(0, 1, 2)),
             [
                 ('CT', 'CT', 'CT', 'GA', 'GA', 'GA'),
                 ('July', 'July', 'June', 'Aug.', 'May', 'May'),
@@ -1000,7 +1014,7 @@ class SortTogetherTest(TestCase):
         )
 
         self.assertEqual(
-            sort_together(iterables, key_list=(2,)),
+            mi.sort_together(iterables, key_list=(2,)),
             [
                 ('GA', 'CT', 'CT', 'GA', 'GA', 'CT'),
                 ('Aug.', 'July', 'June', 'May', 'May', 'July'),
@@ -1017,7 +1031,7 @@ class SortTogetherTest(TestCase):
         ]
 
         self.assertRaises(
-            IndexError, lambda: sort_together(iterables, key_list=(5,))
+            IndexError, lambda: mi.sort_together(iterables, key_list=(5,))
         )
 
     def test_reverse(self):
@@ -1029,7 +1043,7 @@ class SortTogetherTest(TestCase):
         ]
 
         self.assertEqual(
-            sort_together(iterables, key_list=(0, 1, 2), reverse=True),
+            mi.sort_together(iterables, key_list=(0, 1, 2), reverse=True),
             [('GA', 'GA', 'GA', 'CT', 'CT', 'CT'),
              ('May', 'May', 'Aug.', 'June', 'July', 'July'),
              (100, 97, 20, 70, 100, 20)]
@@ -1042,7 +1056,7 @@ class SortTogetherTest(TestCase):
                      [97, 20, 100, 70, 100, 20, 0]]
 
         self.assertEqual(
-            sort_together(iterables),
+            mi.sort_together(iterables),
             [
                 ('CT', 'CT', 'CT', 'GA', 'GA', 'GA'),
                 ('June', 'July', 'July', 'May', 'Aug.', 'May'),
@@ -1055,8 +1069,8 @@ class DivideTest(TestCase):
     """Tests for divide()"""
 
     def test_invalid_n(self):
-        self.assertRaises(ValueError, lambda: divide(-1, [1, 2, 3]))
-        self.assertRaises(ValueError, lambda: divide(0, [1, 2, 3]))
+        self.assertRaises(ValueError, lambda: mi.divide(-1, [1, 2, 3]))
+        self.assertRaises(ValueError, lambda: mi.divide(0, [1, 2, 3]))
 
     def test_basic(self):
         iterable = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
@@ -1067,12 +1081,14 @@ class DivideTest(TestCase):
             (3, [[1, 2, 3, 4], [5, 6, 7], [8, 9, 10]]),
             (10, [[n] for n in range(1, 10 + 1)]),
         ]:
-            self.assertEqual([list(x) for x in divide(n, iterable)], expected)
+            self.assertEqual(
+                [list(x) for x in mi.divide(n, iterable)], expected
+            )
 
     def test_large_n(self):
         iterable = [1, 2, 3, 4]
         self.assertEqual(
-            [list(x) for x in divide(6, iterable)],
+            [list(x) for x in mi.divide(6, iterable)],
             [[1], [2], [3], [4], [], []]
         )
 
@@ -1080,67 +1096,67 @@ class DivideTest(TestCase):
 class TestAlwaysIterable(TestCase):
     """Tests for always_iterable()"""
     def test_single(self):
-        self.assertEqual(always_iterable(1), (1,))
-        self.assertEqual(list(always_iterable(1)), [1])
+        self.assertEqual(mi.always_iterable(1), (1,))
+        self.assertEqual(list(mi.always_iterable(1)), [1])
 
     def test_strings(self):
-        self.assertEqual(always_iterable('foo'), ('foo',))
-        self.assertEqual(always_iterable(six.b('bar')), (six.b('bar'),))
-        self.assertEqual(always_iterable(six.u(b'baz')), (six.u(b'baz'),))
+        self.assertEqual(mi.always_iterable('foo'), ('foo',))
+        self.assertEqual(mi.always_iterable(six.b('bar')), (six.b('bar'),))
+        self.assertEqual(mi.always_iterable(six.u(b'baz')), (six.u(b'baz'),))
 
     def test_iterables(self):
-        self.assertEqual(always_iterable([0, 1]), [0, 1])
+        self.assertEqual(mi.always_iterable([0, 1]), [0, 1])
         self.assertEqual(list(iter('foo')), ['f', 'o', 'o'])
         self.assertEqual(list([]), [])
 
     def test_none(self):
-        self.assertEqual(always_iterable(None), ())
-        self.assertEqual(list(always_iterable(None)), [])
+        self.assertEqual(mi.always_iterable(None), ())
+        self.assertEqual(list(mi.always_iterable(None)), [])
 
     def test_generator(self):
         def _gen():
             yield 0
             yield 1
 
-        self.assertEqual(list(always_iterable(_gen())), [0, 1])
+        self.assertEqual(list(mi.always_iterable(_gen())), [0, 1])
 
 
 class AdjacentTests(TestCase):
     def test_typical(self):
-        actual = list(adjacent(lambda x: x % 5 == 0, range(10)))
+        actual = list(mi.adjacent(lambda x: x % 5 == 0, range(10)))
         expected = [(True, 0), (True, 1), (False, 2), (False, 3), (True, 4),
                     (True, 5), (True, 6), (False, 7), (False, 8), (False, 9)]
         self.assertEqual(actual, expected)
 
     def test_empty_iterable(self):
-        actual = list(adjacent(lambda x: x % 5 == 0, []))
+        actual = list(mi.adjacent(lambda x: x % 5 == 0, []))
         expected = []
         self.assertEqual(actual, expected)
 
     def test_length_one(self):
-        actual = list(adjacent(lambda x: x % 5 == 0, [0]))
+        actual = list(mi.adjacent(lambda x: x % 5 == 0, [0]))
         expected = [(True, 0)]
         self.assertEqual(actual, expected)
 
-        actual = list(adjacent(lambda x: x % 5 == 0, [1]))
+        actual = list(mi.adjacent(lambda x: x % 5 == 0, [1]))
         expected = [(False, 1)]
         self.assertEqual(actual, expected)
 
     def test_consecutive_true(self):
         """Test that when the predicate matches multiple consecutive elements
         it doesn't repeat elements in the output"""
-        actual = list(adjacent(lambda x: x % 5 < 2, range(10)))
+        actual = list(mi.adjacent(lambda x: x % 5 < 2, range(10)))
         expected = [(True, 0), (True, 1), (True, 2), (False, 3), (True, 4),
                     (True, 5), (True, 6), (True, 7), (False, 8), (False, 9)]
         self.assertEqual(actual, expected)
 
     def test_distance(self):
-        actual = list(adjacent(lambda x: x % 5 == 0, range(10), distance=2))
+        actual = list(mi.adjacent(lambda x: x % 5 == 0, range(10), distance=2))
         expected = [(True, 0), (True, 1), (True, 2), (True, 3), (True, 4),
                     (True, 5), (True, 6), (True, 7), (False, 8), (False, 9)]
         self.assertEqual(actual, expected)
 
-        actual = list(adjacent(lambda x: x % 5 == 0, range(10), distance=3))
+        actual = list(mi.adjacent(lambda x: x % 5 == 0, range(10), distance=3))
         expected = [(True, 0), (True, 1), (True, 2), (True, 3), (True, 4),
                     (True, 5), (True, 6), (True, 7), (True, 8), (False, 9)]
         self.assertEqual(actual, expected)
@@ -1148,11 +1164,11 @@ class AdjacentTests(TestCase):
     def test_large_distance(self):
         """Test distance larger than the length of the iterable"""
         iterable = range(10)
-        actual = list(adjacent(lambda x: x % 5 == 4, iterable, distance=20))
+        actual = list(mi.adjacent(lambda x: x % 5 == 4, iterable, distance=20))
         expected = list(zip(repeat(True), iterable))
         self.assertEqual(actual, expected)
 
-        actual = list(adjacent(lambda x: False, iterable, distance=20))
+        actual = list(mi.adjacent(lambda x: False, iterable, distance=20))
         expected = list(zip(repeat(False), iterable))
         self.assertEqual(actual, expected)
 
@@ -1160,20 +1176,24 @@ class AdjacentTests(TestCase):
         """Test that adjacent() reduces to zip+map when distance is 0"""
         iterable = range(1000)
         predicate = lambda x: x % 4 == 2
-        actual = adjacent(predicate, iterable, 0)
+        actual = mi.adjacent(predicate, iterable, 0)
         expected = zip(map(predicate, iterable), iterable)
         self.assertTrue(all(a == e for a, e in zip(actual, expected)))
 
     def test_negative_distance(self):
         """Test that adjacent() raises an error with negative distance"""
         pred = lambda x: x
-        self.assertRaises(ValueError, lambda: adjacent(pred, range(1000), -1))
-        self.assertRaises(ValueError, lambda: adjacent(pred, range(10), -10))
+        self.assertRaises(
+            ValueError, lambda: mi.adjacent(pred, range(1000), -1)
+        )
+        self.assertRaises(
+            ValueError, lambda: mi.adjacent(pred, range(10), -10)
+        )
 
     def test_grouping(self):
         """Test interaction of adjacent() with groupby_transform()"""
-        iterable = adjacent(lambda x: x % 5 == 0, range(10))
-        grouper = groupby_transform(iterable, itemgetter(0), itemgetter(1))
+        iterable = mi.adjacent(lambda x: x % 5 == 0, range(10))
+        grouper = mi.groupby_transform(iterable, itemgetter(0), itemgetter(1))
         actual = [(k, list(g)) for k, g in grouper]
         expected = [
             (True, [0, 1]),
@@ -1193,7 +1213,7 @@ class AdjacentTests(TestCase):
             already_seen.add(item)
             return True
 
-        actual = list(adjacent(predicate, iterable))
+        actual = list(mi.adjacent(predicate, iterable))
         expected = [(True, x) for x in iterable]
         self.assertEqual(actual, expected)
 
@@ -1212,7 +1232,7 @@ class GroupByTransformTests(TestCase):
     def test_default_funcs(self):
         """Test that groupby_transform() with default args mimics groupby()"""
         iterable = [(x // 5, x) for x in range(1000)]
-        actual = groupby_transform(iterable)
+        actual = mi.groupby_transform(iterable)
         expected = groupby(iterable)
         self.assertAllGroupsEqual(actual, expected)
 
@@ -1220,14 +1240,14 @@ class GroupByTransformTests(TestCase):
         iterable = [(int(x / 5), int(x / 3), x) for x in range(10)]
 
         # Test the standard usage of grouping one iterable using another's keys
-        grouper = groupby_transform(
+        grouper = mi.groupby_transform(
             iterable, keyfunc=itemgetter(0), valuefunc=itemgetter(-1)
         )
         actual = [(k, list(g)) for k, g in grouper]
         expected = [(0, [0, 1, 2, 3, 4]), (1, [5, 6, 7, 8, 9])]
         self.assertEqual(actual, expected)
 
-        grouper = groupby_transform(
+        grouper = mi.groupby_transform(
             iterable, keyfunc=itemgetter(1), valuefunc=itemgetter(-1)
         )
         actual = [(k, list(g)) for k, g in grouper]
@@ -1236,7 +1256,7 @@ class GroupByTransformTests(TestCase):
 
         # and now for something a little different
         d = dict(zip(range(10), 'abcdefghij'))
-        grouper = groupby_transform(
+        grouper = mi.groupby_transform(
             range(10), keyfunc=lambda x: x // 5, valuefunc=d.get
         )
         actual = [(k, ''.join(g)) for k, g in grouper]
@@ -1249,16 +1269,16 @@ class GroupByTransformTests(TestCase):
         def key(x):
             return x // 5
 
-        actual = groupby_transform(iterable, key, valuefunc=None)
+        actual = mi.groupby_transform(iterable, key, valuefunc=None)
         expected = groupby(iterable, key)
         self.assertAllGroupsEqual(actual, expected)
 
-        actual = groupby_transform(iterable, key)  # default valuefunc
+        actual = mi.groupby_transform(iterable, key)  # default valuefunc
         expected = groupby(iterable, key)
         self.assertAllGroupsEqual(actual, expected)
 
 
-class ArithmeticSequenceTests(TestCase):
+class NumericRangeTests(TestCase):
     def test_basic(self):
         for args, expected in [
             ((4,), [0, 1, 2, 3]),
@@ -1280,21 +1300,21 @@ class ArithmeticSequenceTests(TestCase):
             ((Fraction(2, 1),), [Fraction(0, 1), Fraction(1, 1)]),
             ((Decimal('2.0'),), [Decimal('0.0'), Decimal('1.0')]),
         ]:
-            actual = list(numeric_range(*args))
+            actual = list(mi.numeric_range(*args))
             self.assertEqual(actual, expected)
             self.assertTrue(
                 all(type(a) == type(e) for a, e in zip(actual, expected))
             )
 
     def test_arg_count(self):
-        self.assertRaises(TypeError, lambda: list(numeric_range()))
+        self.assertRaises(TypeError, lambda: list(mi.numeric_range()))
         self.assertRaises(
-            TypeError, lambda: list(numeric_range(0, 1, 2, 3))
+            TypeError, lambda: list(mi.numeric_range(0, 1, 2, 3))
         )
 
     def test_zero_step(self):
         self.assertRaises(
-            ValueError, lambda: list(numeric_range(1, 2, 0))
+            ValueError, lambda: list(mi.numeric_range(1, 2, 0))
         )
 
 
@@ -1306,36 +1326,36 @@ class CountCycleTests(TestCase):
             (2, 'a'), (2, 'b'), (2, 'c'),
         ]
         for actual in [
-            take(9, count_cycle('abc')),  # n=None
-            list(count_cycle('abc', 3)),  # n=3
+            mi.take(9, mi.count_cycle('abc')),  # n=None
+            list(mi.count_cycle('abc', 3)),  # n=3
         ]:
             self.assertEqual(actual, expected)
 
     def test_empty(self):
-        self.assertEqual(list(count_cycle('')), [])
-        self.assertEqual(list(count_cycle('', 2)), [])
+        self.assertEqual(list(mi.count_cycle('')), [])
+        self.assertEqual(list(mi.count_cycle('', 2)), [])
 
     def test_negative(self):
-        self.assertEqual(list(count_cycle('abc', -3)), [])
+        self.assertEqual(list(mi.count_cycle('abc', -3)), [])
 
 
 class LocateTests(TestCase):
     def test_default_pred(self):
         iterable = [0, 1, 1, 0, 1, 0, 0]
-        actual = list(locate(iterable))
+        actual = list(mi.locate(iterable))
         expected = [1, 2, 4]
         self.assertEqual(actual, expected)
 
     def test_no_matches(self):
         iterable = [0, 0, 0]
-        actual = list(locate(iterable))
+        actual = list(mi.locate(iterable))
         expected = []
         self.assertEqual(actual, expected)
 
     def test_custom_pred(self):
         iterable = ['0', 1, 1, '0', 1, '0', '0']
         pred = lambda x: x == '0'
-        actual = list(locate(iterable, pred))
+        actual = list(mi.locate(iterable, pred))
         expected = [0, 3, 5, 6]
         self.assertEqual(actual, expected)
 
@@ -1345,9 +1365,9 @@ class StripFunctionTests(TestCase):
         iterable = list('www.example.com')
         pred = lambda x: x in set('cmowz.')
 
-        self.assertEqual(list(lstrip(iterable, pred)), list('example.com'))
-        self.assertEqual(list(rstrip(iterable, pred)), list('www.example'))
-        self.assertEqual(list(strip(iterable, pred)), list('example'))
+        self.assertEqual(list(mi.lstrip(iterable, pred)), list('example.com'))
+        self.assertEqual(list(mi.rstrip(iterable, pred)), list('www.example'))
+        self.assertEqual(list(mi.strip(iterable, pred)), list('example'))
 
     def test_not_hashable(self):
         iterable = [
@@ -1355,17 +1375,17 @@ class StripFunctionTests(TestCase):
         ]
         pred = lambda x: x in [list('http://'), list('www'), list('.com')]
 
-        self.assertEqual(list(lstrip(iterable, pred)), iterable[2:])
-        self.assertEqual(list(rstrip(iterable, pred)), iterable[:3])
-        self.assertEqual(list(strip(iterable, pred)), iterable[2: 3])
+        self.assertEqual(list(mi.lstrip(iterable, pred)), iterable[2:])
+        self.assertEqual(list(mi.rstrip(iterable, pred)), iterable[:3])
+        self.assertEqual(list(mi.strip(iterable, pred)), iterable[2: 3])
 
     def test_math(self):
         iterable = [0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2]
         pred = lambda x: x <= 2
 
-        self.assertEqual(list(lstrip(iterable, pred)), iterable[3:])
-        self.assertEqual(list(rstrip(iterable, pred)), iterable[:-3])
-        self.assertEqual(list(strip(iterable, pred)), iterable[3:-3])
+        self.assertEqual(list(mi.lstrip(iterable, pred)), iterable[3:])
+        self.assertEqual(list(mi.rstrip(iterable, pred)), iterable[:-3])
+        self.assertEqual(list(mi.strip(iterable, pred)), iterable[3:-3])
 
 
 class IsliceExtendedTests(TestCase):
@@ -1375,7 +1395,7 @@ class IsliceExtendedTests(TestCase):
         steps = [1, 2, 3, 4, -1, -2, -3, 4]
         for slice_args in product(indexes, indexes, steps):
             try:
-                actual = list(islice_extended(iterable, *slice_args))
+                actual = list(mi.islice_extended(iterable, *slice_args))
             except Exception as e:
                 self.fail((slice_args, e))
 
@@ -1384,4 +1404,4 @@ class IsliceExtendedTests(TestCase):
 
     def test_zero_step(self):
         with self.assertRaises(ValueError):
-            list(islice_extended([1, 2, 3], 0, 1, 0))
+            list(mi.islice_extended([1, 2, 3], 0, 1, 0))

--- a/more_itertools/tests/test_recipes.py
+++ b/more_itertools/tests/test_recipes.py
@@ -1,5 +1,4 @@
 from doctest import DocTestSuite
-from random import seed
 from unittest import TestCase
 
 from six.moves import range

--- a/more_itertools/tests/test_recipes.py
+++ b/more_itertools/tests/test_recipes.py
@@ -4,7 +4,7 @@ from unittest import TestCase
 
 from six.moves import range
 
-from more_itertools import *
+import more_itertools as mi
 
 
 def load_tests(loader, tests, ignore):
@@ -18,21 +18,21 @@ class AccumulateTests(TestCase):
 
     def test_empty(self):
         """Test that an empty input returns an empty output"""
-        self.assertEqual(list(accumulate([])), [])
+        self.assertEqual(list(mi.accumulate([])), [])
 
     def test_default(self):
         """Test accumulate with the default function (addition)"""
-        self.assertEqual(list(accumulate([1, 2, 3])), [1, 3, 6])
+        self.assertEqual(list(mi.accumulate([1, 2, 3])), [1, 3, 6])
 
     def test_bogus_function(self):
         """Test accumulate with an invalid function"""
         with self.assertRaises(TypeError):
-            list(accumulate([1, 2, 3], func=lambda x: x))
+            list(mi.accumulate([1, 2, 3], func=lambda x: x))
 
     def test_custom_function(self):
         """Test accumulate with a custom function"""
         self.assertEqual(
-            list(accumulate((1, 2, 3, 2, 1), func=max)), [1, 2, 3, 3, 3]
+            list(mi.accumulate((1, 2, 3, 2, 1), func=max)), [1, 2, 3, 3, 3]
         )
 
 
@@ -41,24 +41,24 @@ class TakeTests(TestCase):
 
     def test_simple_take(self):
         """Test basic usage"""
-        t = take(5, range(10))
+        t = mi.take(5, range(10))
         self.assertEqual(t, [0, 1, 2, 3, 4])
 
     def test_null_take(self):
         """Check the null case"""
-        t = take(0, range(10))
+        t = mi.take(0, range(10))
         self.assertEqual(t, [])
 
     def test_negative_take(self):
         """Make sure taking negative items results in a ValueError"""
-        self.assertRaises(ValueError, lambda: take(-3, range(10)))
+        self.assertRaises(ValueError, lambda: mi.take(-3, range(10)))
 
     def test_take_too_much(self):
         """Taking more than an iterator has remaining should return what the
         iterator has remaining.
 
         """
-        t = take(10, range(5))
+        t = mi.take(10, range(5))
         self.assertEqual(t, [0, 1, 2, 3, 4])
 
 
@@ -67,13 +67,13 @@ class TabulateTests(TestCase):
 
     def test_simple_tabulate(self):
         """Test the happy path"""
-        t = tabulate(lambda x: x)
+        t = mi.tabulate(lambda x: x)
         f = tuple([next(t) for _ in range(3)])
         self.assertEqual(f, (0, 1, 2))
 
     def test_count(self):
         """Ensure tabulate accepts specific count"""
-        t = tabulate(lambda x: 2 * x, -1)
+        t = mi.tabulate(lambda x: 2 * x, -1)
         f = (next(t), next(t), next(t))
         self.assertEqual(f, (-2, 0, 2))
 
@@ -83,18 +83,18 @@ class TailTests(TestCase):
 
     def test_greater(self):
         """Length of iterable is greather than requested tail"""
-        self.assertEqual(list(tail(3, 'ABCDEFG')), ['E', 'F', 'G'])
+        self.assertEqual(list(mi.tail(3, 'ABCDEFG')), ['E', 'F', 'G'])
 
     def test_equal(self):
         """Length of iterable is equal to the requested tail"""
         self.assertEqual(
-            list(tail(7, 'ABCDEFG')), ['A', 'B', 'C', 'D', 'E', 'F', 'G']
+            list(mi.tail(7, 'ABCDEFG')), ['A', 'B', 'C', 'D', 'E', 'F', 'G']
         )
 
     def test_less(self):
         """Length of iterable is less than requested tail"""
         self.assertEqual(
-            list(tail(8, 'ABCDEFG')), ['A', 'B', 'C', 'D', 'E', 'F', 'G']
+            list(mi.tail(8, 'ABCDEFG')), ['A', 'B', 'C', 'D', 'E', 'F', 'G']
         )
 
 
@@ -104,24 +104,24 @@ class ConsumeTests(TestCase):
     def test_sanity(self):
         """Test basic functionality"""
         r = (x for x in range(10))
-        consume(r, 3)
+        mi.consume(r, 3)
         self.assertEqual(3, next(r))
 
     def test_null_consume(self):
         """Check the null case"""
         r = (x for x in range(10))
-        consume(r, 0)
+        mi.consume(r, 0)
         self.assertEqual(0, next(r))
 
     def test_negative_consume(self):
         """Check that negative consumsion throws an error"""
         r = (x for x in range(10))
-        self.assertRaises(ValueError, lambda: consume(r, -1))
+        self.assertRaises(ValueError, lambda: mi.consume(r, -1))
 
     def test_total_consume(self):
         """Check that iterator is totally consumed by default"""
         r = (x for x in range(10))
-        consume(r)
+        mi.consume(r)
         self.assertRaises(StopIteration, lambda: next(r))
 
 
@@ -132,16 +132,16 @@ class NthTests(TestCase):
         """Make sure the nth item is returned"""
         l = range(10)
         for i, v in enumerate(l):
-            self.assertEqual(nth(l, i), v)
+            self.assertEqual(mi.nth(l, i), v)
 
     def test_default(self):
         """Ensure a default value is returned when nth item not found"""
         l = range(3)
-        self.assertEqual(nth(l, 100, "zebra"), "zebra")
+        self.assertEqual(mi.nth(l, 100, "zebra"), "zebra")
 
     def test_negative_item_raises(self):
         """Ensure asking for a negative item raises an exception"""
-        self.assertRaises(ValueError, lambda: nth(range(10), -3))
+        self.assertRaises(ValueError, lambda: mi.nth(range(10), -3))
 
 
 class AllEqualTests(TestCase):
@@ -149,28 +149,28 @@ class AllEqualTests(TestCase):
 
     def test_true(self):
         """Everything is equal"""
-        self.assertTrue(all_equal('aaaaaa'))
-        self.assertTrue(all_equal([0, 0, 0, 0]))
+        self.assertTrue(mi.all_equal('aaaaaa'))
+        self.assertTrue(mi.all_equal([0, 0, 0, 0]))
 
     def test_false(self):
         """Not everything is equal"""
-        self.assertFalse(all_equal('aaaaab'))
-        self.assertFalse(all_equal([0, 0, 0, 1]))
+        self.assertFalse(mi.all_equal('aaaaab'))
+        self.assertFalse(mi.all_equal([0, 0, 0, 1]))
 
     def test_tricky(self):
         """Not everything is identical, but everything is equal"""
         items = [1, complex(1, 0), 1.0]
-        self.assertTrue(all_equal(items))
+        self.assertTrue(mi.all_equal(items))
 
     def test_empty(self):
         """Return True if the iterable is empty"""
-        self.assertTrue(all_equal(''))
-        self.assertTrue(all_equal([]))
+        self.assertTrue(mi.all_equal(''))
+        self.assertTrue(mi.all_equal([]))
 
     def test_one(self):
         """Return True if the iterable is singular"""
-        self.assertTrue(all_equal('0'))
-        self.assertTrue(all_equal([0]))
+        self.assertTrue(mi.all_equal('0'))
+        self.assertTrue(mi.all_equal([0]))
 
 
 class QuantifyTests(TestCase):
@@ -179,12 +179,12 @@ class QuantifyTests(TestCase):
     def test_happy_path(self):
         """Make sure True count is returned"""
         q = [True, False, True]
-        self.assertEqual(quantify(q), 2)
+        self.assertEqual(mi.quantify(q), 2)
 
     def test_custom_predicate(self):
         """Ensure non-default predicates return as expected"""
         q = range(10)
-        self.assertEqual(quantify(q, lambda x: x % 2 == 0), 5)
+        self.assertEqual(mi.quantify(q, lambda x: x % 2 == 0), 5)
 
 
 class PadnoneTests(TestCase):
@@ -193,7 +193,7 @@ class PadnoneTests(TestCase):
     def test_happy_path(self):
         """wrapper iterator should return None indefinitely"""
         r = range(2)
-        p = padnone(r)
+        p = mi.padnone(r)
         self.assertEqual([0, 1, None, None], [next(p) for _ in range(4)])
 
 
@@ -203,7 +203,7 @@ class NcyclesTests(TestCase):
     def test_happy_path(self):
         """cycle a sequence three times"""
         r = ["a", "b", "c"]
-        n = ncycles(r, 3)
+        n = mi.ncycles(r, 3)
         self.assertEqual(
             ["a", "b", "c", "a", "b", "c", "a", "b", "c"],
             list(n)
@@ -211,12 +211,12 @@ class NcyclesTests(TestCase):
 
     def test_null_case(self):
         """asking for 0 cycles should return an empty iterator"""
-        n = ncycles(range(100), 0)
+        n = mi.ncycles(range(100), 0)
         self.assertRaises(StopIteration, lambda: next(n))
 
     def test_pathalogical_case(self):
         """asking for negative cycles should return an empty iterator"""
-        n = ncycles(range(100), -10)
+        n = mi.ncycles(range(100), -10)
         self.assertRaises(StopIteration, lambda: next(n))
 
 
@@ -225,7 +225,7 @@ class DotproductTests(TestCase):
 
     def test_happy_path(self):
         """simple dotproduct example"""
-        self.assertEqual(400, dotproduct([10, 10], [20, 20]))
+        self.assertEqual(400, mi.dotproduct([10, 10], [20, 20]))
 
 
 class FlattenTests(TestCase):
@@ -234,12 +234,12 @@ class FlattenTests(TestCase):
     def test_basic_usage(self):
         """ensure list of lists is flattened one level"""
         f = [[0, 1, 2], [3, 4, 5]]
-        self.assertEqual(list(range(6)), list(flatten(f)))
+        self.assertEqual(list(range(6)), list(mi.flatten(f)))
 
     def test_single_level(self):
         """ensure list of lists is flattened only one level"""
         f = [[0, [1, 2]], [[3, 4], 5]]
-        self.assertEqual([0, [1, 2], [3, 4], 5], list(flatten(f)))
+        self.assertEqual([0, [1, 2], [3, 4], 5], list(mi.flatten(f)))
 
 
 class RepeatfuncTests(TestCase):
@@ -247,22 +247,22 @@ class RepeatfuncTests(TestCase):
 
     def test_simple_repeat(self):
         """test simple repeated functions"""
-        r = repeatfunc(lambda: 5)
+        r = mi.repeatfunc(lambda: 5)
         self.assertEqual([5, 5, 5, 5, 5], [next(r) for _ in range(5)])
 
     def test_finite_repeat(self):
         """ensure limited repeat when times is provided"""
-        r = repeatfunc(lambda: 5, times=5)
+        r = mi.repeatfunc(lambda: 5, times=5)
         self.assertEqual([5, 5, 5, 5, 5], list(r))
 
     def test_added_arguments(self):
         """ensure arguments are applied to the function"""
-        r = repeatfunc(lambda x: x, 2, 3)
+        r = mi.repeatfunc(lambda x: x, 2, 3)
         self.assertEqual([3, 3], list(r))
 
     def test_null_times(self):
         """repeat 0 should return an empty iterator"""
-        r = repeatfunc(range, 0, 3)
+        r = mi.repeatfunc(range, 0, 3)
         self.assertRaises(StopIteration, lambda: next(r))
 
 
@@ -271,12 +271,12 @@ class PairwiseTests(TestCase):
 
     def test_base_case(self):
         """ensure an iterable will return pairwise"""
-        p = pairwise([1, 2, 3])
+        p = mi.pairwise([1, 2, 3])
         self.assertEqual([(1, 2), (2, 3)], list(p))
 
     def test_short_case(self):
         """ensure an empty iterator if there's not enough values to pair"""
-        p = pairwise("a")
+        p = mi.pairwise("a")
         self.assertRaises(StopIteration, lambda: next(p))
 
 
@@ -289,7 +289,7 @@ class GrouperTests(TestCase):
 
         """
         self.assertEqual(
-            list(grouper(3, 'ABCDEF')), [('A', 'B', 'C'), ('D', 'E', 'F')]
+            list(mi.grouper(3, 'ABCDEF')), [('A', 'B', 'C'), ('D', 'E', 'F')]
         )
 
     def test_odd(self):
@@ -298,13 +298,14 @@ class GrouperTests(TestCase):
 
         """
         self.assertEqual(
-            list(grouper(3, 'ABCDE')), [('A', 'B', 'C'), ('D', 'E', None)]
+            list(mi.grouper(3, 'ABCDE')), [('A', 'B', 'C'), ('D', 'E', None)]
         )
 
     def test_fill_value(self):
         """Test that the fill value is used to pad the final group"""
         self.assertEqual(
-            list(grouper(3, 'ABCDE', 'x')), [('A', 'B', 'C'), ('D', 'E', 'x')]
+            list(mi.grouper(3, 'ABCDE', 'x')),
+            [('A', 'B', 'C'), ('D', 'E', 'x')]
         )
 
 
@@ -314,14 +315,14 @@ class RoundrobinTests(TestCase):
     def test_even_groups(self):
         """Ensure ordered output from evenly populated iterables"""
         self.assertEqual(
-            list(roundrobin('ABC', [1, 2, 3], range(3))),
+            list(mi.roundrobin('ABC', [1, 2, 3], range(3))),
             ['A', 1, 0, 'B', 2, 1, 'C', 3, 2]
         )
 
     def test_uneven_groups(self):
         """Ensure ordered output from unevenly populated iterables"""
         self.assertEqual(
-            list(roundrobin('ABCD', [1, 2], range(0))),
+            list(mi.roundrobin('ABCD', [1, 2], range(0))),
             ['A', 1, 'B', 2, 'C', 'D']
         )
 
@@ -331,13 +332,13 @@ class PartitionTests(TestCase):
 
     def test_bool(self):
         """Test when pred() returns a boolean"""
-        lesser, greater = partition(lambda x: x > 5, range(10))
+        lesser, greater = mi.partition(lambda x: x > 5, range(10))
         self.assertEqual(list(lesser), [0, 1, 2, 3, 4, 5])
         self.assertEqual(list(greater), [6, 7, 8, 9])
 
     def test_arbitrary(self):
         """Test when pred() returns an integer"""
-        divisibles, remainders = partition(lambda x: x % 3, range(10))
+        divisibles, remainders = mi.partition(lambda x: x % 3, range(10))
         self.assertEqual(list(divisibles), [0, 3, 6, 9])
         self.assertEqual(list(remainders), [1, 2, 4, 5, 7, 8])
 
@@ -347,7 +348,7 @@ class PowersetTests(TestCase):
 
     def test_combinatorics(self):
         """Ensure a proper enumeration"""
-        p = powerset([1, 2, 3])
+        p = mi.powerset([1, 2, 3])
         self.assertEqual(
             list(p),
             [(), (1,), (2,), (3,), (1, 2), (1, 3), (2, 3), (1, 2, 3)]
@@ -359,7 +360,7 @@ class UniqueEverseenTests(TestCase):
 
     def test_everseen(self):
         """ensure duplicate elements are ignored"""
-        u = unique_everseen('AAAABBBBCCDAABBB')
+        u = mi.unique_everseen('AAAABBBBCCDAABBB')
         self.assertEqual(
             ['A', 'B', 'C', 'D'],
             list(u)
@@ -367,19 +368,19 @@ class UniqueEverseenTests(TestCase):
 
     def test_custom_key(self):
         """ensure the custom key comparison works"""
-        u = unique_everseen('aAbACCc', key=str.lower)
+        u = mi.unique_everseen('aAbACCc', key=str.lower)
         self.assertEqual(list('abC'), list(u))
 
     def test_unhashable(self):
         """ensure things work for unhashable items"""
         iterable = ['a', [1, 2, 3], [1, 2, 3], 'a']
-        u = unique_everseen(iterable)
+        u = mi.unique_everseen(iterable)
         self.assertEqual(list(u), ['a', [1, 2, 3]])
 
     def test_unhashable_key(self):
         """ensure things work for unhashable items with a custom key"""
         iterable = ['a', [1, 2, 3], [1, 2, 3], 'a']
-        u = unique_everseen(iterable, key=lambda x: x)
+        u = mi.unique_everseen(iterable, key=lambda x: x)
         self.assertEqual(list(u), ['a', [1, 2, 3]])
 
 
@@ -388,12 +389,12 @@ class UniqueJustseenTests(TestCase):
 
     def test_justseen(self):
         """ensure only last item is remembered"""
-        u = unique_justseen('AAAABBBCCDABB')
+        u = mi.unique_justseen('AAAABBBCCDABB')
         self.assertEqual(list('ABCDAB'), list(u))
 
     def test_custom_key(self):
         """ensure the custom key comparison works"""
-        u = unique_justseen('AABCcAD', str.lower)
+        u = mi.unique_justseen('AABCcAD', str.lower)
         self.assertEqual(list('ABCAD'), list(u))
 
 
@@ -403,26 +404,26 @@ class IterExceptTests(TestCase):
     def test_exact_exception(self):
         """ensure the exact specified exception is caught"""
         l = [1, 2, 3]
-        i = iter_except(l.pop, IndexError)
+        i = mi.iter_except(l.pop, IndexError)
         self.assertEqual(list(i), [3, 2, 1])
 
     def test_generic_exception(self):
         """ensure the generic exception can be caught"""
         l = [1, 2]
-        i = iter_except(l.pop, Exception)
+        i = mi.iter_except(l.pop, Exception)
         self.assertEqual(list(i), [2, 1])
 
     def test_uncaught_exception_is_raised(self):
         """ensure a non-specified exception is raised"""
         l = [1, 2, 3]
-        i = iter_except(l.pop, KeyError)
+        i = mi.iter_except(l.pop, KeyError)
         self.assertRaises(IndexError, lambda: list(i))
 
     def test_first(self):
         """ensure first is run before the function"""
         l = [1, 2, 3]
         f = lambda: 25
-        i = iter_except(l.pop, IndexError, f)
+        i = mi.iter_except(l.pop, IndexError, f)
         self.assertEqual(list(i), [25, 3, 2, 1])
 
 
@@ -431,19 +432,21 @@ class FirstTrueTests(TestCase):
 
     def test_something_true(self):
         """Test with no keywords"""
-        self.assertEqual(first_true(range(10)), 1)
+        self.assertEqual(mi.first_true(range(10)), 1)
 
     def test_nothing_true(self):
         """Test default return value."""
-        self.assertEqual(first_true([0, 0, 0]), False)
+        self.assertEqual(mi.first_true([0, 0, 0]), False)
 
     def test_default(self):
         """Test with a default keyword"""
-        self.assertEqual(first_true([0, 0, 0], default='!'), '!')
+        self.assertEqual(mi.first_true([0, 0, 0], default='!'), '!')
 
     def test_pred(self):
         """Test with a custom predicate"""
-        self.assertEqual(first_true([2, 4, 6], pred=lambda x: x % 3 == 0), 6)
+        self.assertEqual(
+            mi.first_true([2, 4, 6], pred=lambda x: x % 3 == 0), 6
+        )
 
 
 class RandomProductTests(TestCase):
@@ -466,7 +469,7 @@ class RandomProductTests(TestCase):
         """
         nums = [1, 2, 3]
         lets = ['a', 'b', 'c']
-        n, m = zip(*[random_product(nums, lets) for _ in range(100)])
+        n, m = zip(*[mi.random_product(nums, lets) for _ in range(100)])
         n, m = set(n), set(m)
         self.assertEqual(n, set(nums))
         self.assertEqual(m, set(lets))
@@ -480,7 +483,7 @@ class RandomProductTests(TestCase):
         """
         nums = [1, 2, 3]
         lets = ['a', 'b', 'c']
-        r = list(random_product(nums, lets, repeat=100))
+        r = list(mi.random_product(nums, lets, repeat=100))
         self.assertEqual(2 * 100, len(r))
         n, m = set(r[::2]), set(r[1::2])
         self.assertEqual(n, set(nums))
@@ -500,7 +503,7 @@ class RandomPermutationTests(TestCase):
 
         """
         i = range(15)
-        r = random_permutation(i)
+        r = mi.random_permutation(i)
         self.assertEqual(set(i), set(r))
         if i == r:
             raise AssertionError("Values were not permuted")
@@ -520,7 +523,7 @@ class RandomPermutationTests(TestCase):
         item_set = set(items)
         all_items = set()
         for _ in range(100):
-            permutation = random_permutation(items, 5)
+            permutation = mi.random_permutation(items, 5)
             self.assertEqual(len(permutation), 5)
             permutation_set = set(permutation)
             self.assertLessEqual(permutation_set, item_set)
@@ -537,7 +540,7 @@ class RandomCombinationTests(TestCase):
         items = range(15)
         all_items = set()
         for _ in range(50):
-            combination = random_combination(items, 5)
+            combination = mi.random_combination(items, 5)
             all_items |= set(combination)
         self.assertEqual(all_items, set(items))
 
@@ -545,10 +548,10 @@ class RandomCombinationTests(TestCase):
         """ensure that elements are sampled without replacement"""
         items = range(15)
         for _ in range(50):
-            combination = random_combination(items, len(items))
+            combination = mi.random_combination(items, len(items))
             self.assertEqual(len(combination), len(set(combination)))
         self.assertRaises(
-            ValueError, lambda: random_combination(items, len(items) + 1)
+            ValueError, lambda: mi.random_combination(items, len(items) + 1)
         )
 
 
@@ -558,7 +561,7 @@ class RandomCombinationWithReplacementTests(TestCase):
     def test_replacement(self):
         """ensure that elements are sampled with replacement"""
         items = range(5)
-        combo = random_combination_with_replacement(items, len(items) * 2)
+        combo = mi.random_combination_with_replacement(items, len(items) * 2)
         self.assertEqual(2 * len(items), len(combo))
         if len(set(combo)) == len(combo):
             raise AssertionError("Combination contained no duplicates")
@@ -569,6 +572,6 @@ class RandomCombinationWithReplacementTests(TestCase):
         items = range(15)
         all_items = set()
         for _ in range(50):
-            combination = random_combination_with_replacement(items, 5)
+            combination = mi.random_combination_with_replacement(items, 5)
             all_items |= set(combination)
         self.assertEqual(all_items, set(items))

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,3 @@
+[flake8]
+exclude = ./docs/conf.py
+ignore = E731, F999

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 # Hack to prevent stupid error on exit of `python setup.py test`. (See
 # http://www.eby-sarna.com/pipermail/peak/2010-May/003357.html.)
 try:
-    import multiprocessing
+    import multiprocessing  # noqa
 except ImportError:
     pass
 from re import sub

--- a/setup.py
+++ b/setup.py
@@ -9,14 +9,28 @@ from re import sub
 from setuptools import setup, find_packages
 
 
+def get_long_description():
+    # Fix display issues on PyPI caused by RST markup
+    readme = open('README.rst').read()
+
+    version_lines = []
+    with open('docs/versions.rst') as infile:
+        next(infile)
+        for line in infile:
+            line = line.rstrip().replace('.. automodule:: more_itertools', '')
+            version_lines.append(line)
+    version_history = '\n'.join(version_lines)
+    version_history = sub(r':func:`([a-zA-Z0-9_]+)`', r'\1', version_history)
+
+    ret = readme + '\n\n' + version_history
+    return ret
+
+
 setup(
     name='more-itertools',
     version='3.2.0',
     description='More routines for operating on iterables, beyond itertools',
-    long_description=open('README.rst').read() + '\n\n' +
-                     sub(r':func:`([a-zA-Z0-9_]+)`', r'\1', '\n'.join(open('docs/versions.rst').read()
-                                                                                         .splitlines()[1:])
-                                                           .replace('.. automodule:: more_itertools', '')),
+    long_description=get_long_description(),
     author='Erik Rose',
     author_email='erikrose@grinchcentral.com',
     license='MIT',


### PR DESCRIPTION
This PR adds the [flake8](http://flake8.pycqa.org/en/latest/) linter and style checker to the automated tests. This helps ensure PEP 8 compliance in the code (and in my experience, helps me find stupid bugs before pushing them publicly and being embarrassed).

This entails a few changes, which I know some don't like. Feel free to propose an alternative, but I'm pretty set on this!
* No more `import *` in the tests (the `__all__` attributes are tested via the `__init__` module)
* No more long lines (I don't like 79 either, but YCAGWYW)
* Some linter refuse (`  # noqa`), but thankfully just a few instances
