### PR TITLE
Add map_reduce function

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -129,6 +129,7 @@ These tools return summarized or aggregated data from an iterable.
 .. autofunction:: consecutive_groups(iterable, ordering=lambda x: x)
 .. autofunction:: exactly_n(iterable, n, predicate=bool)
 .. autoclass:: run_length
+.. autofunction:: map_reduce
 
 ----
 

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -2032,6 +2032,10 @@ def map_reduce(iterable, keyfunc, valuefunc=None, reducefunc=None):
     Note that all items in the iterable are gathered into a list before the
     summarization step, which may require significant storage.
 
+    The returned object is a :obj:`collections.defaultdict` with the
+    ``default_factory`` set to ``None``, such that if behaves as a normal
+    dictionary.
+
     """
     keyfunc = (lambda x: x) if (keyfunc is None) else keyfunc
     valuefunc = (lambda x: x) if (valuefunc is None) else valuefunc
@@ -2046,4 +2050,5 @@ def map_reduce(iterable, keyfunc, valuefunc=None, reducefunc=None):
         for key, value_list in ret.items():
             ret[key] = reducefunc(value_list)
 
+    ret.default_factory = None
     return ret

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -2037,7 +2037,6 @@ def map_reduce(iterable, keyfunc, valuefunc=None, reducefunc=None):
     dictionary.
 
     """
-    keyfunc = (lambda x: x) if (keyfunc is None) else keyfunc
     valuefunc = (lambda x: x) if (valuefunc is None) else valuefunc
 
     ret = defaultdict(list)

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -2033,7 +2033,7 @@ def map_reduce(iterable, keyfunc, valuefunc=None, reducefunc=None):
     summarization step, which may require significant storage.
 
     The returned object is a :obj:`collections.defaultdict` with the
-    ``default_factory`` set to ``None``, such that if behaves as a normal
+    ``default_factory`` set to ``None``, such that it behaves like a normal
     dictionary.
 
     """

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -51,6 +51,7 @@ __all__ = [
     'locate',
     'lstrip',
     'make_decorator',
+    'map_reduce',
     'numeric_range',
     'one',
     'padded',
@@ -1983,3 +1984,66 @@ def make_decorator(wrapping_func, result_index=0):
         return outer_wrapper
 
     return decorator
+
+
+def map_reduce(iterable, keyfunc, valuefunc=None, reducefunc=None):
+    """Return a dictionary that maps the items in *iterable* to categories
+    defined by *keyfunc*, transforms them with *valuefunc*, and
+    then summarizes them by category with *reducefunc*.
+
+    *valuefunc* defaults to the identity function if it is unspecified.
+    If *reducefunc* is unspecified, no summarization takes place:
+
+        >>> keyfunc = lambda x: x.upper()
+        >>> result = map_reduce('abbccc', keyfunc)
+        >>> sorted(result.items())
+        [('A', ['a']), ('B', ['b', 'b']), ('C', ['c', 'c', 'c'])]
+
+    Specifying *valuefunc* transforms the categorized items:
+
+        >>> keyfunc = lambda x: x.upper()
+        >>> valuefunc = lambda x: 1
+        >>> result = map_reduce('abbccc', keyfunc, valuefunc)
+        >>> sorted(result.items())
+        [('A', [1]), ('B', [1, 1]), ('C', [1, 1, 1])]
+
+    Specifying *reducefunc* summarizes the categorized items:
+
+        >>> keyfunc = lambda x: x.upper()
+        >>> valuefunc = lambda x: 1
+        >>> reducefunc = sum
+        >>> result = map_reduce('abbccc', keyfunc, valuefunc, reducefunc)
+        >>> sorted(result.items())
+        [('A', 1), ('B', 2), ('C', 3)]
+
+    You may want to filter the input iterable before applying the map/reduce
+    proecdure:
+
+        >>> all_items = range(30)
+        >>> items = [x for x in all_items if 10 <= x <= 20]  # Filter
+        >>> keyfunc = lambda x: x % 2  # Evens map to 0; odds to 1
+        >>> categories = map_reduce(items, keyfunc=keyfunc)
+        >>> sorted(categories.items())
+        [(0, [10, 12, 14, 16, 18, 20]), (1, [11, 13, 15, 17, 19])]
+        >>> summaries = map_reduce(items, keyfunc=keyfunc, reducefunc=sum)
+        >>> sorted(summaries.items())
+        [(0, 90), (1, 75)]
+
+    Note that all items in the iterable are gathered into a list before the
+    summarization step, which may require significant storage.
+
+    """
+    keyfunc = (lambda x: x) if (keyfunc is None) else keyfunc
+    valuefunc = (lambda x: x) if (valuefunc is None) else valuefunc
+
+    ret = defaultdict(list)
+    for item in iterable:
+        key = keyfunc(item)
+        value = valuefunc(item)
+        ret[key].append(value)
+
+    if reducefunc is not None:
+        for key, value_list in ret.items():
+            ret[key] = reducefunc(value_list)
+
+    return ret

--- a/more_itertools/tests/test_more.py
+++ b/more_itertools/tests/test_more.py
@@ -15,7 +15,7 @@ from itertools import (
     product,
     repeat,
 )
-from operator import add, itemgetter
+from operator import add, mul, itemgetter
 from unittest import TestCase
 
 from six.moves import filter, map, range, zip
@@ -1792,3 +1792,31 @@ class MakeDecoratorTests(TestCase):
 
         it.seek(0)
         self.assertEqual(list(it), ['0', '1', '2', '3', '4'])
+
+
+class MapReduceTests(TestCase):
+    def test_default(self):
+        iterable = (str(x) for x in range(5))
+        keyfunc = lambda x: int(x) // 2
+        actual = sorted(mi.map_reduce(iterable, keyfunc).items())
+        expected = [(0, ['0', '1']), (1, ['2', '3']), (2, ['4'])]
+        self.assertEqual(actual, expected)
+
+    def test_valuefunc(self):
+        iterable = (str(x) for x in range(5))
+        keyfunc = lambda x: int(x) // 2
+        valuefunc = int
+        actual = sorted(mi.map_reduce(iterable, keyfunc, valuefunc).items())
+        expected = [(0, [0, 1]), (1, [2, 3]), (2, [4])]
+        self.assertEqual(actual, expected)
+
+    def test_reducefunc(self):
+        iterable = (str(x) for x in range(5))
+        keyfunc = lambda x: int(x) // 2
+        valuefunc = int
+        reducefunc = lambda value_list: reduce(mul, value_list, 1)
+        actual = sorted(
+            mi.map_reduce(iterable, keyfunc, valuefunc, reducefunc).items()
+        )
+        expected = [(0, 0), (1, 6), (2, 4)]
+        self.assertEqual(actual, expected)

--- a/more_itertools/tests/test_more.py
+++ b/more_itertools/tests/test_more.py
@@ -1820,3 +1820,8 @@ class MapReduceTests(TestCase):
         )
         expected = [(0, 0), (1, 6), (2, 4)]
         self.assertEqual(actual, expected)
+
+    def test_ret(self):
+        d = mi.map_reduce([1, 0, 2, 0, 1, 0], bool)
+        self.assertEqual(d, {False: [0, 0, 0], True: [1, 2, 1]})
+        self.assertRaises(KeyError, lambda: d[None].append(1))


### PR DESCRIPTION
Re: issue #195 , this PR adds a variant of the "dirt simple map/reduce" [recipe](https://code.activestate.com/recipes/577676-dirt-simple-mapreduce/?in=user-178123). 

Per the discussion in the issue, I've modified things a bit:
* With the default arguments, this now scratches the itch I noted in PR #188: "easily make a `defaultdict(list)`"
* The original asks that you filter in the `mapper` function; here I encourage users to filter using standard itertools idioms (generator expressions or list comprehensions). This keeps the functions passed in simple, such that they just have to do one thing.

I think these modifications make the docstring easy to comprehend, which I usually see as a strong virtue:

![image](https://user-images.githubusercontent.com/1922815/36057848-ecf028e2-0dd9-11e8-9b4b-eb1cd4598ec7.png)
