### PR TITLE
Updates for version 4.1.0

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -174,7 +174,7 @@ These tools yield combinatorial arrangements of items from iterables.
 **New itertools**
 
 .. autofunction:: distinct_permutations
-.. autofunction:: cyclic_permutations
+.. autofunction:: circular_shifts
 
 ----
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -50,7 +50,7 @@ copyright = u'2012, Erik Rose'
 # built documents.
 #
 # The short X.Y version.
-version = '4.0.1'
+version = '4.1.0'
 # The full version, including alpha/beta/rc tags.
 release = version
 

--- a/docs/versions.rst
+++ b/docs/versions.rst
@@ -12,7 +12,6 @@ Version History
     * :func:`cyclic_permutations` (thanks to hiqua)
     * :func:`make_decorator` - see the blog post `Yo, I heard you like decorators <https://sites.google.com/site/bbayles/index/decorator_factory>`_
       for a tour (thanks to pylang)
-    * :func:`cyclic_permutations` (thanks to hiqua)
     * :func:`always_reversible` (thanks to michael-celani)
     * :func:`nth_combination` (from the `Python 3.7 docs <https://docs.python.org/3.7/library/itertools.html#itertools-recipes>`_)
 

--- a/docs/versions.rst
+++ b/docs/versions.rst
@@ -9,7 +9,7 @@ Version History
 
 * New itertools:
     * :func:`split_at` (thanks to michael-celani)
-    * :func:`cyclic_permutations` (thanks to hiqua)
+    * :func:`circular_shifts` (thanks to hiqua)
     * :func:`make_decorator` - see the blog post `Yo, I heard you like decorators <https://sites.google.com/site/bbayles/index/decorator_factory>`_
       for a tour (thanks to pylang)
     * :func:`always_reversible` (thanks to michael-celani)

--- a/docs/versions.rst
+++ b/docs/versions.rst
@@ -4,6 +4,24 @@ Version History
 
 .. automodule:: more_itertools
 
+4.0.2
+-----
+
+* New itertools:
+    * :func:`split_at` (thanks to michael-celani)
+    * :func:`cyclic_permutations` (thanks to hiqua)
+    * :func:`make_decorator` - see the blog post `Yo, I heard you like decorators <https://sites.google.com/site/bbayles/index/decorator_factory>`_
+      for a tour (thanks to pylang)
+    * :func:`cyclic_permutations` (thanks to hiqua)
+    * :func:`always_reversible` (thanks to michael-celani)
+    * :func:`nth_combination` (from the `Python 3.7 docs <https://docs.python.org/3.7/library/itertools.html#itertools-recipes>`_)
+
+* Improvements to existing itertools:
+    * :func:`seekable` now has an ``elements`` method to return cached items.
+    * The performance tradeoffs between :func:`roundrobin` and
+      :func:`interleave_longest` are now documented (thanks michael-celani,
+      pylang, and MSeifert04)
+
 4.0.1
 -----
 

--- a/docs/versions.rst
+++ b/docs/versions.rst
@@ -4,7 +4,7 @@ Version History
 
 .. automodule:: more_itertools
 
-4.0.2
+4.1.0
 -----
 
 * New itertools:

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -29,12 +29,12 @@ __all__ = [
     'always_reversible',
     'bucket',
     'chunked',
+    'circular_shifts',
     'collapse',
     'collate',
     'consecutive_groups',
     'consumer',
     'count_cycle',
-    'cyclic_permutations',
     'difference',
     'distinct_permutations',
     'distribute',
@@ -1910,10 +1910,10 @@ def exactly_n(iterable, n, predicate=bool):
     return len(take(n + 1, filter(predicate, iterable))) == n
 
 
-def cyclic_permutations(iterable):
-    """Return a list of cyclic permutations of *iterable*.
+def circular_shifts(iterable):
+    """Return a list of circular shifts of *iterable*.
 
-        >>> cyclic_permutations(range(4))
+        >>> circular_shifts(range(4))
         [(0, 1, 2, 3), (1, 2, 3, 0), (2, 3, 0, 1), (3, 0, 1, 2)]
     """
     lst = list(iterable)

--- a/more_itertools/tests/test_more.py
+++ b/more_itertools/tests/test_more.py
@@ -1725,20 +1725,24 @@ class AlwaysReversibleTests(TestCase):
                             mi.always_reversible(x for x in (1, 2)).__class__)
 
 
-class CyclicPermutationsTests(TestCase):
-    """Tests for ``cyclic_permutations()``"""
-
+class CircularShiftsTests(TestCase):
     def test_empty(self):
-        """test the empty iterator case"""
-        self.assertEqual(list(mi.cyclic_permutations([])), [])
+        # empty iterable -> empty list
+        self.assertEqual(list(mi.circular_shifts([])), [])
 
-    def test_simple_cyclic_permutations(self):
-        """test the a simple iterator case"""
-        self.assertEqual(mi.cyclic_permutations(range(4)),
-                         [(0, 1, 2, 3),
-                          (1, 2, 3, 0),
-                          (2, 3, 0, 1),
-                          (3, 0, 1, 2)])
+    def test_simple_circular_shifts(self):
+        # test the a simple iterator case
+        self.assertEqual(
+            mi.circular_shifts(range(4)),
+            [(0, 1, 2, 3), (1, 2, 3, 0), (2, 3, 0, 1), (3, 0, 1, 2)]
+        )
+
+    def test_duplicates(self):
+        # test non-distinct entries
+        self.assertEqual(
+            mi.circular_shifts([0, 1, 0, 1]),
+            [(0, 1, 0, 1), (1, 0, 1, 0), (0, 1, 0, 1), (1, 0, 1, 0)]
+        )
 
 
 class MakeDecoratorTests(TestCase):

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ def get_long_description():
 
 setup(
     name='more-itertools',
-    version='4.0.1',
+    version='4.1.0',
     description='More routines for operating on iterables, beyond itertools',
     long_description=get_long_description(),
     author='Erik Rose',


### PR DESCRIPTION
This PR adds release notes for version 4.1.0.

In addition to the doc updates, this PR also changes the name of `cyclic_permutations` to `circular_shifts`. According to [Wikipedia](https://en.wikipedia.org/wiki/Circular_shift), the latter (which we're producing) are a special case of the [former](https://en.wikipedia.org/wiki/Cyclic_permutation).