### PR TITLE
Improve asymptotic running time of interleave_longest

### DIFF
--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -23,8 +23,10 @@ from six.moves import filter, map, range, zip, zip_longest
 
 from .recipes import consume, flatten, take
 
-if version_info > (3, 1, 0):
+try:
     from collections import OrderedDict
+except ImportError:
+    OrderedDict = None
 
 __all__ = [
     'adjacent',
@@ -832,7 +834,7 @@ def interleave_longest(*iterables):
 
 # If available, the OrderedDict implementation has better worst-case
 # runtime guarantees than the chain implementation
-if version_info > (3, 1, 0):
+if OrderedDict is not None:
     _interleave_longest_docstring = interleave_longest.__doc__
     interleave_longest = _interleave_longest_ordered
     interleave_longest.__doc__ = _interleave_longest_docstring


### PR DESCRIPTION
`interleave_longest()` currently works by using `zip_longest()` with a `fillvalue` of `_marker`, and then filtering out all the `_marker` references in the returned iterable.

This has a running time of `O(len(iterables) * max(map(ilen,iterables))`. This is particularly inefficient if one iterable is much larger than any of others.

Using the proposed `OrderedDict` based implementation, the running time can be cut down to `O(sum(map(ilen, iterables)) + len(iterables))`.
