### PR TITLE
Allow one() to throw user-specified exceptions.

### DIFF
--- a/more_itertools/tests/test_more.py
+++ b/more_itertools/tests/test_more.py
@@ -422,6 +422,12 @@ class OneTests(TestCase):
         self.assertRaises(ValueError, lambda: mi.one(numbers))  # burn 0 and 1
         self.assertEqual(next(numbers), 2)
 
+        # Custom exceptions
+        self.assertRaises(ZeroDivisionError,
+                lambda: mi.one([], ZeroDivisionError, OverflowError))
+        self.assertRaises(OverflowError,
+                lambda: mi.one([1,2], ZeroDivisionError, OverflowError))
+
 
 class IntersperseTest(TestCase):
     """ Tests for intersperse() """


### PR DESCRIPTION
The use-case for me is that I often want to present a different error message to the user depending on whether there were too many or too few items in the iterable that was supposed to just have one thing in it.  So I added ``too_short`` and ``too_long`` arguments to ``one()``.  If the iterable is either too short or too long, ``one()`` will raise the exception provided by the appropriate argument.  The default behaviour is to do the exact same thing as before (raise a ValueError in either case).

Tests and documentation are both updated.