### PR TITLE
Additional tests and notes on performance for interleave_longest and roundrobin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 
 # Packages
 *.egg
+*.eggs
 *.egg-info
 dist
 build

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -803,7 +803,7 @@ def interleave_longest(*iterables):
 
     """
     i = chain.from_iterable(zip_longest(*iterables, fillvalue=_marker))
-    return filter(lambda x: x is not _marker, i)
+    return (x for x in i if x is not _marker)
 
 
 def collapse(iterable, base_type=None, levels=None):

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -801,6 +801,10 @@ def interleave_longest(*iterables):
         >>> list(interleave_longest([1, 2, 3], [4, 5], [6, 7, 8]))
         [1, 4, 6, 2, 5, 7, 3, 8]
 
+    This function produces the same output as :func:`roundrobin`, but may
+    perform better for some inputs (in particular when the number of iterables
+    is large).
+
     """
     i = chain.from_iterable(zip_longest(*iterables, fillvalue=_marker))
     return (x for x in i if x is not _marker)

--- a/more_itertools/recipes.py
+++ b/more_itertools/recipes.py
@@ -300,7 +300,9 @@ def roundrobin(*iterables):
         >>> list(roundrobin('ABC', 'D', 'EF'))
         ['A', 'D', 'E', 'B', 'F', 'C']
 
-    See :func:`interleave_longest` for a slightly faster implementation.
+    This function produces the same output as :func:`interleave_longest`, but
+    may perform better for some inputs (in particular when the number of
+    iterables is small).
 
     """
     # Recipe credited to George Sakkis

--- a/more_itertools/tests/test_more.py
+++ b/more_itertools/tests/test_more.py
@@ -650,34 +650,44 @@ class SpyTests(TestCase):
         self.assertEqual(list(new_iterable), ['a', 'b', 'c'])
 
 
-class TestInterleave(TestCase):
-    """Tests for ``interleave()`` and ``interleave_longest()``"""
+class InterleaveTests(TestCase):
+    def test_even(self):
+        actual = list(mi.interleave([1, 4, 7], [2, 5, 8], [3, 6, 9]))
+        expected = [1, 2, 3, 4, 5, 6, 7, 8, 9]
+        self.assertEqual(actual, expected)
 
-    def test_interleave(self):
-        l = [[1, 2, 3], [4, 5], [6, 7, 8]]
-        self.assertEqual(list(mi.interleave(*l)), [1, 4, 6, 2, 5, 7])
+    def test_short(self):
+        actual = list(mi.interleave([1, 4], [2, 5, 7], [3, 6, 8]))
+        expected = [1, 2, 3, 4, 5, 6]
+        self.assertEqual(actual, expected)
 
-        l = [[1, 2], [3, 4, 5], [6, 7, 8]]
-        self.assertEqual(list(mi.interleave(*l)), [1, 3, 6, 2, 4, 7])
+    def test_mixed_types(self):
+        it_list = ['a', 'b', 'c', 'd']
+        it_str = '12345'
+        it_inf = count()
+        actual = list(mi.interleave(it_list, it_str, it_inf))
+        expected = ['a', '1', 0, 'b', '2', 1, 'c', '3', 2, 'd', '4', 3]
+        self.assertEqual(actual, expected)
 
-        l = [[1, 2, 3], [4, 5, 6], [7, 8]]
-        self.assertEqual(list(mi.interleave(*l)), [1, 4, 7, 2, 5, 8])
 
-    def test_interleave_longest(self):
-        l = [[1, 2, 3], [4, 5], [6, 7, 8]]
-        self.assertEqual(
-            list(mi.interleave_longest(*l)), [1, 4, 6, 2, 5, 7, 3, 8]
-        )
+class InterleaveLongestTests(TestCase):
+    def test_even(self):
+        actual = list(mi.interleave_longest([1, 4, 7], [2, 5, 8], [3, 6, 9]))
+        expected = [1, 2, 3, 4, 5, 6, 7, 8, 9]
+        self.assertEqual(actual, expected)
 
-        l = [[1, 2], [3, 4, 5], [6, 7, 8]]
-        self.assertEqual(
-            list(mi.interleave_longest(*l)), [1, 3, 6, 2, 4, 7, 5, 8]
-        )
+    def test_short(self):
+        actual = list(mi.interleave_longest([1, 4], [2, 5, 7], [3, 6, 8]))
+        expected = [1, 2, 3, 4, 5, 6, 7, 8]
+        self.assertEqual(actual, expected)
 
-        l = [[1, 2, 3], [4, 5, 6], [7, 8]]
-        self.assertEqual(
-            list(mi.interleave_longest(*l)), [1, 4, 7, 2, 5, 8, 3, 6]
-        )
+    def test_mixed_types(self):
+        it_list = ['a', 'b', 'c', 'd']
+        it_str = '12345'
+        it_gen = (x for x in range(3))
+        actual = list(mi.interleave_longest(it_list, it_str, it_gen))
+        expected = ['a', '1', 0, 'b', '2', 1, 'c', '3', 2, 'd', '4', '5']
+        self.assertEqual(actual, expected)
 
 
 class TestCollapse(TestCase):

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,3 @@
 [flake8]
-exclude = ./docs/conf.py
+exclude = ./docs/conf.py, .eggs/
 ignore = E731, E741, F999


### PR DESCRIPTION
Re: the discussion in PR #189, this PR implements [these](https://github.com/erikrose/more-itertools/pull/189#issuecomment-355298498) points to help clarify things w.r.t. `interleave_longest` and `roundrobin`.

* Change the `return` value of `interleave_longest` to `(x for x in it if x is not _marker)` - this helps with PyPy
* Change the note in the docstring for `roundrobin` to mention that it may be faster for small numbers of iterables, but `interleave_longest` should be preferred for larger numbers
* Add a note in the docstring for `interleave_longest` to mention that `roundrobin` does the same thing, and may be faster for small numbers of iterables.
* Separate the tests for `interleave` and `interleave_longest` and add tests with mixed types etc.