### PR TITLE
Add seekable.elements method

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -217,6 +217,7 @@ Others
 .. autofunction:: side_effect
 .. autofunction:: iterate
 .. autofunction:: difference(iterable, func=operator.sub)
+.. autoclass:: SequenceView
 
 ----
 

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -56,6 +56,7 @@ __all__ = [
     'rstrip',
     'run_length',
     'seekable',
+    'SequenceView',
     'side_effect',
     'sliced',
     'sort_together',
@@ -1698,8 +1699,33 @@ def difference(iterable, func=sub):
 
 
 class SequenceView(Sequence):
-    """Read-only view of the target sequence.
-    Supports for indexing, slicing, and iteration like a list or tuple.
+    """Return a read-only view of the sequence object *target*.
+
+    :class:`SequenceView` objects are analagous to Python's built-in
+    "dictionary view" types. They provide a dynamic view of a sequence's items,
+    meaning that when the sequence updates, so does the view.
+
+        >>> seq = ['0', '1', '2']
+        >>> view = SequenceView(seq)
+        >>> view
+        SequenceView(['0', '1', '2'])
+        >>> seq.append('3')
+        >>> view
+        SequenceView(['0', '1', '2', '3'])
+
+    Sequence views support indexing, slicing, and length queries. They act
+    like the underlying sequence, except they don't allow assignment:
+
+        >>> view[1]
+        '1'
+        >>> view[1:-1]
+        ['1', '2']
+        >>> len(view)
+        4
+
+    Sequence views are useful as an alternative to copying, as they don't
+    require (much) extra storage.
+
     """
     def __init__(self, target):
         if not isinstance(target, Sequence):
@@ -1713,7 +1739,7 @@ class SequenceView(Sequence):
         return len(self._target)
 
     def __repr__(self):
-        return 'SequenceView({})'.format(repr(self._target))
+        return '{}({})'.format(self.__class__.__name__, repr(self._target))
 
 
 class seekable(object):
@@ -1752,8 +1778,8 @@ class seekable(object):
     The cache grows as the source iterable progresses, so beware of wrapping
     very large or infinite iterables.
 
-    Retrieve the contents of the cache with the :meth:`items` method, which
-    returns a read-only view of the cache that updates automatically:
+    You may view the contents of the cache with the :meth:`items` method.
+    That returns a :class:`SequenceView`, a view that updates automatically:
 
         >>> it = seekable((str(n) for n in range(10)))
         >>> next(it), next(it), next(it)

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -1733,6 +1733,14 @@ class seekable(object):
     The cache grows as the source iterable progresses, so beware of wrapping
     very large or infinite iterables.
 
+    View the contents with the :meth:`items` method:
+
+        >>> it = seekable((str(n) for n in range(10)))
+        >>> next(it), next(it), next(it)
+        ('0', '1', '2')
+        >>> it.items()
+        ['0', '1', '2']
+
     """
 
     def __init__(self, iterable):
@@ -1758,6 +1766,9 @@ class seekable(object):
         return item
 
     next = __next__
+
+    def items(self):
+        return self._cache[:]
 
     def seek(self, index):
         self._index = index

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -1790,18 +1790,18 @@ class seekable(object):
     The cache grows as the source iterable progresses, so beware of wrapping
     very large or infinite iterables.
 
-    You may view the contents of the cache with the :meth:`items` method.
+    You may view the contents of the cache with the :meth:`elements` method.
     That returns a :class:`SequenceView`, a view that updates automatically:
 
         >>> it = seekable((str(n) for n in range(10)))
         >>> next(it), next(it), next(it)
         ('0', '1', '2')
-        >>> items = it.items()
-        >>> items
+        >>> elements = it.elements()
+        >>> elements
         SequenceView(['0', '1', '2'])
         >>> next(it)
         '3'
-        >>> items
+        >>> elements
         SequenceView(['0', '1', '2', '3'])
 
     """
@@ -1830,7 +1830,7 @@ class seekable(object):
 
     next = __next__
 
-    def items(self):
+    def elements(self):
         return SequenceView(self._cache)
 
     def seek(self, index):

--- a/more_itertools/tests/test_more.py
+++ b/more_itertools/tests/test_more.py
@@ -1587,19 +1587,19 @@ class SeekableTest(TestCase):
 
 class SequenceViewTests(TestCase):
     def test_init(self):
-        view = mi.SequenceView(('a', 'b', 'c'))
-        self.assertEqual(repr(view), "SequenceView(('a', 'b', 'c'))")
+        view = mi.SequenceView((1, 2, 3))
+        self.assertEqual(repr(view), "SequenceView((1, 2, 3))")
         self.assertRaises(TypeError, lambda: mi.SequenceView({}))
 
     def test_update(self):
-        seq = ['a', 'b', 'c']
+        seq = [1, 2, 3]
         view = mi.SequenceView(seq)
         self.assertEqual(len(view), 3)
-        self.assertEqual(repr(view), "SequenceView(['a', 'b', 'c'])")
+        self.assertEqual(repr(view), "SequenceView([1, 2, 3])")
 
         seq.pop()
         self.assertEqual(len(view), 2)
-        self.assertEqual(repr(view), "SequenceView(['a', 'b'])")
+        self.assertEqual(repr(view), "SequenceView([1, 2])")
 
     def test_indexing(self):
         seq = ('a', 'b', 'c', 'd', 'e', 'f')

--- a/more_itertools/tests/test_more.py
+++ b/more_itertools/tests/test_more.py
@@ -1583,9 +1583,61 @@ class SeekableTest(TestCase):
 
         mi.take(10, s)
         self.assertEqual(list(items), [str(n) for n in range(20)])
-        self.assertEqual(len(items), 20)
 
-        self.assertRaises(TypeError, lambda: type(items)({}))
+
+class SequenceViewTests(TestCase):
+    def test_init(self):
+        view = mi.SequenceView(('a', 'b', 'c'))
+        self.assertEqual(repr(view), "SequenceView(('a', 'b', 'c'))")
+        self.assertRaises(TypeError, lambda: mi.SequenceView({}))
+
+    def test_update(self):
+        seq = ['a', 'b', 'c']
+        view = mi.SequenceView(seq)
+        self.assertEqual(len(view), 3)
+        self.assertEqual(repr(view), "SequenceView(['a', 'b', 'c'])")
+
+        seq.pop()
+        self.assertEqual(len(view), 2)
+        self.assertEqual(repr(view), "SequenceView(['a', 'b'])")
+
+    def test_indexing(self):
+        seq = ('a', 'b', 'c', 'd', 'e', 'f')
+        view = mi.SequenceView(seq)
+        for i in range(-len(seq), len(seq)):
+            self.assertEqual(view[i], seq[i])
+
+    def test_slicing(self):
+        seq = ('a', 'b', 'c', 'd', 'e', 'f')
+        view = mi.SequenceView(seq)
+        n = len(seq)
+        indexes = list(range(-n - 1, n + 1)) + [None]
+        steps = list(range(-n, n + 1))
+        steps.remove(0)
+        for slice_args in product(indexes, indexes, steps):
+            i = slice(*slice_args)
+            self.assertEqual(view[i], seq[i])
+
+    def test_abc_methods(self):
+        # collections.Sequence should provide all of this functionality
+        seq = ('a', 'b', 'c', 'd', 'e', 'f', 'f')
+        view = mi.SequenceView(seq)
+
+        # __contains__
+        self.assertIn('b', view)
+        self.assertNotIn('g', view)
+
+        # __iter__
+        self.assertEqual(list(iter(view)), list(seq))
+
+        # __reversed__
+        self.assertEqual(list(reversed(view)), list(reversed(seq)))
+
+        # index
+        self.assertEqual(view.index('b'), 1)
+
+        # count
+        self.assertEqual(seq.count('f'), 2)
 
 
 class RunLengthTest(TestCase):

--- a/more_itertools/tests/test_more.py
+++ b/more_itertools/tests/test_more.py
@@ -1536,6 +1536,9 @@ class SeekableTest(TestCase):
         s.seek(0)
         self.assertEqual(list(s), iterable)  # Back in action
 
+        self.assertEqual(s.items(), iterable)
+        self.assertFalse(s.items() is s._cache)
+
     def test_partial_reset(self):
         iterable = [str(n) for n in range(10)]
 

--- a/more_itertools/tests/test_more.py
+++ b/more_itertools/tests/test_more.py
@@ -1582,20 +1582,20 @@ class SeekableTest(TestCase):
         s.seek(0)  # Back to 0
         self.assertEqual(list(s), iterable)  # No difference in result
 
-    def test_items(self):
+    def test_elements(self):
         iterable = map(str, count())
 
         s = mi.seekable(iterable)
         mi.take(10, s)
 
-        items = s.items()
+        elements = s.elements()
         self.assertEqual(
-            [items[i] for i in range(10)], [str(n) for n in range(10)]
+            [elements[i] for i in range(10)], [str(n) for n in range(10)]
         )
-        self.assertEqual(len(items), 10)
+        self.assertEqual(len(elements), 10)
 
         mi.take(10, s)
-        self.assertEqual(list(items), [str(n) for n in range(20)])
+        self.assertEqual(list(elements), [str(n) for n in range(20)])
 
 
 class SequenceViewTests(TestCase):

--- a/more_itertools/tests/test_more.py
+++ b/more_itertools/tests/test_more.py
@@ -9,7 +9,7 @@ from itertools import chain, count, groupby, permutations, product, repeat
 from operator import add, itemgetter
 from unittest import TestCase
 
-from six.moves import filter, range, zip
+from six.moves import filter, map, range, zip
 
 import more_itertools as mi
 
@@ -1536,9 +1536,6 @@ class SeekableTest(TestCase):
         s.seek(0)
         self.assertEqual(list(s), iterable)  # Back in action
 
-        self.assertEqual(s.items(), iterable)
-        self.assertFalse(s.items() is s._cache)
-
     def test_partial_reset(self):
         iterable = [str(n) for n in range(10)]
 
@@ -1571,6 +1568,24 @@ class SeekableTest(TestCase):
 
         s.seek(0)  # Back to 0
         self.assertEqual(list(s), iterable)  # No difference in result
+
+    def test_items(self):
+        iterable = map(str, count())
+
+        s = mi.seekable(iterable)
+        mi.take(10, s)
+
+        items = s.items()
+        self.assertEqual(
+            [items[i] for i in range(10)], [str(n) for n in range(10)]
+        )
+        self.assertEqual(len(items), 10)
+
+        mi.take(10, s)
+        self.assertEqual(list(items), [str(n) for n in range(20)])
+        self.assertEqual(len(items), 20)
+
+        self.assertRaises(TypeError, lambda: type(items)({}))
 
 
 class RunLengthTest(TestCase):


### PR DESCRIPTION
This PR adds ~`seekable.items()`~`seekable.elements()`, which just returns a copy of the cache of things that have been iterated over so far.

~I'm having it return a copy instead of a reference to `self._cache`, because mutating the result would then affect the seeking behavior.~

~An alternative name might be `elements` - [Counter](https://docs.python.org/3/library/collections.html#collections.Counter.elements) has this, but it's a little different.~