### PR TITLE
Add make_decorator function

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -217,6 +217,7 @@ Others
 .. autofunction:: side_effect
 .. autofunction:: iterate
 .. autofunction:: difference(iterable, func=operator.sub)
+.. autofunction:: make_decorator
 
 ----
 

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -49,6 +49,7 @@ __all__ = [
     'iterate',
     'locate',
     'lstrip',
+    'make_decorator',
     'numeric_range',
     'one',
     'padded',
@@ -1823,7 +1824,7 @@ def cyclic_permutations(iterable):
     return take(len(lst), windowed(cycle(lst), len(lst)))
 
 
-def decorator_factory(wrapping_func, result_index=0):
+def make_decorator(wrapping_func, result_index=0):
     """Return a decorator version of *wrapping_func*, which is a function that
     modifies an iterable. *result_index* is the position in that function's
     signature where the iterable goes.
@@ -1835,7 +1836,7 @@ def decorator_factory(wrapping_func, result_index=0):
     For example, to produce a decorator version of :func:`chunked`:
 
         >>> from more_itertools import chunked
-        >>> chunker = decorator_factory(chunked, result_index=0)
+        >>> chunker = make_decorator(chunked, result_index=0)
         >>> @chunker(3)
         ... def iter_range(n):
         ...     return iter(range(n))
@@ -1845,26 +1846,16 @@ def decorator_factory(wrapping_func, result_index=0):
 
     To only allow truthy items to be returned:
 
-        >>> truth_serum = decorator_factory(filter, result_index=1)
+        >>> truth_serum = make_decorator(filter, result_index=1)
         >>> @truth_serum(bool)
         ... def boolean_test():
         ...     return [0, 1, '', ' ', False, True]
         >>> list(boolean_test())
         [1, ' ', True]
 
-    To limit the number of results yielded to the first n:
-
-        >>> from itertools import count, islice
-        >>> limiter = decorator_factory(islice, result_index=0)
-        >>> @limiter(5)
-        ... def infinite_counter(n):
-        ...     return count(n)
-        ...
-        >>> list(infinite_counter(0))
-        [0, 1, 2, 3, 4]
-
     """
-
+    # See https://sites.google.com/site/bbayles/index/decorator_factory for
+    # notes on how this works.
     def decorator(*wrapping_args, **wrapping_kwargs):
         def outer_wrapper(f):
             def inner_wrapper(*args, **kwargs):

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -1850,8 +1850,26 @@ def make_decorator(wrapping_func, result_index=0):
         >>> @truth_serum(bool)
         ... def boolean_test():
         ...     return [0, 1, '', ' ', False, True]
+        ...
         >>> list(boolean_test())
         [1, ' ', True]
+
+    The :func:`peekable` and :func:`seekable` wrappers make for practical
+    decorators:
+
+        >>> from more_itertools import peekable
+        >>> peekable_function = make_decorator(peekable)
+        >>> @peekable_function()
+        ... def str_range(*args):
+        ...     return (str(x) for x in range(*args))
+        ...
+        >>> it = str_range(1, 20, 2)
+        >>> next(it), next(it), next(it)
+        ('1', '3', '5')
+        >>> it.peek()
+        '7'
+        >>> next(it)
+        '7'
 
     """
     # See https://sites.google.com/site/bbayles/index/decorator_factory for

--- a/more_itertools/tests/test_more.py
+++ b/more_itertools/tests/test_more.py
@@ -5,11 +5,19 @@ from doctest import DocTestSuite
 from fractions import Fraction
 from functools import reduce
 from io import StringIO
-from itertools import chain, count, groupby, permutations, product, repeat
+from itertools import (
+    chain,
+    count,
+    groupby,
+    islice,
+    permutations,
+    product,
+    repeat,
+)
 from operator import add, itemgetter
 from unittest import TestCase
 
-from six.moves import filter, range, zip
+from six.moves import filter, map, range, zip
 
 import more_itertools as mi
 
@@ -1622,3 +1630,52 @@ class CyclicPermutationsTests(TestCase):
                           (1, 2, 3, 0),
                           (2, 3, 0, 1),
                           (3, 0, 1, 2)])
+
+
+class MakeDecoratorTests(TestCase):
+    def test_basic(self):
+        slicer = mi.make_decorator(islice)
+
+        @slicer(1, 10, 2)
+        def user_function(arg_1, arg_2, kwarg_1=None):
+            self.assertEqual(arg_1, 'arg_1')
+            self.assertEqual(arg_2, 'arg_2')
+            self.assertEqual(kwarg_1, 'kwarg_1')
+            return map(str, count())
+
+        it = user_function('arg_1', 'arg_2', kwarg_1='kwarg_1')
+        actual = list(it)
+        expected = ['1', '3', '5', '7', '9']
+        self.assertEqual(actual, expected)
+
+    def test_result_index(self):
+        def stringify(*args, **kwargs):
+            self.assertEqual(args[0], 'arg_0')
+            iterable = args[1]
+            self.assertEqual(args[2], 'arg_2')
+            self.assertEqual(kwargs['kwarg_1'], 'kwarg_1')
+            return map(str, iterable)
+
+        stringifier = mi.make_decorator(stringify, result_index=1)
+
+        @stringifier('arg_0', 'arg_2', kwarg_1='kwarg_1')
+        def user_function(n):
+            return count(n)
+
+        it = user_function(1)
+        actual = mi.take(5, it)
+        expected = ['1', '2', '3', '4', '5']
+        self.assertEqual(actual, expected)
+
+    def test_wrap_class(self):
+        seeker = mi.make_decorator(mi.seekable)
+
+        @seeker()
+        def user_function(n):
+            return map(str, range(n))
+
+        it = user_function(5)
+        self.assertEqual(list(it), ['0', '1', '2', '3', '4'])
+
+        it.seek(0)
+        self.assertEqual(list(it), ['0', '1', '2', '3', '4'])


### PR DESCRIPTION
So... the hyper-meta thing we discussed in [Issue #181](https://github.com/erikrose/more-itertools/issues/181#issuecomment-350423213) does just as good a job on `peekable` and `seekable` as the more convention PR #182, _and_ allows for fairly useful things like creating decorator versions of `chunked`.

So, like, we could use it. I'm not taking the step of making decorator versions of things in the library, but the examples show how you could do it.