### PR TITLE
Add difference()

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+more_itertools/more.py merge=union
+more_itertools/tests/test_more.py merge=union

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -211,12 +211,13 @@ Others
 .. autofunction:: numeric_range(start, stop, step)
 .. autofunction:: side_effect
 .. autofunction:: iterate
+.. autofunction:: difference(iterable, func=operator.sub)
 
 ----
 
 **Itertools recipes**
 
 .. autofunction:: consume
-.. autofunction:: accumulate
+.. autofunction:: accumulate(iterable, func=operator.add)
 .. autofunction:: tabulate
 .. autofunction:: repeatfunc

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -1621,4 +1621,8 @@ def difference(iterable, func=sub):
 
     """
     a, b = tee(iterable)
-    return chain([next(b)], map(lambda x: func(x[1], x[0]), zip(a, b)))
+    try:
+        item = next(b)
+    except StopIteration:
+        return iter([])
+    return chain([item], map(lambda x: func(x[1], x[0]), zip(a, b)))

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -1628,6 +1628,8 @@ def difference(iterable, func=sub):
     except StopIteration:
         return iter([])
     return chain([item], map(lambda x: func(x[1], x[0]), zip(a, b)))
+
+
 class seekable(object):
     """Wrap an iterator to allow for seeking backward and forward. This
     progressively caches the items in the source iterable so they can be

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -14,7 +14,7 @@ from itertools import (
     takewhile,
     tee
 )
-from operator import itemgetter, lt, gt
+from operator import itemgetter, lt, gt, sub
 from sys import maxsize, version_info
 
 from six import binary_type, string_types, text_type
@@ -32,6 +32,7 @@ __all__ = [
     'consecutive_groups',
     'consumer',
     'count_cycle',
+    'difference',
     'distinct_permutations',
     'distribute',
     'divide',
@@ -1587,3 +1588,37 @@ def consecutive_groups(iterable, ordering=lambda x: x):
         enumerate(iterable), key=lambda x: x[0] - ordering(x[1])
     ):
         yield map(itemgetter(1), g)
+
+
+def difference(iterable, func=sub):
+    """By default, compute the first difference of *iterable* using
+    :func:`operator.sub`.
+
+        >>> iterable = [0, 1, 3, 6, 10]
+        >>> list(difference(iterable))
+        [0, 1, 2, 3, 4]
+
+    This is the opposite of :func:`accumulate`'s default behavior:
+
+        >>> from more_itertools import accumulate
+        >>> iterable = [0, 1, 2, 3, 4]
+        >>> list(accumulate(iterable))
+        [0, 1, 3, 6, 10]
+        >>> list(difference(accumulate(iterable)))
+        [0, 1, 2, 3, 4]
+
+    By default *func* is :func:`operator.sub`, but other functions can be
+    specified. They will be applied as follows::
+
+        A, B, C, D, ... --> A, func(B, A), func(C, B), func(D, C), ...
+
+    For example, to do progressive division:
+
+        >>> iterable = [1, 2, 6, 24, 120]  # Factorial sequence
+        >>> func = lambda x, y: x // y
+        >>> list(difference(iterable, func))
+        [1, 2, 3, 4, 5]
+
+    """
+    a, b = tee(iterable)
+    return chain([next(b)], map(lambda x: func(x[1], x[0]), zip(a, b)))

--- a/more_itertools/tests/test_more.py
+++ b/more_itertools/tests/test_more.py
@@ -6,7 +6,7 @@ from fractions import Fraction
 from functools import reduce
 from io import StringIO
 from itertools import chain, count, groupby, permutations, product, repeat
-from operator import itemgetter
+from operator import add, itemgetter
 from unittest import TestCase
 
 from six.moves import filter, range, zip
@@ -1472,3 +1472,29 @@ class ConsecutiveGroupsTest(TestCase):
             [('d', 'b', 'c', 'a'), ('d', 'c', 'a', 'b')],
         ]
         self.assertEqual(actual, expected)
+
+
+class DifferenceTest(TestCase):
+    def test_normal(self):
+        iterable = [10, 20, 30, 40, 50]
+        actual = list(mi.difference(iterable))
+        expected = [10, 10, 10, 10, 10]
+        self.assertEqual(actual, expected)
+
+    def test_custom(self):
+        iterable = [10, 20, 30, 40, 50]
+        actual = list(mi.difference(iterable, add))
+        expected = [10, 30, 50, 70, 90]
+        self.assertEqual(actual, expected)
+
+    def test_roundtrip(self):
+        original = list(range(100))
+        accumulated = mi.accumulate(original)
+        actual = list(mi.difference(accumulated))
+        self.assertEqual(actual, original)
+
+    def test_one(self):
+        self.assertEqual(list(mi.difference([0])), [0])
+
+    def test_empty(self):
+        self.assertEqual(list(mi.difference([])), [])

--- a/more_itertools/tests/test_more.py
+++ b/more_itertools/tests/test_more.py
@@ -1498,6 +1498,8 @@ class DifferenceTest(TestCase):
 
     def test_empty(self):
         self.assertEqual(list(mi.difference([])), [])
+
+
 class SeekableTest(TestCase):
     def test_exhaustion_reset(self):
         iterable = [str(n) for n in range(10)]


### PR DESCRIPTION
This PR adds `difference()`, which is the inverse of `accumulate()`.

```python
>>> from more_itertools import accumulate, difference
>>> [1, 2, 3, 4, 5]
[1, 2, 3, 4, 5]
>>> list(accumulate(_))
[1, 3, 6, 10, 15]
>>> list(difference(_))
[1, 2, 3, 4, 5]
```

Like `accumulate()`, this also allows for a custom function to be specified (i.e. one that's not `operator.sub()`):

```python
>>> list(difference('itertools', lambda y, x: '{}->{}'.format(x, y)))
['i', 'i->t', 't->e', 'e->r', 'r->t', 't->o', 'o->o', 'o->l', 'l->s']
```

Numpy calls this operation [`diff()`](https://docs.scipy.org/doc/numpy-1.13.0/reference/generated/numpy.diff.html). There was a Python [issue](https://bugs.python.org/issue13252) that suggested `decumulate()`. In signal processing it would be the "first difference," so `difference()` sounded fine to me.