### PR TITLE
Add peekable.index method

### DIFF
--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -168,7 +168,7 @@ class peekable(object):
     storage.
 
     To locate the position of the first instance of some value in the
-    iterable, use :meth:`index`. This won't advance the source iterator.
+    iterable, use :meth:`index`. This won't advance the iterator.
 
         >>> p = peekable(iter('abcdabcd'))
         >>> p.index('b')
@@ -305,19 +305,19 @@ class peekable(object):
     def index(self, value, start=0, stop=None):
         """Return the index ``k`` of the first instance *value* in the
         iterable, optionally starting from the *start* index and finishing
-        before the *stop* index. Does not advance the source iterator.
+        before the *stop* index. Does not advance the iterator.
         """
-        cache_len = len(self._cache)
-
         # Check the cache first
-        cache_stop = cache_len if stop is None else stop
-        try:
-            return self._cache.index(value, start, cache_stop)
-        except ValueError:
-            pass
+        for i, item in enumerate(self._cache):
+            if i < start:
+                continue
+            if (stop is not None) and (i >= stop):
+                raise ValueError('{} not found'.format(repr(value)))
+            if item == value:
+                return i
 
         # Continue searching through the iterable, caching values as we go
-        for i, item in enumerate(self._it, cache_len):
+        for i, item in enumerate(self._it, len(self._cache)):
             self._cache.append(item)
             if i < start:
                 continue

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -320,25 +320,15 @@ class peekable(object):
         return self._cache[index]
 
     def index(self, value, start=0, stop=None):
-        """Return the index ``k`` of the first instance *value* in the
+        """Return the index of the first instance *value* in the
         iterable, optionally starting from the *start* index and finishing
         before the *stop* index. Does not advance the iterator.
         """
-        # Check the cache first
-        for i, item in enumerate(self._cache):
-            if i < start:
-                continue
-            if (stop is not None) and (i >= stop):
-                raise ValueError('{} not found'.format(repr(value)))
-            if item == value:
-                return i
-
-        # Continue searching through the iterable, caching values as we go
-        for i, item in enumerate(self._it, len(self._cache)):
-            self._cache.append(item)
-            if i < start:
-                continue
-            if (stop is not None) and (i >= stop):
+        indexes = count(start) if stop is None else range(start, stop)
+        for i in indexes:
+            try:
+                item = self[i]
+            except IndexError:
                 break
             if item == value:
                 return i

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -164,11 +164,12 @@ class peekable(object):
         'a'
 
     Negative indexes are supported, but be aware that they will cache the
-    remaining items in the source iterator, which may require significant
+    remaining items of the source iterator, which may require significant
     storage.
 
     To locate the position of the first instance of some value in the
-    iterable, use :meth:`index`. This won't advance the iterator.
+    iterable, use :meth:`index`. This won't advance the iterator (but it will
+    cache values up to the first instance).
 
         >>> p = peekable(iter('abcdabcd'))
         >>> p.index('b')
@@ -179,6 +180,14 @@ class peekable(object):
         Traceback (most recent call last):
         ...
         ValueError: 'b' not found
+
+    Similarly, the `in` operator can be used without advancing the iterator:
+
+        >>> p = peekable(iter('abcdabcd'))
+        >>> 'b' in p  # Caches up to the first instance of 'b'
+        True
+        >>> 'x' in p  # Caches the remaining values in the iterator
+        False
 
     To check whether a peekable is exhausted, check its truth value:
 
@@ -204,6 +213,14 @@ class peekable(object):
         except StopIteration:
             return False
         return True
+
+    def __contains__(self, value):
+        try:
+            self.index(value)
+        except ValueError:
+            return False
+        else:
+            return True
 
     def __nonzero__(self):
         # For Python 2 compatibility

--- a/more_itertools/tests/test_more.py
+++ b/more_itertools/tests/test_more.py
@@ -382,6 +382,7 @@ class PeekableTests(TestCase):
         # There was no advancing of the source iterator
         self.assertEqual(list(it), list(source_iterable))
 
+
 class ConsumerTests(TestCase):
     """Tests for ``consumer()``"""
 

--- a/more_itertools/tests/test_more.py
+++ b/more_itertools/tests/test_more.py
@@ -362,6 +362,25 @@ class PeekableTests(TestCase):
         expected = [12, 11, 10, 0, 1, 2]
         self.assertEqual(actual, expected)
 
+    def test_index(self):
+        source_iterable = 'abbcccabbccc'
+        it = mi.peekable(iter(source_iterable))
+
+        # Not in the cache yet
+        self.assertEqual(it.index('b'), 1)
+
+        # Now in the cache - using deque.index
+        self.assertEqual(it.index('b'), 1)
+        self.assertEqual(it.index('b', 0), 1)
+        self.assertEqual(it.index('b', 0, 2), 1)
+        self.assertRaises(ValueError, lambda: it.index('b', 0, 1))
+
+        # Outside the cache, skip over some values
+        self.assertEqual(it.index('c', 4), 4)
+        self.assertRaises(ValueError, lambda: it.index('c', 6, 9))
+
+        # There was no advancing of the source iterator
+        self.assertEqual(list(it), list(source_iterable))
 
 class ConsumerTests(TestCase):
     """Tests for ``consumer()``"""

--- a/more_itertools/tests/test_more.py
+++ b/more_itertools/tests/test_more.py
@@ -382,6 +382,21 @@ class PeekableTests(TestCase):
         # There was no advancing of the source iterator
         self.assertEqual(list(it), list(source_iterable))
 
+    def test_contains(self):
+        source_iterable = 'abbcccabbccc'
+        it = mi.peekable(iter(source_iterable))
+
+        # Search twice, once not already cached and once cached
+        self.assertIn('a', it)
+        self.assertIn('a', it)
+        self.assertEqual(list(it._cache), ['a'])
+
+        self.assertIn('c', it)
+        self.assertIn('c', it)
+        self.assertEqual(list(it._cache), ['a', 'b', 'b', 'c'])
+
+        self.assertEqual(list(it), list(source_iterable))
+
 
 class ConsumerTests(TestCase):
     """Tests for ``consumer()``"""

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,3 @@
 [flake8]
 exclude = ./docs/conf.py
-ignore = E731, F999
+ignore = E731, E741, F999


### PR DESCRIPTION
This PR adds an `index()` method to `peekable()`-wrapped iterables. Like `list.index(x)`, this returns the index of first occurrence of `x`. It caches values as it searches, so you don't advance the iterator by searching.

I can be talked out of this, but I'm tempted to also add `__contains__` with similar caching. (Update: I did)