### PR TITLE
Insert path for docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -18,7 +18,7 @@ import sphinx_rtd_theme
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
-#sys.path.insert(0, os.path.abspath('.'))
+sys.path.insert(0, os.path.abspath('..'))
 
 # -- General configuration -----------------------------------------------------
 


### PR DESCRIPTION
Well, [that was easy](https://github.com/erikrose/more-itertools/issues/197#issuecomment-367194453).

http://more-itertools.readthedocs.io/en/doc-source/api.html)

(This PR fixes the missing `[source]` links on RTD)