### PR TITLE
Add reversed_extended()

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -214,7 +214,7 @@ Others
 **New itertools**
 
 .. autofunction:: numeric_range(start, stop, step)
-.. autofunction:: reversed_extended
+.. autofunction:: always_reversible
 .. autofunction:: side_effect
 .. autofunction:: iterate
 .. autofunction:: difference(iterable, func=operator.sub)

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -214,6 +214,7 @@ Others
 **New itertools**
 
 .. autofunction:: numeric_range(start, stop, step)
+.. autofunction:: reversed_extended
 .. autofunction:: side_effect
 .. autofunction:: iterate
 .. autofunction:: difference(iterable, func=operator.sub)

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -54,6 +54,7 @@ __all__ = [
     'one',
     'padded',
     'peekable',
+    'reversed_extended',
     'rstrip',
     'run_length',
     'seekable',
@@ -1633,6 +1634,24 @@ def islice_extended(iterable, *args):
 
             for item in cache[i::step]:
                 yield item
+
+
+def reversed_extended(iterable):
+    """An extension of :func:`reversed` that supports all iterables, not
+    just those which implement the ``Reversible`` or ``Sequence`` protocols.
+
+        >>> print(*reversed_extended(x for x in range(3)))
+        2 1 0
+
+    If the iterable is already reversible, this function returns the
+    result of :func:`reversed()`. If the iterable is not reversible,
+    this function will cache the remaining items in the iterable and
+    yield them in reverse order, which may require significant storage.
+    """
+    try:
+        return reversed(iterable)
+    except TypeError:
+        return reversed(deque(iterable))
 
 
 def consecutive_groups(iterable, ordering=lambda x: x):

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -26,6 +26,7 @@ from .recipes import consume, flatten, take
 __all__ = [
     'adjacent',
     'always_iterable',
+    'always_reversible',
     'bucket',
     'chunked',
     'collapse',
@@ -54,7 +55,6 @@ __all__ = [
     'one',
     'padded',
     'peekable',
-    'reversed_extended',
     'rstrip',
     'run_length',
     'seekable',
@@ -1636,11 +1636,11 @@ def islice_extended(iterable, *args):
                 yield item
 
 
-def reversed_extended(iterable):
+def always_reversible(iterable):
     """An extension of :func:`reversed` that supports all iterables, not
     just those which implement the ``Reversible`` or ``Sequence`` protocols.
 
-        >>> print(*reversed_extended(x for x in range(3)))
+        >>> print(*always_reversible(x for x in range(3)))
         2 1 0
 
     If the iterable is already reversible, this function returns the
@@ -1651,7 +1651,7 @@ def reversed_extended(iterable):
     try:
         return reversed(iterable)
     except TypeError:
-        return reversed(deque(iterable))
+        return reversed(list(iterable))
 
 
 def consecutive_groups(iterable, ordering=lambda x: x):

--- a/more_itertools/tests/test_more.py
+++ b/more_itertools/tests/test_more.py
@@ -1691,6 +1691,23 @@ class ExactlyNTests(TestCase):
         self.assertFalse(mi.exactly_n([], 1))
 
 
+class ReversedExtendedTests(TestCase):
+    """Tests for ``reversed_extended()``"""
+
+    def test_regular_reversed(self):
+        self.assertEqual(list(reversed(range(10))), list(mi.reversed_extended(range(10))))
+        self.assertEqual(list(reversed([1, 2, 3])), list(mi.reversed_extended([1, 2, 3])))
+        self.assertEqual(reversed([1, 2, 3]).__class__, mi.reversed_extended([1, 2, 3]).__class__)
+
+    def test_nonseq_reversed(self):
+        with self.assertRaises(TypeError):
+            reversed(x for x in range(10))  # Create a non-reversible generator from a sequence
+
+        self.assertEqual(list(reversed(range(10))), list(mi.reversed_extended(x for x in range(10))))
+        self.assertEqual(list(reversed([1, 2, 3])), list(mi.reversed_extended(x for x in [1, 2, 3])))
+        self.assertNotEqual(reversed([1, 2, 3]).__class__, mi.reversed_extended(x for x in [1, 2, 3]).__class__)
+
+
 class CyclicPermutationsTests(TestCase):
     """Tests for ``cyclic_permutations()``"""
 

--- a/more_itertools/tests/test_more.py
+++ b/more_itertools/tests/test_more.py
@@ -1695,17 +1695,24 @@ class ReversedExtendedTests(TestCase):
     """Tests for ``reversed_extended()``"""
 
     def test_regular_reversed(self):
-        self.assertEqual(list(reversed(range(10))), list(mi.reversed_extended(range(10))))
-        self.assertEqual(list(reversed([1, 2, 3])), list(mi.reversed_extended([1, 2, 3])))
-        self.assertEqual(reversed([1, 2, 3]).__class__, mi.reversed_extended([1, 2, 3]).__class__)
+        self.assertEqual(list(reversed(range(10))),
+                         list(mi.reversed_extended(range(10))))
+        self.assertEqual(list(reversed([1, 2, 3])),
+                         list(mi.reversed_extended([1, 2, 3])))
+        self.assertEqual(reversed([1, 2, 3]).__class__,
+                         mi.reversed_extended([1, 2, 3]).__class__)
 
     def test_nonseq_reversed(self):
+        # Create a non-reversible generator from a sequence
         with self.assertRaises(TypeError):
-            reversed(x for x in range(10))  # Create a non-reversible generator from a sequence
+            reversed(x for x in range(10))
 
-        self.assertEqual(list(reversed(range(10))), list(mi.reversed_extended(x for x in range(10))))
-        self.assertEqual(list(reversed([1, 2, 3])), list(mi.reversed_extended(x for x in [1, 2, 3])))
-        self.assertNotEqual(reversed([1, 2, 3]).__class__, mi.reversed_extended(x for x in [1, 2, 3]).__class__)
+        self.assertEqual(list(reversed(range(10))),
+                         list(mi.reversed_extended(x for x in range(10))))
+        self.assertEqual(list(reversed([1, 2, 3])),
+                         list(mi.reversed_extended(x for x in [1, 2, 3])))
+        self.assertNotEqual(reversed([1, 2]).__class__,
+                            mi.reversed_extended(x for x in [1, 2]).__class__)
 
 
 class CyclicPermutationsTests(TestCase):

--- a/more_itertools/tests/test_more.py
+++ b/more_itertools/tests/test_more.py
@@ -1691,16 +1691,16 @@ class ExactlyNTests(TestCase):
         self.assertFalse(mi.exactly_n([], 1))
 
 
-class ReversedExtendedTests(TestCase):
-    """Tests for ``reversed_extended()``"""
+class AlwaysReversibleTests(TestCase):
+    """Tests for ``always_reversible()``"""
 
     def test_regular_reversed(self):
         self.assertEqual(list(reversed(range(10))),
-                         list(mi.reversed_extended(range(10))))
+                         list(mi.always_reversible(range(10))))
         self.assertEqual(list(reversed([1, 2, 3])),
-                         list(mi.reversed_extended([1, 2, 3])))
+                         list(mi.always_reversible([1, 2, 3])))
         self.assertEqual(reversed([1, 2, 3]).__class__,
-                         mi.reversed_extended([1, 2, 3]).__class__)
+                         mi.always_reversible([1, 2, 3]).__class__)
 
     def test_nonseq_reversed(self):
         # Create a non-reversible generator from a sequence
@@ -1708,11 +1708,11 @@ class ReversedExtendedTests(TestCase):
             reversed(x for x in range(10))
 
         self.assertEqual(list(reversed(range(10))),
-                         list(mi.reversed_extended(x for x in range(10))))
+                         list(mi.always_reversible(x for x in range(10))))
         self.assertEqual(list(reversed([1, 2, 3])),
-                         list(mi.reversed_extended(x for x in [1, 2, 3])))
-        self.assertNotEqual(reversed([1, 2]).__class__,
-                            mi.reversed_extended(x for x in [1, 2]).__class__)
+                         list(mi.always_reversible(x for x in [1, 2, 3])))
+        self.assertNotEqual(reversed((1, 2)).__class__,
+                            mi.always_reversible(x for x in (1, 2)).__class__)
 
 
 class CyclicPermutationsTests(TestCase):


### PR DESCRIPTION
The builtin ``reversed()`` function returns a reverse iterator on iterables that implement ``__reversed__()`` or both ``__len__()`` and ``__getitem__()``, but won't work on other iterables, such as the results of ``map()``, file iterators, or arbitrary generator functions:

```python
>>> print(*map(lambda x: x * 2, reversed([1,2,3])))
6 4 2

# Changing the location of the reversed causes errors
>>> print(*reversed(map(lambda x: x * 2, [1,2,3]))) 
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: 'map' object is not reversible
```

```python
>>> with open('/Users/mcelani/Desktop/my_file.txt', 'r') as file_iter:
...   print(*reversed(file_iter), sep='')
... 
Traceback (most recent call last):
  File "<stdin>", line 2, in <module>
TypeError: '_io.TextIOWrapper' object is not reversible

# Need to add extra 'list' cruft to get this to work
>>> with open('/Users/mcelani/Desktop/my_file.txt', 'r') as file_iter: 
...   print(*reversed(list(file_iter)), sep='')
... 
World
Hello
```

This pull request implements ``reversed_extended()``, which is a simple `try` / `catch` wrapper around ``reversed()`` that automatically handles non-reversible iterators by caching all the values and returning them in reverse order. Reversible iterables still leverage the return of ``reversed()``. 

You can import it as its own function or as a drop-in replacement for ``reversed()``:
```python
>>> from more_itertools import reversed_extended as reversed
>>> with open('/Users/mcelani/Desktop/my_file.txt', 'r') as file_iter:
...   print(*reversed(file_iter), sep='')
... 
World
Hello
```