### PR TITLE
Make seekable() and peekable() decorators

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -41,8 +41,8 @@ These tools peek at an iterable's values without advancing it.
 
 
 .. autofunction:: spy
-.. autoclass:: peekable
-.. autoclass:: seekable
+.. autofunction:: peekable(iterable)
+.. autofunction:: seekable(iterable)
 
 
 Windowing

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -207,6 +207,23 @@ class _Peekable(object):
     negative indexes and slices are supported. Indexing will cache only the
     necessary items, but be aware that this may require significant storage.
 
+    :func:`peekable` can be used as a decorator for generator functions (and
+    other callables that return iterable objects):
+
+        >>> @peekable
+        ... def yielder(n):
+        ...     for i in range(n):
+        ...         yield str(i)
+        ...
+        >>> it = yielder(5)
+        >>> it.peek()
+        '0'
+        >>> list(it)
+        ['0', '1', '2', '3', '4']
+        >>> it.peek('default')
+        'default'
+
+
     """
     def __init__(self, iterable):
         self._it = iter(iterable)
@@ -1748,7 +1765,6 @@ class _Seekable(object):
         >>> it.seek(0)
         >>> list(it)
         ['0', '1', '2', '3', '4']
-        >>> it.seek(0)
 
     The cache grows as the source iterable progresses, so beware of wrapping
     very large or infinite iterables.

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -1,7 +1,7 @@
 from __future__ import print_function
 
 from collections import Counter, defaultdict, deque
-from functools import partial, wraps
+from functools import partial, update_wrapper, wraps
 from heapq import merge
 from itertools import (
     chain,
@@ -74,7 +74,7 @@ __all__ = [
 _marker = object()
 
 
-def _decorator_factory(cls):
+def _wrapper_factory(cls):
     """Allow *cls* to wrap either an iterable or a function.
     *cls* must be a class whose constructor takes an iterable, or a callable
     function or method that returns an iterable object.
@@ -95,7 +95,7 @@ def _decorator_factory(cls):
 
         return callable_wrapper
 
-    decorator.__doc__ = cls.__doc__
+    update_wrapper(decorator, cls)
 
     return decorator
 
@@ -317,7 +317,7 @@ class _Peekable(object):
         return self._cache[index]
 
 
-peekable = _decorator_factory(_Peekable)
+peekable = _wrapper_factory(_Peekable)
 
 
 def _collate(*iterables, **kwargs):
@@ -1803,7 +1803,7 @@ class _Seekable(object):
             consume(self, remainder)
 
 
-seekable = _decorator_factory(_Seekable)
+seekable = _wrapper_factory(_Seekable)
 
 
 class run_length(object):

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -32,7 +32,6 @@ __all__ = [
     'consecutive_groups',
     'consumer',
     'count_cycle',
-    '_decorator_factory',
     'difference',
     'distinct_permutations',
     'distribute',

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -82,12 +82,12 @@ def _wrapper_factory(cls):
     """
     def decorator(iterable_or_callable):
         try:
-            iter(iterable_or_callable)
+            it = iter(iterable_or_callable)
         except TypeError:
             if not callable(iterable_or_callable):
                 raise
         else:
-            return cls(iterable_or_callable)
+            return cls(it)
 
         @wraps(iterable_or_callable)
         def callable_wrapper(*args, **kwargs):
@@ -226,8 +226,8 @@ class _Peekable(object):
 
 
     """
-    def __init__(self, iterable):
-        self._it = iter(iterable)
+    def __init__(self, iterable, force_iter=False):
+        self._it = iter(iterable) if force_iter else iterable
         self._cache = deque()
 
     def __iter__(self):
@@ -1772,8 +1772,8 @@ class _Seekable(object):
 
     """
 
-    def __init__(self, iterable):
-        self._source = iter(iterable)
+    def __init__(self, iterable, force_iter=False):
+        self._source = iter(iterable) if force_iter else iterable
         self._cache = []
         self._index = None
 

--- a/more_itertools/tests/test_more.py
+++ b/more_itertools/tests/test_more.py
@@ -370,6 +370,21 @@ class PeekableTests(TestCase):
         self.assertEqual(list(p), ['1', '2', '3', '4'])
         self.assertEqual(generator_function.__doc__, 'docstring')
 
+    def test_iter_count(self):
+        # Don't call __iter__ twice when wrapping
+        class IterCounter(list):
+            def __init__(self, *args, **kwargs):
+                super(IterCounter, self).__init__(*args, **kwargs)
+                self.iter_count = 0
+
+            def __iter__(self):
+                self.iter_count += 1
+                return super(IterCounter, self).__iter__()
+
+        obj = IterCounter()
+        mi.peekable(obj)
+        self.assertEqual(obj.iter_count, 1)
+
 
 class ConsumerTests(TestCase):
     """Tests for ``consumer()``"""
@@ -1589,6 +1604,21 @@ class SeekableTest(TestCase):
         it.seek(0)
         self.assertEqual(list(it), ['0', '1', '2', '3', '4'])
         self.assertEqual(generator_function.__doc__, 'docstring')
+
+    def test_iter_count(self):
+        # Don't call __iter__ twice when wrapping
+        class IterCounter(list):
+            def __init__(self, *args, **kwargs):
+                super(IterCounter, self).__init__(*args, **kwargs)
+                self.iter_count = 0
+
+            def __iter__(self):
+                self.iter_count += 1
+                return super(IterCounter, self).__iter__()
+
+        obj = IterCounter()
+        mi.seekable(obj)
+        self.assertEqual(obj.iter_count, 1)
 
 
 class RunLengthTest(TestCase):

--- a/more_itertools/tests/test_more.py
+++ b/more_itertools/tests/test_more.py
@@ -12,7 +12,7 @@ from unittest import TestCase
 from six.moves import filter, map, range, zip
 
 import more_itertools as mi
-from more_itertools.more import _decorator_factory
+from more_itertools.more import _wrapper_factory
 
 
 def load_tests(loader, tests, ignore):
@@ -1645,7 +1645,7 @@ class CyclicPermutationsTests(TestCase):
                           (3, 0, 1, 2)])
 
 
-# Dummy class for _decorator_factory tests
+# Dummy class for _wrapper_factory tests
 
 class _ItemCounter(object):
     """Call :meth:`item_count` to see how many items have been seen"""
@@ -1665,10 +1665,10 @@ class _ItemCounter(object):
     next = __next__
 
 
-item_counter = _decorator_factory(_ItemCounter)
+item_counter = _wrapper_factory(_ItemCounter)
 
 
-class DecoratorFactoryTests(TestCase):
+class WrapperFactoryTests(TestCase):
     def test_decorate_generator_function(self):
         @item_counter
         def generator_function(n):

--- a/more_itertools/tests/test_more.py
+++ b/more_itertools/tests/test_more.py
@@ -12,6 +12,7 @@ from unittest import TestCase
 from six.moves import filter, map, range, zip
 
 import more_itertools as mi
+from more_itertools.more import _decorator_factory
 
 
 def load_tests(loader, tests, ignore):
@@ -1648,7 +1649,7 @@ class _ItemCounter(object):
     next = __next__
 
 
-item_counter = mi._decorator_factory(_ItemCounter)
+item_counter = _decorator_factory(_ItemCounter)
 
 
 class DecoratorFactoryTests(TestCase):


### PR DESCRIPTION
Re: Issue #181 , this PR takes another shot at @pylang's idea about making `peekable()` and `seekable()` act as decorators.

PR #182 had some discussion about one implementation, using decorator classes. That implementation has only [minor issues](https://github.com/erikrose/more-itertools/pull/182#issuecomment-349863951), but I found that this decorator function implementation seems cleaner.

In a nutshell, this PR:
* Adds `more._decorator_factory`, which handles turning iterable-wrapping classes into function-wrapping decorators.
* Adds thorough tests for the new function
* Uses the new function to make `peekable` and `seekable` into decorators
* Cleans up the `peekable` docstring a bit.

The new function isn't documented as part of the library and is considered internal.