### PR TITLE
Add consecutive_groups()

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -124,6 +124,7 @@ These tools return summarized or aggregated data from an iterable.
 .. autofunction:: one
 .. autofunction:: unique_to_each
 .. autofunction:: locate
+.. autofunction:: consecutive_groups
 
 ----
 

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -29,6 +29,7 @@ __all__ = [
     'chunked',
     'collapse',
     'collate',
+    'consecutive_groups',
     'consumer',
     'count_cycle',
     'distinct_permutations',
@@ -1530,3 +1531,40 @@ def islice_extended(iterable, *args):
 
             for item in cache[i::step]:
                 yield item
+
+
+def consecutive_groups(iterable, ordering=lambda x: x):
+    """Yield groups of consecutive items using :func:`itertools.groupby`.
+    The *ordering* function determines whether two items are adjacent by
+    returning their position.
+
+    By default, the ordering function is the identity function. This is
+    suitable for finding runs of numbers:
+
+        >>> iterable = [1, 10, 11, 12, 20, 30, 31, 32, 33, 40]
+        >>> for group in consecutive_groups(iterable):
+        ...     print(list(group))
+        [1]
+        [10, 11, 12]
+        [20]
+        [30, 31, 32, 33]
+        [40]
+
+    For finding runs of adjacent letters, try using the :meth:`index` method
+    of a string of letters:
+
+        >>> from string import ascii_lowercase
+        >>> iterable = 'abcdfgilmnop'
+        >>> ordering = ascii_lowercase.index
+        >>> for group in consecutive_groups(iterable, ordering):
+        ...     print(list(group))
+        ['a', 'b', 'c', 'd']
+        ['f', 'g']
+        ['i']
+        ['l', 'm', 'n', 'o', 'p']
+
+    """
+    for k, g in groupby(
+        enumerate(iterable), key=lambda x: x[0] - ordering(x[1])
+    ):
+        yield map(itemgetter(1), g)

--- a/more_itertools/tests/test_more.py
+++ b/more_itertools/tests/test_more.py
@@ -1429,3 +1429,36 @@ class IsliceExtendedTests(TestCase):
     def test_zero_step(self):
         with self.assertRaises(ValueError):
             list(mi.islice_extended([1, 2, 3], 0, 1, 0))
+
+
+class ConsecutiveGroupsTest(TestCase):
+    def test_numbers(self):
+        iterable = [-10, -8, -7, -6, 1, 2, 4, 5, -1, 7]
+        actual = [list(g) for g in mi.consecutive_groups(iterable)]
+        expected = [[-10], [-8, -7, -6], [1, 2], [4, 5], [-1], [7]]
+        self.assertEqual(actual, expected)
+
+    def test_custom_ordering(self):
+        iterable = ['1', '10', '11', '20', '21', '22', '30', '31']
+        ordering = lambda x: int(x)
+        actual = [list(g) for g in mi.consecutive_groups(iterable, ordering)]
+        expected = [['1'], ['10', '11'], ['20', '21', '22'], ['30', '31']]
+        self.assertEqual(actual, expected)
+
+    def test_exotic_ordering(self):
+        iterable = [
+            ('a', 'b', 'c', 'd'),
+            ('a', 'c', 'b', 'd'),
+            ('a', 'c', 'd', 'b'),
+            ('a', 'd', 'b', 'c'),
+            ('d', 'b', 'c', 'a'),
+            ('d', 'c', 'a', 'b'),
+        ]
+        ordering = list(permutations('abcd')).index
+        actual = [list(g) for g in mi.consecutive_groups(iterable, ordering)]
+        expected = [
+            [('a', 'b', 'c', 'd')],
+            [('a', 'c', 'b', 'd'), ('a', 'c', 'd', 'b'), ('a', 'd', 'b', 'c')],
+            [('d', 'b', 'c', 'a'), ('d', 'c', 'a', 'b')],
+        ]
+        self.assertEqual(actual, expected)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,3 @@
 [flake8]
 exclude = ./docs/conf.py
-ignore = E731, F999
+ignore = E731, E741, F999


### PR DESCRIPTION
This PR adds `consecutive_groups()`, a tool for finding consecutive blocks of items in an iterable. This is an extension of the example in the [old itertools docs](https://docs.python.org/release/2.4.4/lib/itertools-example.html).

--- 

I've always admired the trick offered in the example, which is excerpted here:

```python
>>> data = [ 1,  4,5,6, 10, 15,16,17,18, 22, 25,26,27,28]
>>> for k, g in groupby(enumerate(data), lambda (i,x):i-x):
...     print map(operator.itemgetter(1), g)
... 
[1]
[4, 5, 6]
[10]
[15, 16, 17, 18]
[22]
[25, 26, 27, 28]

```

This works because `enumerate` counts up by 1 for each item in the iterable (`0, 1, 2, 3...`), so if we have a run of numbers (`20, 21, 22, 23`), we'll wind up with a constant difference between the index and each item in the run (`20 - 0 = 20`, `21 - 1 = 20`, `22 - 2 = 20`, ...). This we use for grouping.

---

The example shows how to work with iterables of numbers, but the same method can be applied to any sequence with a clear ordering. I've used this for finding consecutive IP addresses, for example.

```python
>>> from socket import inet_aton
... from struct import unpack
... 
... from more_itertools import consecutive_groups
... 
... iterable = ['192.0.2.0', '192.0.2.2', '192.0.2.3', '192.0.2.5']
... ordering = lambda x: unpack(b'!I', inet_aton(x))[0]
... 
... for group in consecutive_groups(iterable, ordering):
...     print(list(group))
['192.0.2.0']
['192.0.2.2', '192.0.2.3']
['192.0.2.5']
```

The [tests](https://github.com/erikrose/more-itertools/compare/consecutive-groups-rebased?expand=1#diff-228d30171f84b762c55cb716df56ec37R1457) show another example where there's not an obvious numerical representation, but all we need is a ranking method.
