### PR TITLE
Add split()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ _build
 # IDE files
 .idea
 .vscode
+.DS_Store

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -17,7 +17,7 @@ These tools yield groups of items from a source iterable.
 .. autofunction:: sliced
 .. autofunction:: distribute
 .. autofunction:: divide
-.. autofunction:: split
+.. autofunction:: split_at
 .. autofunction:: split_before
 .. autofunction:: split_after
 .. autofunction:: bucket

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -17,6 +17,7 @@ These tools yield groups of items from a source iterable.
 .. autofunction:: sliced
 .. autofunction:: distribute
 .. autofunction:: divide
+.. autofunction:: split
 .. autofunction:: split_before
 .. autofunction:: split_after
 .. autofunction:: bucket

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -125,6 +125,7 @@ These tools return summarized or aggregated data from an iterable.
 .. autofunction:: unique_to_each
 .. autofunction:: locate
 .. autofunction:: consecutive_groups
+.. autofunction:: exactly_n
 
 ----
 

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -55,6 +55,7 @@ __all__ = [
     'side_effect',
     'sliced',
     'sort_together',
+    'split',
     'split_after',
     'split_before',
     'spy',
@@ -882,6 +883,38 @@ def sliced(seq, n):
 
     """
     return takewhile(bool, (seq[i: i + n] for i in count(0, n)))
+
+
+def split(iterable, pred, maxsplit=float('inf')):
+    """Yield lists of items from *iterable*, where each list is delimited by
+    an item where callable *pred* returns ``True``. The lists do not include
+    the delimiting items.
+
+    If *maxsplit* is given, at most *maxsplit* splits are done; if *maxsplit*
+    is negative or not specified, all possible splits are made.
+
+        >>> list(split('abcdcba', lambda x: x == 'b'))
+        [['a'], ['c', 'd', 'c'], ['a']]
+
+        >>> list(split(range(10), lambda n: n % 2 == 1))
+        [[0], [2], [4], [6], [8], []]
+
+        >>> list(split(range(10), lambda n: n % 2 == 1, 1))
+        [[0], [2, 3, 4, 5, 6, 7, 8, 9]]
+    """
+    buf = []
+    splits = 0
+    if maxsplit < 0:
+        maxsplit = float('inf')
+
+    for item in iterable:
+        if pred(item) and splits < maxsplit:
+            yield buf
+            buf = []
+            splits += 1
+        else:
+            buf.append(item)
+    yield buf
 
 
 def split_before(iterable, pred):

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -1590,18 +1590,19 @@ def consecutive_groups(iterable, ordering=lambda x: x):
         yield map(itemgetter(1), g)
 
 
-def exactly_n(iterable, n, predicate=bool):
-    """Return ``True`` if exactly ``n`` items in the iterable are ``True``
-    according to the predicate, a function of one argument which returns
-    a boolean.
+def exactly_n(iterable, n, pred=bool):
+    """Return ``True`` if for exactly ``n`` items in the iterable 
+    :func:`pred` returns ``True``.
     
-    This function will short circuit as soon as it finds n + 1 ``True``
+    This function will short circuit as soon as it finds `n + 1` ``True``
     elements.
 
         >>> exactly_n([True, True, False], 2)
         True
         >>> exactly_n([True, True, False], 1)
         False
+        >>> exactly_n(range(100), 10, lambda x: x < 10)
+        True
 
     """
-    return len(take(n + 1, filter(predicate, iterable))) == n
+    return len(take(n + 1, filter(pred, iterable))) == n

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -885,7 +885,7 @@ def sliced(seq, n):
     return takewhile(bool, (seq[i: i + n] for i in count(0, n)))
 
 
-def split(iterable, pred, maxsplit=float('inf')):
+def split(iterable, pred, maxsplit=-1):
     """Yield lists of items from *iterable*, where each list is delimited by
     an item where callable *pred* returns ``True``. The lists do not include
     the delimiting items.
@@ -902,16 +902,15 @@ def split(iterable, pred, maxsplit=float('inf')):
         >>> list(split(range(10), lambda n: n % 2 == 1, 1))
         [[0], [2, 3, 4, 5, 6, 7, 8, 9]]
     """
-    buf = []
-    splits = 0
     if maxsplit < 0:
         maxsplit = float('inf')
 
+    buf = []
     for item in iterable:
-        if pred(item) and splits < maxsplit:
+        if pred(item) and maxsplit:
             yield buf
             buf = []
-            splits += 1
+            maxsplit -= 1
         else:
             buf.append(item)
     yield buf

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -55,7 +55,7 @@ __all__ = [
     'side_effect',
     'sliced',
     'sort_together',
-    'split',
+    'split_at',
     'split_after',
     'split_before',
     'spy',
@@ -885,7 +885,7 @@ def sliced(seq, n):
     return takewhile(bool, (seq[i: i + n] for i in count(0, n)))
 
 
-def split(iterable, pred, maxsplit=-1):
+def split_at(iterable, pred, maxsplit=-1, discard=True):
     """Yield lists of items from *iterable*, where each list is delimited by
     an item where callable *pred* returns ``True``. The lists do not include
     the delimiting items.
@@ -893,14 +893,21 @@ def split(iterable, pred, maxsplit=-1):
     If *maxsplit* is given, at most *maxsplit* splits are done; if *maxsplit*
     is negative or not specified, all possible splits are made.
 
-        >>> list(split('abcdcba', lambda x: x == 'b'))
+        >>> list(split_at('abcdcba', lambda x: x == 'b'))
         [['a'], ['c', 'd', 'c'], ['a']]
 
-        >>> list(split(range(10), lambda n: n % 2 == 1))
+        >>> list(split_at(range(10), lambda n: n % 2 == 1))
         [[0], [2], [4], [6], [8], []]
 
-        >>> list(split(range(10), lambda n: n % 2 == 1, 1))
+        >>> list(split_at(range(10), lambda n: n % 2 == 1, 1))
         [[0], [2, 3, 4, 5, 6, 7, 8, 9]]
+
+    If the *discard* parameter is set to ``False``, instead of the function
+    omitting the delimiting items, it yields additional lists containing
+    only the delimiter:
+
+        >>> list(split_at('abcdcba', lambda x: x == 'b', discard=False))
+        [['a'], ['b'], ['c', 'd', 'c'], ['b'], ['a']]
     """
     if maxsplit < 0:
         maxsplit = float('inf')
@@ -909,6 +916,8 @@ def split(iterable, pred, maxsplit=-1):
     for item in iterable:
         if pred(item) and maxsplit:
             yield buf
+            if not discard:
+                yield [item]
             buf = []
             maxsplit -= 1
         else:

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -885,41 +885,22 @@ def sliced(seq, n):
     return takewhile(bool, (seq[i: i + n] for i in count(0, n)))
 
 
-def split_at(iterable, pred, maxsplit=-1, discard=True):
+def split_at(iterable, pred):
     """Yield lists of items from *iterable*, where each list is delimited by
     an item where callable *pred* returns ``True``. The lists do not include
     the delimiting items.
-
-    If *maxsplit* is given, at most *maxsplit* splits are done; if *maxsplit*
-    is negative or not specified, all possible splits are made.
 
         >>> list(split_at('abcdcba', lambda x: x == 'b'))
         [['a'], ['c', 'd', 'c'], ['a']]
 
         >>> list(split_at(range(10), lambda n: n % 2 == 1))
         [[0], [2], [4], [6], [8], []]
-
-        >>> list(split_at(range(10), lambda n: n % 2 == 1, 1))
-        [[0], [2, 3, 4, 5, 6, 7, 8, 9]]
-
-    If the *discard* parameter is set to ``False``, instead of the function
-    omitting the delimiting items, it yields additional lists containing
-    only the delimiter:
-
-        >>> list(split_at('abcdcba', lambda x: x == 'b', discard=False))
-        [['a'], ['b'], ['c', 'd', 'c'], ['b'], ['a']]
     """
-    if maxsplit < 0:
-        maxsplit = float('inf')
-
     buf = []
     for item in iterable:
-        if pred(item) and maxsplit:
+        if pred(item):
             yield buf
-            if not discard:
-                yield [item]
             buf = []
-            maxsplit -= 1
         else:
             buf.append(item)
     yield buf

--- a/more_itertools/tests/test_more.py
+++ b/more_itertools/tests/test_more.py
@@ -781,30 +781,16 @@ class SlicedTests(TestCase):
 class SplitAtTests(TestCase):
     """Tests for ``split()``"""
 
-    def comp_with_str_split(self, str_to_split, delim, maxsplits):
+    def comp_with_str_split(self, str_to_split, delim):
         pred = lambda c: c == delim
-        actual = list(map(''.join, mi.split_at(str_to_split, pred, maxsplits)))
-        expected = str_to_split.split(delim, maxsplits)
+        actual = list(map(''.join, mi.split_at(str_to_split, pred)))
+        expected = str_to_split.split(delim)
         self.assertEqual(actual, expected)
 
-    def test_seperators_with_maxsplit(self):
+    def test_seperators(self):
         test_strs = ['', 'abcba', 'aaabbbcccddd', 'e']
-        for s, delim, maxsplits in product(test_strs, 'abcd', range(-2, 3)):
-            self.comp_with_str_split(s, delim, maxsplits)
-
-    def test_discard(self):
-        is_b = lambda c: c == 'b'
-        spl_iter = mi.split_at('abbcb', is_b, discard=False)
-        actual = list(map(''.join, spl_iter))
-        expected = ['a', 'b', '', 'b', 'c', 'b', '']
-        self.assertEqual(actual, expected)
-
-    def test_discard_and_maxsplit(self):
-        is_b = lambda c: c == 'b'
-        spl_iter = mi.split_at('abbcb', is_b, maxsplit=2, discard=False)
-        actual = list(map(''.join, spl_iter))
-        expected = ['a', 'b', '', 'b', 'cb']
-        self.assertEqual(actual, expected)
+        for s, delim in product(test_strs, 'abcd'):
+            self.comp_with_str_split(s, delim)
 
 
 class SplitBeforeTest(TestCase):

--- a/more_itertools/tests/test_more.py
+++ b/more_itertools/tests/test_more.py
@@ -778,14 +778,30 @@ class SlicedTests(TestCase):
             list(mi.sliced(seq, 3))
 
 
-class SplitTests(TestCase):
+class SplitAtTests(TestCase):
     """Tests for ``split()``"""
 
-    def test_seperators_with_maxsteps(self):
+    def test_seperators_with_maxsplit(self):
         test_strs = ['', 'abcba', 'aaabbbcccddd', 'e']
-        for s, sep, num in product(test_strs, 'abcd', range(-2, 3)):
-            actual = list(map(''.join, mi.split(s, lambda c: c == sep, num)))
-            self.assertEqual(actual, s.split(sep, num))
+        for s, sep, n in product(test_strs, 'abcd', range(-2, 3)):
+            actual = list(map(''.join, mi.split_at(s, lambda c: c == sep, n)))
+            self.assertEqual(actual, s.split(sep, n))
+
+    def test_discard(self):
+        is_b = lambda c: c == 'b'
+        spl_iter = mi.split_at('abcb', is_b, discard=False)
+
+        actual = list(map(''.join, spl_iter))
+        expected = ['a', 'b', 'c', 'b', '']
+        self.assertEqual(actual, expected)
+
+    def test_discard_and_maxsplit(self):
+        is_b = lambda c: c == 'b'
+        spl_iter = mi.split_at('abcb', is_b, maxsplit=1, discard=False)
+
+        actual = list(map(''.join, spl_iter))
+        expected = ['a', 'b', 'cb']
+        self.assertEqual(actual, expected)
 
 
 class SplitBeforeTest(TestCase):

--- a/more_itertools/tests/test_more.py
+++ b/more_itertools/tests/test_more.py
@@ -781,26 +781,29 @@ class SlicedTests(TestCase):
 class SplitAtTests(TestCase):
     """Tests for ``split()``"""
 
+    def comp_with_str_split(self, str_to_split, delim, maxsplits):
+        pred = lambda c: c == delim
+        actual = list(map(''.join, mi.split_at(str_to_split, pred, maxsplits)))
+        expected = str_to_split.split(delim, maxsplits)
+        self.assertEqual(actual, expected)
+
     def test_seperators_with_maxsplit(self):
         test_strs = ['', 'abcba', 'aaabbbcccddd', 'e']
-        for s, sep, n in product(test_strs, 'abcd', range(-2, 3)):
-            actual = list(map(''.join, mi.split_at(s, lambda c: c == sep, n)))
-            self.assertEqual(actual, s.split(sep, n))
+        for s, delim, maxsplits in product(test_strs, 'abcd', range(-2, 3)):
+            self.comp_with_str_split(s, delim, maxsplits)
 
     def test_discard(self):
         is_b = lambda c: c == 'b'
-        spl_iter = mi.split_at('abcb', is_b, discard=False)
-
+        spl_iter = mi.split_at('abbcb', is_b, discard=False)
         actual = list(map(''.join, spl_iter))
-        expected = ['a', 'b', 'c', 'b', '']
+        expected = ['a', 'b', '', 'b', 'c', 'b', '']
         self.assertEqual(actual, expected)
 
     def test_discard_and_maxsplit(self):
         is_b = lambda c: c == 'b'
-        spl_iter = mi.split_at('abcb', is_b, maxsplit=1, discard=False)
-
+        spl_iter = mi.split_at('abbcb', is_b, maxsplit=2, discard=False)
         actual = list(map(''.join, spl_iter))
-        expected = ['a', 'b', 'cb']
+        expected = ['a', 'b', '', 'b', 'cb']
         self.assertEqual(actual, expected)
 
 

--- a/more_itertools/tests/test_more.py
+++ b/more_itertools/tests/test_more.py
@@ -782,7 +782,7 @@ class SplitTests(TestCase):
     """Tests for ``split()``"""
 
     def test_seperators_with_maxsteps(self):
-        test_strs = ['','abcba','aaabbbcccddd','e']
+        test_strs = ['', 'abcba', 'aaabbbcccddd', 'e']
         for s, sep, num in product(test_strs, 'abcd', range(-2, 3)):
             actual = list(map(''.join, mi.split(s, lambda c: c == sep, num)))
             self.assertEqual(actual, s.split(sep, num))

--- a/more_itertools/tests/test_more.py
+++ b/more_itertools/tests/test_more.py
@@ -778,6 +778,16 @@ class SlicedTests(TestCase):
             list(mi.sliced(seq, 3))
 
 
+class SplitTests(TestCase):
+    """Tests for ``split()``"""
+
+    def test_seperators_with_maxsteps(self):
+        test_strs = ['','abcba','aaabbbcccddd','e']
+        for s, sep, num in product(test_strs, 'abcd', range(-2, 3)):
+            actual = list(map(''.join, mi.split(s, lambda c: c == sep, num)))
+            self.assertEqual(actual, s.split(sep, num))
+
+
 class SplitBeforeTest(TestCase):
     """Tests for ``split_before()``"""
 


### PR DESCRIPTION
We have ``split_before()``, a splitting function where lists start with the delimiting item, and ``split_after()``, a splitting function where lists end with the delimiting item, but no ``split()`` function that's analogous to ``str.split()``, which omits the delimiting item entirely. This pull request adds such a function.

Note that this itertool is not implemented using `itertools.takewhile()` because that implementation cannot tell if we exhausted the iterator because it ran out of elements or if because the last element's predicate returned `True`. This is problematic because that determines whether or not we should yield an additional empty list. I don't know how to work around that, so I thought a new itertool would be appropriate:

```python
>>> list(split('abcdc', lambda x: x == 'b'))
[['a'], ['c', 'd', 'c']]
>>> list(split('abcdcb', lambda x: x == 'b'))  # takewhile() would consume the last 'b'
[['a'], ['c', 'd', 'c'], []]
```
