### PR TITLE
Add validator parameter to bucket()

### DIFF
--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -674,7 +674,7 @@ class bucket(object):
                     if item_value == value:
                         yield item
                         break
-                    else:
+                    elif self._validator(item_value):
                         self._cache[item_value].append(item)
 
     def __getitem__(self, value):

--- a/more_itertools/tests/test_more.py
+++ b/more_itertools/tests/test_more.py
@@ -583,13 +583,14 @@ class BucketTests(TestCase):
         self.assertEqual(next(D[10]), 10)
 
     def test_validator(self):
-        iterable = count(1)  # All numbers starting with 1
+        iterable = count(0)
         key = lambda x: int(str(x)[0])  # First digit of each number
         validator = lambda x: 0 < x < 10  # No leading zeros
         D = mi.bucket(iterable, key, validator=validator)
-        self.assertNotIn(0, D)
-        self.assertEqual(list(D[0]), [])
         self.assertEqual(mi.take(3, D[1]), [1, 10, 11])
+        self.assertNotIn(0, D)  # Non-valid entries don't return True
+        self.assertNotIn(0, D._cache)  # Don't store non-valid entries
+        self.assertEqual(list(D[0]), [])
 
 
 class SpyTests(TestCase):

--- a/more_itertools/tests/test_more.py
+++ b/more_itertools/tests/test_more.py
@@ -582,6 +582,15 @@ class BucketTests(TestCase):
         # Checking in-ness shouldn't advance the iterator
         self.assertEqual(next(D[10]), 10)
 
+    def test_validator(self):
+        iterable = count(1)  # All numbers starting with 1
+        key = lambda x: int(str(x)[0])  # First digit of each number
+        validator = lambda x: 0 < x < 10  # No leading zeros
+        D = mi.bucket(iterable, key, validator=validator)
+        self.assertNotIn(0, D)
+        self.assertEqual(list(D[0]), [])
+        self.assertEqual(mi.take(3, D[1]), [1, 10, 11])
+
 
 class SpyTests(TestCase):
     """Tests for ``spy()``"""

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,3 @@
 [flake8]
 exclude = ./docs/conf.py
-ignore = E731, F999
+ignore = E731, E741, F999


### PR DESCRIPTION
This PR adds a new keyword argument to `bucket()`, which helps protect against accidentally exhausting memory when checking for membership.

I was initially hung up on this issue when doing [PR 66](https://github.com/erikrose/more-itertools/pull/66#issuecomment-259952519), thinking that you should have to specify your keys to `bucket()` up-front. However, I ultimately conceded that this was too limiting.

[This discussion](https://groups.google.com/forum/#!searchin/python-ideas/itertools|sort:date/python-ideas/L6qwK69xkIA/78rlTjK5BAAJ) in `python-ideas` sparked an idea for a solution - an optional validation function.

If you know what keys will be in the iterable, you can convey that and then not worry about checking for membership.

Before:
```python
>>> iterable = count(1)  # All numbers starting with 1
>>> key = lambda x: int(str(x)[0])  # First digit of each number
>>> D = bucket(iterable, key)
>>> 0 in D  # Run out of memory and die
>>> list(D[0])  # Run out of memory and die
```

After:
```python
>>> iterable = count(1)  # All numbers starting with 1
>>> key = lambda x: int(str(x)[0])  # First digit of each number
>>> validator = lambda x: 0 < x < 10  # No leading zeros
>>> D = bucket(iterable, key, validator=validator)
>>> 0 in D
False
>>> list(D[0])
[]
```