### PR TITLE
Add base_type argument to always_iterable()

### DIFF
--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -1119,7 +1119,7 @@ def divide(n, iterable):
     return ret
 
 
-def always_iterable(obj):
+def always_iterable(obj, base_type=None):
     """
     Given an object, always return an iterable.
 
@@ -1139,10 +1139,15 @@ def always_iterable(obj):
         >>> always_iterable([1, 2, 3])
         [1, 2, 3]
 
-    Strings (binary or unicode) are not considered to be iterable::
+    By default, strings (binary or unicode) are not considered to be iterable::
 
         >>> always_iterable('foo')
         ('foo',)
+
+    To consider other types as non-iterable, set *base_type*::
+
+        >>> always_iterable({'a': 1})
+        {'a': 1}
 
     This function is useful in applications where a passed parameter may be
     either a single item or a collection of items::
@@ -1162,8 +1167,9 @@ def always_iterable(obj):
     if obj is None:
         return ()
 
-    string_like_types = (text_type, binary_type)
-    if isinstance(obj, string_like_types) or not hasattr(obj, '__iter__'):
+    base_type = (text_type, binary_type) if base_type is None else base_type
+
+    if isinstance(obj, base_type) or not hasattr(obj, '__iter__'):
         return obj,
 
     return obj

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -1146,8 +1146,6 @@ def always_iterable(obj, base_type=(text_type, binary_type)):
         >>> obj = 'foo'
         >>> list(always_iterable(obj))  # Default behavior
         ['foo']
-        >>> list(always_iterable(obj, base_type=None))  # No special handling
-        ['f', 'o', 'o']
 
         >>> obj = {'a': 1}
         >>> list(always_iterable(obj))  # Default behavior
@@ -1171,10 +1169,7 @@ def always_iterable(obj, base_type=(text_type, binary_type)):
     if obj is None:
         return ()
 
-    is_base_type = False if base_type is None else isinstance(obj, base_type)
-    is_iterable = hasattr(obj, '__iter__')
-
-    if is_base_type or not is_iterable:
+    if isinstance(obj, base_type) or not hasattr(obj, '__iter__'):
         return obj,
 
     return obj

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -1139,35 +1139,42 @@ def always_iterable(obj, base_type=(text_type, binary_type)):
         >>> always_iterable([1, 2, 3])
         [1, 2, 3]
 
-    By default, strings (binary or unicode) are not considered to be iterable::
 
-        >>> always_iterable('foo')
-        ('foo',)
+    The *base_type* keyword can override which types are considered iterable.
+    By default, ``str`` and ``bytes`` types are not considered iterable::
 
-    To consider other types as non-iterable, set *base_type*::
+        >>> obj = 'foo'
+        >>> list(always_iterable(obj))  # Default behavior
+        ['foo']
+        >>> list(always_iterable(obj, base_type=None))  # No special handling
+        ['f', 'o', 'o']
 
-        >>> always_iterable({'a': 1})
-        {'a': 1}
+        >>> obj = {'a': 1}
+        >>> list(always_iterable(obj))  # Default behavior
+        ['a']
+        >>> list(always_iterable(obj, base_type=dict))
+        [{'a': 1}]
+
 
     This function is useful in applications where a passed parameter may be
     either a single item or a collection of items::
 
-        >>> def item_sum(param):
-        ...     total = 0
-        ...     for item in always_iterable(param):
-        ...         total += item
-        ...
-        ...     return total
-        >>> item_sum(10)
-        10
-        >>> item_sum([10, 20])
+        >>> arg = [10, 20]
+        >>> sum(always_iterable(arg))
         30
+
+        >>> arg = 10
+        >>> sum(always_iterable(arg))
+        10
 
     """
     if obj is None:
         return ()
 
-    if isinstance(obj, base_type) or not hasattr(obj, '__iter__'):
+    is_base_type = False if base_type is None else isinstance(obj, base_type)
+    is_iterable = hasattr(obj, '__iter__')
+
+    if is_base_type or not is_iterable:
         return obj,
 
     return obj

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -1126,7 +1126,7 @@ def always_iterable(obj, base_type=(text_type, binary_type)):
         >>> list(always_iterable(obj))
         [1, 2, 3]
 
-    If *obj* is not iterable, return an one-item iterable containing *obj*::
+    If *obj* is not iterable, return a one-item iterable containing *obj*::
 
         >>> obj = 1
         >>> list(always_iterable(obj))

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -1120,59 +1120,59 @@ def divide(n, iterable):
 
 
 def always_iterable(obj, base_type=(text_type, binary_type)):
-    """
-    Given an object, always return an iterable.
+    """If *obj* is iterable, return an iterator over its items::
 
-    If the object is not already iterable, return a tuple containing containing
-    the object::
-
-        >>> always_iterable(1)
-        (1,)
-
-    If the object is ``None``, return an empty iterable::
-
-        >>> always_iterable(None)
-        ()
-
-    Otherwise, return the object itself::
-
-        >>> always_iterable([1, 2, 3])
+        >>> obj = (1, 2, 3)
+        >>> list(always_iterable(obj))
         [1, 2, 3]
 
+    If *obj* is not iterable, return an one-item iterable containing *obj*::
 
-    The *base_type* keyword can override which types are considered iterable.
-    By default, ``str`` and ``bytes`` types are not considered iterable::
+        >>> obj = 1
+        >>> list(always_iterable(obj))
+        [1]
+
+
+    If *obj* is ``None``, return an empty iterable:
+
+        >>> obj = None
+        >>> list(always_iterable(None))
+        []
+
+    By default, binary and text strings are not considered iterable::
 
         >>> obj = 'foo'
-        >>> list(always_iterable(obj))  # Default behavior
+        >>> list(always_iterable(obj))
         ['foo']
 
+    If *base_type* is set, objects for which ``isinstance(obj, base_type)``
+    returns ``True`` won't be considered iterable.
+
         >>> obj = {'a': 1}
-        >>> list(always_iterable(obj))  # Default behavior
+        >>> list(always_iterable(obj))  # Iterate over the dict's keys
         ['a']
-        >>> list(always_iterable(obj, base_type=dict))
+        >>> list(always_iterable(obj, base_type=dict))  # Treat dicts as a unit
         [{'a': 1}]
 
+    Set *base_type* to ``None`` to avoid any special handling and treat objects
+    Python considers iterable as iterable:
 
-    This function is useful in applications where a passed parameter may be
-    either a single item or a collection of items::
+        >>> obj = 'foo'
+        >>> list(always_iterable(obj, base_type=None))
+        ['f', 'o', 'o']
 
-        >>> arg = [10, 20]
-        >>> sum(always_iterable(arg))
-        30
-
-        >>> arg = 10
-        >>> sum(always_iterable(arg))
-        10
 
     """
     if obj is None:
-        return ()
+        return iter(())
 
-    if isinstance(obj, base_type) or not hasattr(obj, '__iter__'):
-        return obj,
+    if (base_type is not None) and isinstance(obj, base_type):
+        return iter((obj,))
 
-    return obj
+    try:
+        return iter(obj)
+    except TypeError:
+        return iter((obj,))
 
 
 def adjacent(predicate, iterable, distance=1):

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -1119,7 +1119,7 @@ def divide(n, iterable):
     return ret
 
 
-def always_iterable(obj, base_type=None):
+def always_iterable(obj, base_type=(text_type, binary_type)):
     """
     Given an object, always return an iterable.
 
@@ -1166,8 +1166,6 @@ def always_iterable(obj, base_type=None):
     """
     if obj is None:
         return ()
-
-    base_type = (text_type, binary_type) if base_type is None else base_type
 
     if isinstance(obj, base_type) or not hasattr(obj, '__iter__'):
         return obj,

--- a/more_itertools/tests/test_more.py
+++ b/more_itertools/tests/test_more.py
@@ -1119,12 +1119,6 @@ class TestAlwaysIterable(TestCase):
         custom_expected = [obj]
         self.assertEqual(custom_actual, custom_expected)
 
-    def test_base_type_none(self):
-        obj = 'string'
-        actual = list(mi.always_iterable(obj, base_type=None))
-        expected = list(obj)
-        self.assertEqual(actual, expected)
-
     def test_iterables(self):
         self.assertEqual(mi.always_iterable([0, 1]), [0, 1])
         self.assertEqual(mi.always_iterable([0, 1], base_type=list), ([0, 1],))

--- a/more_itertools/tests/test_more.py
+++ b/more_itertools/tests/test_more.py
@@ -1106,8 +1106,22 @@ class TestAlwaysIterable(TestCase):
         self.assertEqual(mi.always_iterable(six.b('bar')), (six.b('bar'),))
         self.assertEqual(mi.always_iterable(six.u(b'baz')), (six.u(b'baz'),))
 
+    def test_base_type(self):
+        obj = {'a': 1, 'b': 2}
+
+        # Default: dicts are iterable like they normally are
+        default_actual = list(mi.always_iterable(obj))
+        default_expected = list(obj)
+        self.assertEqual(default_actual, default_expected)
+
+        # Base type set: dicts are not iterable
+        custom_actual = list(mi.always_iterable(obj, base_type=dict))
+        custom_expected = [obj]
+        self.assertEqual(custom_actual, custom_expected)
+
     def test_iterables(self):
         self.assertEqual(mi.always_iterable([0, 1]), [0, 1])
+        self.assertEqual(mi.always_iterable([0, 1], base_type=list), ([0, 1],))
         self.assertEqual(list(iter('foo')), ['f', 'o', 'o'])
         self.assertEqual(list([]), [])
 

--- a/more_itertools/tests/test_more.py
+++ b/more_itertools/tests/test_more.py
@@ -9,7 +9,6 @@ from itertools import chain, count, groupby, permutations, product, repeat
 from operator import itemgetter
 from unittest import TestCase
 
-import six
 from six.moves import filter, range, zip
 
 import more_itertools as mi
@@ -1098,37 +1097,44 @@ class DivideTest(TestCase):
 class TestAlwaysIterable(TestCase):
     """Tests for always_iterable()"""
     def test_single(self):
-        self.assertEqual(mi.always_iterable(1), (1,))
         self.assertEqual(list(mi.always_iterable(1)), [1])
 
     def test_strings(self):
-        self.assertEqual(mi.always_iterable('foo'), ('foo',))
-        self.assertEqual(mi.always_iterable(six.b('bar')), (six.b('bar'),))
-        self.assertEqual(mi.always_iterable(six.u(b'baz')), (six.u(b'baz'),))
+        for obj in ['foo', b'bar', u'baz']:
+            actual = list(mi.always_iterable(obj))
+            expected = [obj]
+            self.assertEqual(actual, expected)
 
     def test_base_type(self):
-        obj = {'a': 1, 'b': 2}
+        dict_obj = {'a': 1, 'b': 2}
+        str_obj = '123'
 
         # Default: dicts are iterable like they normally are
-        default_actual = list(mi.always_iterable(obj))
-        default_expected = list(obj)
+        default_actual = list(mi.always_iterable(dict_obj))
+        default_expected = list(dict_obj)
         self.assertEqual(default_actual, default_expected)
 
-        # Base type set: dicts are not iterable
-        custom_actual = list(mi.always_iterable(obj, base_type=dict))
-        custom_expected = [obj]
+        # Unitary types set: dicts are not iterable
+        custom_actual = list(mi.always_iterable(dict_obj, base_type=dict))
+        custom_expected = [dict_obj]
         self.assertEqual(custom_actual, custom_expected)
 
+        # With unitary types set, strings are iterable
+        str_actual = list(mi.always_iterable(str_obj, base_type=None))
+        str_expected = list(str_obj)
+        self.assertEqual(str_actual, str_expected)
+
     def test_iterables(self):
-        self.assertEqual(mi.always_iterable([0, 1]), [0, 1])
-        self.assertEqual(mi.always_iterable([0, 1], base_type=list), ([0, 1],))
+        self.assertEqual(list(mi.always_iterable([0, 1])), [0, 1])
+        self.assertEqual(
+            list(mi.always_iterable([0, 1], base_type=list)), [[0, 1]]
+        )
         self.assertEqual(
             list(mi.always_iterable(iter('foo'))), ['f', 'o', 'o']
         )
         self.assertEqual(list(mi.always_iterable([])), [])
 
     def test_none(self):
-        self.assertEqual(mi.always_iterable(None), ())
         self.assertEqual(list(mi.always_iterable(None)), [])
 
     def test_generator(self):

--- a/more_itertools/tests/test_more.py
+++ b/more_itertools/tests/test_more.py
@@ -1122,8 +1122,10 @@ class TestAlwaysIterable(TestCase):
     def test_iterables(self):
         self.assertEqual(mi.always_iterable([0, 1]), [0, 1])
         self.assertEqual(mi.always_iterable([0, 1], base_type=list), ([0, 1],))
-        self.assertEqual(list(iter('foo')), ['f', 'o', 'o'])
-        self.assertEqual(list([]), [])
+        self.assertEqual(
+            list(mi.always_iterable(iter('foo'))), ['f', 'o', 'o']
+        )
+        self.assertEqual(list(mi.always_iterable([])), [])
 
     def test_none(self):
         self.assertEqual(mi.always_iterable(None), ())

--- a/more_itertools/tests/test_more.py
+++ b/more_itertools/tests/test_more.py
@@ -1119,6 +1119,12 @@ class TestAlwaysIterable(TestCase):
         custom_expected = [obj]
         self.assertEqual(custom_actual, custom_expected)
 
+    def test_base_type_none(self):
+        obj = 'string'
+        actual = list(mi.always_iterable(obj, base_type=None))
+        expected = list(obj)
+        self.assertEqual(actual, expected)
+
     def test_iterables(self):
         self.assertEqual(mi.always_iterable([0, 1]), [0, 1])
         self.assertEqual(mi.always_iterable([0, 1], base_type=list), ([0, 1],))


### PR DESCRIPTION
Re: Issue #164, this PR adds a `base_type` argument to `always_iterable`.

This allows for the "by default, strings are not considered iterable" behavior to be overridden, and allows other types (e.g. `dict`) to be considered non-iterable.