### PR TITLE
Updates for version 4.0.0

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -124,9 +124,9 @@ These tools return summarized or aggregated data from an iterable.
 .. autofunction:: first(iterable[, default])
 .. autofunction:: one
 .. autofunction:: unique_to_each
-.. autofunction:: locate
-.. autofunction:: consecutive_groups
-.. autofunction:: exactly_n
+.. autofunction:: locate(iterable, pred=bool)
+.. autofunction:: consecutive_groups(iterable, ordering=lambda x: x)
+.. autofunction:: exactly_n(iterable, n, predicate=bool)
 .. autoclass:: run_length
 
 ----
@@ -136,7 +136,7 @@ These tools return summarized or aggregated data from an iterable.
 .. autofunction:: all_equal
 .. autofunction:: first_true
 .. autofunction:: nth
-.. autofunction:: quantify
+.. autofunction:: quantify(iterable, pred=bool)
 
 
 Selecting

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -50,7 +50,7 @@ copyright = u'2012, Erik Rose'
 # built documents.
 #
 # The short X.Y version.
-version = '3.2.0'
+version = '4.0.0'
 # The full version, including alpha/beta/rc tags.
 release = version
 

--- a/docs/versions.rst
+++ b/docs/versions.rst
@@ -13,7 +13,7 @@ Version History
       you're in luck!)
     * :func:`exactly_n` (thanks to michael-celani)
     * :func:`run_length.encode` and :func:`run_length.decode`
-    * :func:`difference`, for inverting :func:`accumulate`
+    * :func:`difference`
 
 * Improvements to existing itertools:
     * The number of items between filler elements in :func:`intersperse` can
@@ -23,9 +23,25 @@ Version History
     * :func:`always_iterable` now returns an iterator object. It also now
       allows different types to be considered iterable (thanks to jaraco)
     * :func:`bucket` can now limit the keys it stores in memory
+
 * Other changes:
     * A few typos were fixed (thanks to EdwardBetts)
     * All tests can now be run with ``python setup.py test``
+
+The major version update is due to the change in the return value of :func:`always_iterable`.
+It now always returns iterator objects:
+
+.. code-block:: python
+
+    >>> from more_itertools import always_iterable
+    # Non-iterable objects are wrapped with iter(tuple(obj))
+    >>> always_iterable(12345)
+    <tuple_iterator object at 0x7fb24c9488d0>
+    >>> list(always_iterable(12345))
+    [12345]
+    # Iterable objects are wrapped with iter()
+    >>> always_iterable([1, 2, 3, 4, 5])
+    <list_iterator object at 0x7fb24c948c50>
 
 3.2.0
 -----

--- a/docs/versions.rst
+++ b/docs/versions.rst
@@ -4,8 +4,32 @@ Version History
 
 .. automodule:: more_itertools
 
+4.0.0
+-----
+
+* New itertools:
+    * :func:`consecutive_groups` (Based on the example in the `Python 2.4 docs <https://docs.python.org/release/2.4.4/lib/itertools-example.html>`_)
+    * :func:`seekable` (If you're looking for how to "reset" an iterator,
+      you're in luck!)
+    * :func:`exactly_n` (thanks to michael-celani)
+    * :func:`run_length.encode` and :func:`run_length.decode`
+    * :func:`difference`, for inverting :func:`accumulate`
+
+* Improvements to existing itertools:
+    * The number of items between filler elements in :func:`intersperse` can
+      now be specified (thanks to pylang)
+    * :func:`distinct_permutations` and :func:`peekable` got some minor
+      adjustments (thanks to MSeifert04)
+    * :func:`always_iterable` now returns an iterator object. It also now
+      allows different types to be considered iterable (thanks to jaraco)
+    * :func:`bucket` can now limit the keys it stores in memory
+* Other changes:
+    * A few typos were fixed (thanks to EdwardBetts)
+    * All tests can now be run with ``python setup.py test``
+
 3.2.0
 -----
+
 * New itertools:
     * :func:`lstrip`, :func:`rstrip`, and :func:`strip`
       (thanks to MSeifert04 and pylang)

--- a/docs/versions.rst
+++ b/docs/versions.rst
@@ -23,6 +23,7 @@ Version History
     * :func:`always_iterable` now returns an iterator object. It also now
       allows different types to be considered iterable (thanks to jaraco)
     * :func:`bucket` can now limit the keys it stores in memory
+    * :func:`one` now allows for custom exceptions (thanks to kalekundert)
 
 * Other changes:
     * A few typos were fixed (thanks to EdwardBetts)

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -1373,6 +1373,20 @@ def locate(iterable, pred=bool):
         >>> list(locate(windowed(iterable, len(sub)), pred=pred))
         [1, 5, 9]
 
+    Use with :func:`seekable` to find indexes and then retrieve the associated
+    items:
+
+        >>> from itertools import count
+        >>> from more_itertools import seekable
+        >>> source = (3 * n + 1 if (n % 2) else n // 2 for n in count())
+        >>> it = seekable(source)
+        >>> pred = lambda x: x > 100
+        >>> indexes = locate(it, pred=pred)
+        >>> i = next(indexes)
+        >>> it.seek(i)
+        >>> next(it)
+        106
+
     """
     return compress(count(), map(pred, iterable))
 

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ def get_long_description():
 
 setup(
     name='more-itertools',
-    version='3.2.0',
+    version='4.0.0',
     description='More routines for operating on iterables, beyond itertools',
     long_description=get_long_description(),
     author='Erik Rose',


### PR DESCRIPTION
This PR adds release notes and some documentation changes for version 4.0.0.

Several new things in this release - many thanks to all the contributors. As the notes state, the major version bump is due to the change in what `always_iterable()` returns (it's mostly compatible, but there's a difference).
