### PR TITLE
Add exactly_n()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ _build
 
 # IDE files
 .idea
+.vscode

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -1590,8 +1590,13 @@ def consecutive_groups(iterable, ordering=lambda x: x):
         yield map(itemgetter(1), g)
 
 
-def exactly_n(iterable, n):
-    """Return ``True`` if exactly ``n`` items in the iterable are ``True``.
+def exactly_n(iterable, n, predicate=bool):
+    """Return ``True`` if exactly ``n`` items in the iterable are ``True``
+    according to the predicate, a function of one argument which returns
+    a boolean.
+    
+    This function will short circuit as soon as it finds n + 1 ``True``
+    elements.
 
         >>> exactly_n([True, True, False], 2)
         True
@@ -1599,13 +1604,4 @@ def exactly_n(iterable, n):
         False
 
     """
-    if n < 0:
-        return False
-
-    num_true = 0
-    for _ in filter(bool, iterable):
-        num_true += 1
-        if num_true > n:
-            return False
-
-    return num_true == n
+    return len(take(n + 1, filter(predicate, iterable))) == n

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -1589,6 +1589,7 @@ def consecutive_groups(iterable, ordering=lambda x: x):
     ):
         yield map(itemgetter(1), g)
 
+
 def exactly_n(iterable, n):
     """Return ``True`` if exactly ``n`` items in the iterable are ``True``.
 

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -35,6 +35,7 @@ __all__ = [
     'distinct_permutations',
     'distribute',
     'divide',
+    'exactly_n',
     'first',
     'groupby_transform',
     'ilen',
@@ -1587,3 +1588,23 @@ def consecutive_groups(iterable, ordering=lambda x: x):
         enumerate(iterable), key=lambda x: x[0] - ordering(x[1])
     ):
         yield map(itemgetter(1), g)
+
+def exactly_n(iterable, n):
+    """Return ``True`` if exactly ``n`` items in the iterable are ``True``.
+
+        >>> exactly_n([True, True, False], 2)
+        True
+        >>> exactly_n([True, True, False], 1)
+        False
+
+    """
+    if n < 0:
+        return False
+
+    num_true = 0
+    for _ in filter(bool, iterable):
+        num_true += 1
+        if num_true > n:
+            return False
+
+    return num_true == n

--- a/more_itertools/tests/test_more.py
+++ b/more_itertools/tests/test_more.py
@@ -1473,6 +1473,7 @@ class ConsecutiveGroupsTest(TestCase):
         ]
         self.assertEqual(actual, expected)
 
+
 class ExactlyNTests(TestCase):
     """Tests for ``exactly_n()``"""
 
@@ -1492,4 +1493,4 @@ class ExactlyNTests(TestCase):
     def test_empty(self):
         """Return ``True`` if the iterable is empty and ``n`` is 0"""
         self.assertTrue(mi.exactly_n([], 0))
-        self.assertFalse(mi.exactly_n([],1))
+        self.assertFalse(mi.exactly_n([], 1))

--- a/more_itertools/tests/test_more.py
+++ b/more_itertools/tests/test_more.py
@@ -1482,6 +1482,7 @@ class ExactlyNTests(TestCase):
         self.assertTrue(mi.exactly_n([True, False, True], 2))
         self.assertTrue(mi.exactly_n([1, 1, 1, 0], 3))
         self.assertTrue(mi.exactly_n([False, False], 0))
+        self.assertTrue(mi.exactly_n(range(100), 10, lambda x: x < 10))
 
     def test_false(self):
         """Iterable does not have ``n`` ``True`` elements"""
@@ -1489,6 +1490,7 @@ class ExactlyNTests(TestCase):
         self.assertFalse(mi.exactly_n([True, True, False], 1))
         self.assertFalse(mi.exactly_n([False], 1))
         self.assertFalse(mi.exactly_n([True], -1))
+        self.assertFalse(mi.exactly_n(repeat(True), 100))
 
     def test_empty(self):
         """Return ``True`` if the iterable is empty and ``n`` is 0"""

--- a/more_itertools/tests/test_more.py
+++ b/more_itertools/tests/test_more.py
@@ -1472,3 +1472,24 @@ class ConsecutiveGroupsTest(TestCase):
             [('d', 'b', 'c', 'a'), ('d', 'c', 'a', 'b')],
         ]
         self.assertEqual(actual, expected)
+
+class ExactlyNTests(TestCase):
+    """Tests for ``exactly_n()``"""
+
+    def test_true(self):
+        """Iterable has ``n`` ``True`` elements"""
+        self.assertTrue(mi.exactly_n([True, False, True], 2))
+        self.assertTrue(mi.exactly_n([1, 1, 1, 0], 3))
+        self.assertTrue(mi.exactly_n([False, False], 0))
+
+    def test_false(self):
+        """Iterable does not have ``n`` ``True`` elements"""
+        self.assertFalse(mi.exactly_n([True, False, False], 2))
+        self.assertFalse(mi.exactly_n([True, True, False], 1))
+        self.assertFalse(mi.exactly_n([False], 1))
+        self.assertFalse(mi.exactly_n([True], -1))
+
+    def test_empty(self):
+        """Return ``True`` if the iterable is empty and ``n`` is 0"""
+        self.assertTrue(mi.exactly_n([], 0))
+        self.assertFalse(mi.exactly_n([],1))


### PR DESCRIPTION
This pull request adds the function `exactly_n(iterable, n)`. This function is designed to be used like the built-in `any()` and `all()` functions. It will return `True` if and only if the input `iterable` has `n` `True` elements.

```python
>>> exactly_n([True, True, False], 2)
True
>>> exactly_n([True, True, False], 1)
False
```