### PR TITLE
Make seekable() a decorator

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -42,7 +42,7 @@ These tools peek at an iterable's values without advancing it.
 
 .. autofunction:: spy
 .. autoclass:: peekable
-.. autoclass:: seekable
+.. autofunction:: seekable
 
 
 Windowing

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -1,7 +1,7 @@
 from __future__ import print_function
 
 from collections import Counter, defaultdict, deque
-from functools import partial, update_wrapper, wraps
+from functools import partial, wraps
 from heapq import merge
 from itertools import (
     chain,
@@ -1696,6 +1696,12 @@ def difference(iterable, func=sub):
 
 
 class _Seekable(object):
+    """Wrapper class for iterables, allowing them to seek backward and forward.
+    See :func:`seekable`, which allows this to be used as a decorator for
+    details.
+
+    """
+
     def __init__(self, iterable):
         self._source = iter(iterable)
         self._cache = []

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -1,7 +1,7 @@
 from __future__ import print_function
 
 from collections import Counter, defaultdict, deque
-from functools import partial, wraps
+from functools import partial, update_wrapper, wraps
 from heapq import merge
 from itertools import (
     chain,
@@ -1759,6 +1759,7 @@ class seekable(object):
                 raise
             self._source = None
             self._func = iterable
+            update_wrapper(self, iterable)
         else:
             self._func = None
 

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -1761,14 +1761,26 @@ class seekable(object):
             self._func = iterable
         else:
             self._func = None
+
+        self._instance = None
         self._cache = []
         self._index = None
 
     def __call__(self, *args, **kwargs):
         if self._func is None:
             raise TypeError('object is not callable')
+
+        # For decorating methods
+        if self._instance is not None:
+            args = (self._instance,) + args
+
         self._source = iter(self._func(*args, **kwargs))
         return self
+
+    def __get__(self, instance, owner):
+        self._instance = instance
+
+        return self.__call__
 
     def __iter__(self):
         return self

--- a/more_itertools/tests/test_more.py
+++ b/more_itertools/tests/test_more.py
@@ -1666,6 +1666,24 @@ class SeekableTest(TestCase):
         s.seek(1)
         self.assertEqual(list(s), [1, 2, 3, 4])
 
+    def test_decorate_method(self):
+        class Methodical(object):
+            def __init__(self, n):
+                self._n = n
+
+            def __call__(self, x):
+                return self._n + x
+
+            @mi.seekable
+            def method(self, x):
+                for i in range(self._n + x):
+                    yield i
+
+        it = Methodical(5).method(1)
+        self.assertEqual(list(it), [0, 1, 2, 3, 4, 5])
+        it.seek(1)
+        self.assertEqual(list(it), [1, 2, 3, 4, 5])
+
     def test_type_failure(self):
         self.assertRaises(TypeError, lambda: mi.seekable(5))
 

--- a/more_itertools/tests/test_more.py
+++ b/more_itertools/tests/test_more.py
@@ -1627,6 +1627,8 @@ class SeekableTest(TestCase):
             def __next__(self):
                 return next(self._it)
 
+            next = __next__
+
         # The class implements __iter__ and __next__
         s = Iterable(5)
         self.assertEqual(list(s), [0, 1, 2, 3, 4])

--- a/more_itertools/tests/test_more.py
+++ b/more_itertools/tests/test_more.py
@@ -1569,6 +1569,104 @@ class SeekableTest(TestCase):
         s.seek(0)  # Back to 0
         self.assertEqual(list(s), iterable)  # No difference in result
 
+    def test_callability(self):
+        # If we're wrapping an iterable, you shouldn't be able to call the
+        # wrapped result
+        self.assertRaises(TypeError, lambda: mi.seekable([])())
+
+        # If we're wrapping a function, you should get back the
+        # seekable-wrapped object when you call it
+        s = mi.seekable(lambda n: iter(range(n)))
+        call_result = s(5)
+        self.assertEqual(list(call_result), [0, 1, 2, 3, 4])
+
+    def test_decorate_generator_function(self):
+        @mi.seekable
+        def generator_function(n):
+            return iter(range(n))
+
+        s = generator_function(5)
+        self.assertEqual(list(s), [0, 1, 2, 3, 4])
+        s.seek(1)
+        self.assertEqual(list(s), [1, 2, 3, 4])
+
+    def test_decorate_regular_function(self):
+        @mi.seekable
+        def regular_function(n):
+            return n + n
+
+        # The function isn't a generator function, nor does it return an
+        # iterable
+        self.assertRaises(TypeError, lambda: regular_function(5))
+
+    def test_decorate_reiterable_class(self):
+        @mi.seekable
+        class Reiterable(object):
+            def __init__(self, n):
+                self.n = n
+
+            def __iter__(self):
+                for i in range(self.n):
+                    yield i
+
+        # The class implements __iter__ but not __next__
+        s = Reiterable(5)
+        self.assertEqual(list(s), [0, 1, 2, 3, 4])
+        s.seek(1)
+        self.assertEqual(list(s), [1, 2, 3, 4])
+
+    def test_decorate_iterable_class(self):
+        @mi.seekable
+        class Iterable(object):
+            def __init__(self, n):
+                self._it = (i for i in range(n))
+
+            def __iter__(self):
+                return self
+
+            def __next__(self):
+                return next(self._it)
+
+        # The class implements __iter__ and __next__
+        s = Iterable(5)
+        self.assertEqual(list(s), [0, 1, 2, 3, 4])
+        s.seek(1)
+        self.assertEqual(list(s), [1, 2, 3, 4])
+
+    def test_decorate_callable_class(self):
+        @mi.seekable
+        class Callable(object):
+            def __init__(self, n):
+                self._n = n
+
+            def __call__(self, x):
+                return self._n + x
+
+        # The class implements __call__, so isn't rejected in __init__.
+        self.assertRaises(TypeError, lambda: Callable(5))
+
+    def test_decorate_sequence(self):
+        @mi.seekable
+        class Sequence(object):
+            def __init__(self, n):
+                self._n = n
+                self._seq = list(range(n))
+
+            def __len__(self):
+                return self._n
+
+            def __getitem__(self, index):
+                return self._seq[index]
+
+        # The class implements the Sequence protocol
+        s = Sequence(5)
+        self.assertEqual(list(s), [0, 1, 2, 3, 4])
+        s.seek(1)
+        self.assertEqual(list(s), [1, 2, 3, 4])
+
+    def test_type_failure(self):
+        self.assertRaises(TypeError, lambda: mi.seekable(5))
+
 
 class RunLengthTest(TestCase):
     def test_encode(self):

--- a/more_itertools/tests/test_more.py
+++ b/more_itertools/tests/test_more.py
@@ -1646,7 +1646,7 @@ class SeekableTest(TestCase):
             def __call__(self, x):
                 return self._n + x
 
-        # The class implements __call__, so isn't rejected in __init__.
+        # The class implements __call__, so isn't rejected right away.
         self.assertRaises(TypeError, lambda: Callable(5))
 
     def test_decorate_sequence(self):
@@ -1678,6 +1678,7 @@ class SeekableTest(TestCase):
 
             @mi.seekable
             def method(self, x):
+                """docstring"""
                 for i in range(self._n + x):
                     yield i
 
@@ -1685,6 +1686,7 @@ class SeekableTest(TestCase):
         self.assertEqual(list(it), [0, 1, 2, 3, 4, 5])
         it.seek(1)
         self.assertEqual(list(it), [1, 2, 3, 4, 5])
+        self.assertEqual(Methodical(5).method.__doc__, 'docstring')
 
     def test_type_failure(self):
         self.assertRaises(TypeError, lambda: mi.seekable(5))

--- a/more_itertools/tests/test_more.py
+++ b/more_itertools/tests/test_more.py
@@ -1593,11 +1593,13 @@ class SeekableTest(TestCase):
     def test_decorate_regular_function(self):
         @mi.seekable
         def regular_function(n):
+            """docstring"""
             return n + n
 
         # The function isn't a generator function, nor does it return an
         # iterable
         self.assertRaises(TypeError, lambda: regular_function(5))
+        self.assertEqual(regular_function.__doc__, 'docstring')
 
     def test_decorate_reiterable_class(self):
         @mi.seekable


### PR DESCRIPTION
Re: Issue #181 , this PR takes @pylang's suggestion seriously and augments `seekable()` such that it can behave as a decorator.

My concern with my [hacky original implementation](https://github.com/erikrose/more-itertools/issues/181#issuecomment-349185921) (which checked the argument to `seekable()` to see whether it was `callable()`) was in wrapping classes that were both iterable and callable.

I think I've satisfied myself that it's possible to avoid any issues with that and preserve the original behavior of `seekable()`. So in this implementation we check whether the argument is iterable. It it is, we continue as always. If not, we check whether it's a function.

Anybody see any downsides? As you can see, I took a two-belts-and-four-suspenders approach in the tests to convince myself.

I'll look at doing `peekable()` also.