### PR TITLE
Custom exceptions for one()

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -122,7 +122,7 @@ These tools return summarized or aggregated data from an iterable.
 
 .. autofunction:: ilen
 .. autofunction:: first(iterable[, default])
-.. autofunction:: one
+.. autofunction:: one(iterable, too_short=ValueError, too_long=ValueError)
 .. autofunction:: unique_to_each
 .. autofunction:: locate
 .. autofunction:: consecutive_groups

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -122,7 +122,7 @@ These tools return summarized or aggregated data from an iterable.
 
 .. autofunction:: ilen
 .. autofunction:: first(iterable[, default])
-.. autofunction:: one(iterable, too_short=ValueError, too_long=ValueError)
+.. autofunction:: one
 .. autofunction:: unique_to_each
 .. autofunction:: locate
 .. autofunction:: consecutive_groups

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -422,12 +422,12 @@ def with_iter(context_manager):
 
 def one(iterable, too_short=ValueError, too_long=ValueError):
     """Return the first item from *iterable*, which is expected to contain only
-    that item. Raise an exception *iterable* is empty or has more than one
+    that item. Raise an exception if *iterable* is empty or has more than one
     item.
 
     :func:`one` is useful for ensuring that an iterable contains only one item.
     For example, it can be used to retrieve the result of a database query
-    that is expected to return only a single row.
+    that is expected to return a single row.
 
     If *iterable* is empty, ``ValueError`` will be raised. You may specify a
     different exception type with the *too_short* keyword:

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -420,7 +420,7 @@ def with_iter(context_manager):
             yield item
 
 
-def one(iterable, too_short=ValueError, too_long=ValueError):
+def one(iterable, too_short=None, too_long=None):
     """Return the first item from *iterable*, which is expected to contain only
     that item. Raise an exception if *iterable* is empty or has more than one
     item.
@@ -430,20 +430,21 @@ def one(iterable, too_short=ValueError, too_long=ValueError):
     that is expected to return a single row.
 
     If *iterable* is empty, ``ValueError`` will be raised. You may specify a
-    different exception type with the *too_short* keyword:
+    different exception with the *too_short* keyword:
 
         >>> it = []
         >>> one(it)  # doctest: +IGNORE_EXCEPTION_DETAIL
         Traceback (most recent call last):
         ...
         ValueError: too many items in iterable (expected 1)'
-        >>> one(it, too_short=IndexError)  # doctest: +IGNORE_EXCEPTION_DETAIL
+        >>> too_short = IndexError('too few items')
+        >>> one(it, too_short=too_short)  # doctest: +IGNORE_EXCEPTION_DETAIL
         Traceback (most recent call last):
         ...
-        IndexError: too few items in iterable (expected 1)'
+        IndexError: too few items
 
     Similarly, if *iterable* contains more than one item, ``ValueError`` will
-    be raised. You may specify a different exception type with the *too_long*
+    be raised. You may specify a different exception with the *too_long*
     keyword:
 
         >>> it = ['too', 'many']
@@ -451,10 +452,11 @@ def one(iterable, too_short=ValueError, too_long=ValueError):
         Traceback (most recent call last):
         ...
         ValueError: too many items in iterable (expected 1)'
-        >>> one(it, too_long=RuntimeError)  # doctest: +IGNORE_EXCEPTION_DETAIL
+        >>> too_long = RuntimeError
+        >>> one(it, too_long=too_long)  # doctest: +IGNORE_EXCEPTION_DETAIL
         Traceback (most recent call last):
         ...
-        RuntimeError: too many items in iterable (expected 1)'
+        RuntimeError
 
     Note that :func:`one` attempts to advance *iterable* twice to ensure there
     is only one item. If there is more than one, both items will be discarded.
@@ -467,14 +469,14 @@ def one(iterable, too_short=ValueError, too_long=ValueError):
     try:
         value = next(it)
     except StopIteration:
-        raise too_short('two few items in iterable (expected 1)')
+        raise too_short or ValueError('too few items in iterable (expected 1)')
 
     try:
         next(it)
     except StopIteration:
         pass
     else:
-        raise too_long('too many items in iterable (expected 1)')
+        raise too_long or ValueError('too many items in iterable (expected 1)')
 
     return value
 

--- a/more_itertools/tests/test_more.py
+++ b/more_itertools/tests/test_more.py
@@ -415,18 +415,22 @@ class WithIterTests(TestCase):
 
 
 class OneTests(TestCase):
-    def test_one(self):
-        """Test the ``one()`` cases that aren't covered by its doctests."""
-        # Infinite iterables
-        numbers = count()
-        self.assertRaises(ValueError, lambda: mi.one(numbers))  # burn 0 and 1
-        self.assertEqual(next(numbers), 2)
+    def test_basic(self):
+        it = iter(['item'])
+        self.assertEqual(mi.one(it), 'item')
 
-        # Custom exceptions
-        self.assertRaises(ZeroDivisionError,
-                lambda: mi.one([], ZeroDivisionError, OverflowError))
-        self.assertRaises(OverflowError,
-                lambda: mi.one([1,2], ZeroDivisionError, OverflowError))
+    def test_too_short(self):
+        it = iter([])
+        self.assertRaises(ValueError, lambda: mi.one(it))
+        self.assertRaises(IndexError, lambda: mi.one(it, too_short=IndexError))
+
+    def test_too_long(self):
+        it = count()
+        self.assertRaises(ValueError, lambda: mi.one(it))  # burn 0 and 1
+        self.assertEqual(next(it), 2)
+        self.assertRaises(
+            OverflowError, lambda: mi.one(it, too_long=OverflowError)
+        )
 
 
 class IntersperseTest(TestCase):

--- a/more_itertools/tests/test_more.py
+++ b/more_itertools/tests/test_more.py
@@ -422,6 +422,12 @@ class OneTests(TestCase):
         self.assertRaises(ValueError, lambda: mi.one(numbers))  # burn 0 and 1
         self.assertEqual(next(numbers), 2)
 
+        # Custom exceptions
+        self.assertRaises(ZeroDivisionError,
+                lambda: mi.one([], ZeroDivisionError, OverflowError))
+        self.assertRaises(OverflowError,
+                lambda: mi.one([1,2], ZeroDivisionError, OverflowError))
+
 
 class IntersperseTest(TestCase):
     """ Tests for intersperse() """


### PR DESCRIPTION
This is PR #176, with:
* `flake8` errors fixed
* ~Exceptions passed as kwargs~
* Re-worked docstring, with a mention of alternatives for situations in which discarding the items isn't desirable