### PR TITLE
Add seekable()

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -29,8 +29,8 @@ These tools yield groups of items from a source iterable.
 .. autofunction:: partition
 
 
-Lookahead
-=========
+Lookahead and lookback
+======================
 
 These tools peek at an iterable's values without advancing it.
 
@@ -41,6 +41,7 @@ These tools peek at an iterable's values without advancing it.
 
 .. autofunction:: spy
 .. autoclass:: peekable
+.. autoclass:: seekable
 
 
 Windowing

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -1620,10 +1620,9 @@ class seekable(object):
             else:
                 return item
 
-        if self._cache_iter is None:
-            item = next(self._source)
-            self._cache.append(item)
-            return item
+        item = next(self._source)
+        self._cache.append(item)
+        return item
 
     next = __next__
 

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -1609,18 +1609,19 @@ class seekable(object):
     def __init__(self, iterable):
         self._source = iter(iterable)
         self._cache = []
-        self._cache_iter = None
+        self._index = None
 
     def __iter__(self):
         return self
 
     def __next__(self):
-        if self._cache_iter is not None:
+        if self._index is not None:
             try:
-                item = next(self._cache_iter)
-            except StopIteration:
-                self._cache_iter = None
+                item = self._cache[self._index]
+            except IndexError:
+                self._index = None
             else:
+                self._index += 1
                 return item
 
         item = next(self._source)
@@ -1630,10 +1631,7 @@ class seekable(object):
     next = __next__
 
     def seek(self, index):
-        self._cache_iter = iter(self._cache)
-
-        consume(self._cache_iter, index)
-
+        self._index = index
         remainder = index - len(self._cache)
         if remainder > 0:
             consume(self, remainder)

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -1600,6 +1600,9 @@ class seekable(object):
         >>> it.seek(20)  # Seeking past the end of the source isn't a problem
         >>> list(it)
         []
+        >>> it.seek(0)  # Resetting works even after hitting the end
+        >>> next(it), next(it), next(it)
+        ('0', '1', '2')
 
     """
 

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -1604,6 +1604,9 @@ class seekable(object):
         >>> next(it), next(it), next(it)
         ('0', '1', '2')
 
+    The cache grows as the source iterable progresses, so beware of wrapping
+    very large or infinite iterables.
+
     """
 
     def __init__(self, iterable):

--- a/more_itertools/tests/test_more.py
+++ b/more_itertools/tests/test_more.py
@@ -1462,3 +1462,48 @@ class ConsecutiveGroupsTest(TestCase):
             [('d', 'b', 'c', 'a'), ('d', 'c', 'a', 'b')],
         ]
         self.assertEqual(actual, expected)
+
+
+class SeekableTest(TestCase):
+    def test_exhaustion_reset(self):
+        iterable = [str(n) for n in range(10)]
+
+        s = mi.seekable(iterable)
+        self.assertEqual(list(s), iterable)  # Normal iteration
+        self.assertEqual(list(s), [])  # Iterable is exhausted
+
+        s.seek(0)
+        self.assertEqual(list(s), iterable)  # Back in action
+
+    def test_partial_reset(self):
+        iterable = [str(n) for n in range(10)]
+
+        s = mi.seekable(iterable)
+        self.assertEqual(mi.take(5, s), iterable[:5])  # Normal iteration
+
+        s.seek(1)
+        self.assertEqual(list(s), iterable[1:])  # Get the rest of the iterable
+
+    def test_forward(self):
+        iterable = [str(n) for n in range(10)]
+
+        s = mi.seekable(iterable)
+        self.assertEqual(mi.take(1, s), iterable[:1])  # Normal iteration
+
+        s.seek(3)  # Skip over index 2
+        self.assertEqual(list(s), iterable[3:])  # Result is similar to slicing
+
+        s.seek(0)  # Back to 0
+        self.assertEqual(list(s), iterable)  # No difference in result
+
+    def test_past_end(self):
+        iterable = [str(n) for n in range(10)]
+
+        s = mi.seekable(iterable)
+        self.assertEqual(mi.take(1, s), iterable[:1])  # Normal iteration
+
+        s.seek(20)
+        self.assertEqual(list(s), [])  # Iterable is exhausted
+
+        s.seek(0)  # Back to 0
+        self.assertEqual(list(s), iterable)  # No difference in result


### PR DESCRIPTION
This PR adds a new wrapper class, `seekable()`. This does progressive caching of an iterable, allowing you to return to the values that have been seen so far. In addition, it allows for jumping forward and backward in the stream:

```python
>>> from itertools import count
>>> from more_itertools import seekable, take
>>> it = seekable((str(n) for n in count()))
>>> take(5, it)
['0', '1', '2', '3', '4']
>>> it.seek(0)
>>> take(6, it)
['0', '1', '2', '3', '4', '5']
>>> it.seek(10)
>>> take(5, it)
['10', '11', '12', '13', '14']
```

---

The question of "how do you reset an iterator?" is all over Stack Overflow. The standard answers are:
1. You can't, sorry
2. Wrap it with `list()`
3. Use `tee()` to copy it

I think this class improves on (2) - you can use it with infinite iterators (for a while, anyway).

I'm certain this class offers a usability improvement compared to (3).

I was originally going to call this `rewindable()` or `resettable()` or something and just have it seek to 0, but then I realized that it's pretty easy to pick an arbitrary index. The name "seekable" just happens to pair nicely with "peekable."

I fiddled with adding similar functionality to `peekable()`, but I couldn't make it seem natural.