### PR TITLE
Add bitmap.encode and bitmap.decode

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -129,6 +129,7 @@ These tools return summarized or aggregated data from an iterable.
 .. autofunction:: consecutive_groups(iterable, ordering=lambda x: x)
 .. autofunction:: exactly_n(iterable, n, predicate=bool)
 .. autoclass:: run_length
+.. autoclass:: bitmap
 
 ----
 

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -23,8 +23,10 @@ from six.moves import filter, map, range, zip, zip_longest
 
 from .recipes import consume, flatten, take
 
-if version_info > (3, 1, 0):
+try:
     from collections import OrderedDict
+except ImportError:
+    OrderedDict = None
 
 __all__ = [
     'adjacent',
@@ -832,7 +834,7 @@ def interleave_longest(*iterables):
 
 # If available, the OrderedDict implementation has better worst-case
 # runtime guarantees than the chain implementation
-if version_info > (3, 1, 0):
+if OrderedDict is not None:
     _interleave_longest_docstring = interleave_longest.__doc__
     interleave_longest = _interleave_longest_ordered
     interleave_longest.__doc__ = _interleave_longest_docstring

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -22,7 +22,7 @@ from sys import maxsize, version_info
 from six import binary_type, string_types, text_type
 from six.moves import filter, map, range, zip, zip_longest
 
-from .recipes import consume, flatten, take, roundrobin
+from .recipes import consume, flatten, take
 
 __all__ = [
     'adjacent',
@@ -805,16 +805,6 @@ def interleave_longest(*iterables):
     """
     i = chain.from_iterable(zip_longest(*iterables, fillvalue=_marker))
     return filter(lambda x: x is not _marker, i)
-
-
-# The performance of roundrobin is far superior to interleave_longest in PyPy
-if python_implementation() == 'PyPy':
-    _interleave_longest_docstring = interleave_longest.__doc__
-
-    def interleave_longest(*iterables):
-        return roundrobin(*iterables)
-
-    interleave_longest.__doc__ = _interleave_longest_docstring
 
 
 def collapse(iterable, base_type=None, levels=None):

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -809,7 +809,10 @@ def interleave_longest(*iterables):
 # The performance of roundrobin is far superior to interleave_longest in PyPy
 if python_implementation() == 'PyPy':
     _interleave_longest_docstring = interleave_longest.__doc__
-    interleave_longest = roundrobin
+
+    def interleave_longest(*iterables):
+        return roundrobin(*iterables)
+
     interleave_longest.__doc__ = _interleave_longest_docstring
 
 

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -803,8 +803,8 @@ def _interleave_longest_ordered(*iterables):
     using a version of Python with OrderedDict available.
 
     This implementation of interleave_longest removes iterators from
-    consideration after they are exhausted instead of generating and
-    discarding instances of _marker.
+    consideration after they are exhausted instead of copying and
+    discarding references to _marker.
     """
     iterables = OrderedDict(enumerate(map(iter, iterables)))
     while iterables:

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -16,7 +16,6 @@ from itertools import (
     tee
 )
 from operator import itemgetter, lt, gt, sub
-from platform import python_implementation
 from sys import maxsize, version_info
 
 from six import binary_type, string_types, text_type

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -27,6 +27,7 @@ from .recipes import consume, flatten, take, roundrobin
 __all__ = [
     'adjacent',
     'always_iterable',
+    'bitmap',
     'bucket',
     'chunked',
     'collapse',
@@ -1878,6 +1879,39 @@ class run_length(object):
     @staticmethod
     def decode(iterable):
         return chain.from_iterable(repeat(k, n) for k, n in iterable)
+
+
+class bitmap(object):
+    """
+    :func:`bitmap.encode` compresses an iterable into a bitmap.
+    It applies `predicate` to all the elements in the iterable, setting
+    a bit in an integer for each ``True`` value and returning that value
+    and the length of the uncompressed iterable.
+
+        >>> uncompressed = [1, 0, 1, 1, 0]
+        >>> bitmap.encode(uncompressed)
+        (13, 5)
+
+    :func:`bitmap.decode` decompresses a bitmap value and length pair. It
+    yields the boolean value for each bit set in the value:
+
+        >>> compressed = (13, 5)
+        >>> list(bitmap.decode(compressed))
+        [True, False, True, True, False]
+    """
+
+    @staticmethod
+    def encode(iterable, predicate=bool):
+        iter_val, iter_length = 0, 0
+        for bit, result in enumerate(map(predicate, iterable)):
+            iter_val |= int(bool(result)) << bit
+            iter_length += 1
+        return iter_val, iter_length
+
+    @staticmethod
+    def decode(bitmap_tuple):
+        for bit in range(bitmap_tuple[1]):
+            yield bool(bitmap_tuple[0] & (1 << bit))
 
 
 def exactly_n(iterable, n, predicate=bool):

--- a/more_itertools/tests/test_more.py
+++ b/more_itertools/tests/test_more.py
@@ -1672,6 +1672,25 @@ class RunLengthTest(TestCase):
         self.assertEqual(actual, expected)
 
 
+class BitmapTest(TestCase):
+    def test_encode(self):
+        iterable = "The quick brown fox jumps over the lazy dog."
+        bit_str = '11110111101110111101111101110111110111110111'
+
+        expected = (int(bit_str, 2), len(bit_str))
+        actual = mi.bitmap.encode(iterable, lambda c: c != ' ')
+        self.assertEqual(actual, expected)
+
+    def test_decode(self):
+        iterable = "The quick brown fox jumps over the lazy dog."
+        bit_str = '11110111101110111101111101110111110111110111'
+
+        bitmap_tuple = (int(bit_str, 2), len(bit_str))
+        expected = list(map(lambda c: c != ' ', iterable))
+        actual = list(mi.bitmap.decode(bitmap_tuple))
+        self.assertEqual(actual, expected)
+
+
 class ExactlyNTests(TestCase):
     """Tests for ``exactly_n()``"""
 

--- a/more_itertools/tests/test_more.py
+++ b/more_itertools/tests/test_more.py
@@ -679,11 +679,6 @@ class TestInterleave(TestCase):
             list(mi.interleave_longest(*l)), [1, 4, 7, 2, 5, 8, 3, 6]
         )
 
-        l = [range(100000), range(100000)]
-        self.assertEqual(
-            list(mi.interleave_longest(*l)), list(mi.interleave(*l))
-        )
-
 
 class TestCollapse(TestCase):
     """Tests for ``collapse()``"""

--- a/more_itertools/tests/test_more.py
+++ b/more_itertools/tests/test_more.py
@@ -679,6 +679,11 @@ class TestInterleave(TestCase):
             list(mi.interleave_longest(*l)), [1, 4, 7, 2, 5, 8, 3, 6]
         )
 
+        l = [range(100000), range(100000)]
+        self.assertEqual(
+            list(mi.interleave_longest(*l)), list(mi.interleave(*l))
+        )
+
 
 class TestCollapse(TestCase):
     """Tests for ``collapse()``"""


### PR DESCRIPTION
``bool`` is rather expensive in Python. It's a subclass of ``int``, so they both end up taking at least 24 bytes:

```python
>>> sys.getsizeof(10)
24
>>> sys.getsizeof(True)
24
```

But we can store a lot more truth values in a single integer by leveraging a bitmap. This pull request implements a set of functions that compress booleans into an integer / length pair and recreates that stream of booleans from it.

```python
>>> uncompressed = [1, 0, 1, 1, 0]
>>> bitmap.encode(uncompressed)
(13, 5)

>>> compressed = (13, 5)
>>> list(bitmap.decode(compressed))
[True, False, True, True, False]
```
  