### PR TITLE
Add edit_distance

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -122,6 +122,7 @@ These tools return summarized or aggregated data from an iterable.
 **New itertools**
 
 .. autofunction:: ilen
+.. autofunction:: edit_distance
 .. autofunction:: first(iterable[, default])
 .. autofunction:: one
 .. autofunction:: unique_to_each

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -39,6 +39,7 @@ __all__ = [
     'distinct_permutations',
     'distribute',
     'divide',
+    'edit_distance',
     'exactly_n',
     'first',
     'groupby_transform',
@@ -407,6 +408,44 @@ def ilen(iterable):
     """
     d = deque(enumerate(iterable, 1), maxlen=1)
     return d[0][0] if d else 0
+
+
+def edit_distance(iterable_a, iterable_b):
+    """Returns the minimum number of insertions, deletions, and substitutions
+    required to transform *iterable_a* into *iterable_b*.
+
+    >>> edit_distance([1, 2, 3], [1, 2, 4, 5, 3])
+    2
+
+    This caches the elements in the iterables, which may require significant
+    storage.
+
+    """
+    list_a = list(iterable_a)
+    list_b = list(iterable_b)
+    len_a = len(list_a)
+    len_b = len(list_b)
+
+    # Wagner–Fischer algorithm
+    memo = [[0] * (len_b + 1) for _ in range(len_a + 1)]
+
+    for i in range(len_a + 1):
+        memo[i][0] = i
+
+    for i in range(len_b + 1):
+        memo[0][i] = i
+
+    for num_a in range(1, len_a + 1):
+        for num_b in range(1, len_b + 1):
+            if list_a[num_a - 1] == list_b[num_b - 1]:
+                memo[num_a][num_b] = memo[num_a - 1][num_b - 1]
+                continue
+
+            memo[num_a][num_b] = min(memo[num_a][num_b - 1] + 1,
+                                     memo[num_a - 1][num_b] + 1,
+                                     memo[num_a - 1][num_b - 1] + 1)
+
+    return memo[len_a][len_b]
 
 
 def iterate(func, start):

--- a/more_itertools/tests/test_more.py
+++ b/more_itertools/tests/test_more.py
@@ -1825,3 +1825,25 @@ class MapReduceTests(TestCase):
         d = mi.map_reduce([1, 0, 2, 0, 1, 0], bool)
         self.assertEqual(d, {False: [0, 0, 0], True: [1, 2, 1]})
         self.assertRaises(KeyError, lambda: d[None].append(1))
+
+
+class EditDistanceTests(TestCase):
+    def test_insertion(self):
+        str_a, str_b = 'abc', 'abdc'
+        self.assertEqual(1, mi.edit_distance(str_a, str_b))
+
+    def test_deletion(self):
+        str_a, str_b = 'abc', 'ac'
+        self.assertEqual(1, mi.edit_distance(str_a, str_b))
+
+    def test_substitution(self):
+        str_a, str_b = 'abc', 'acc'
+        self.assertEqual(1, mi.edit_distance(str_a, str_b))
+
+    def test_all(self):
+        str_a, str_b = 'invention', 'contention'
+        self.assertEqual(3, mi.edit_distance(str_a, str_b))
+
+    def test_non_string(self):
+        iter_a, iter_b = range(19), range(20)
+        self.assertEqual(1, mi.edit_distance(iter_a, iter_b))


### PR DESCRIPTION
Adds the `edit_distance()` function, which computes the Levenshtein distance of two sequences. The Levenshtein distance of two sequences is the minimum amount of insertions, deletions, and substitutions it would require to transform one iterable into another:

```python
>>> edit_distance([1, 2, 3], [1, 2, 4, 5, 3])
2
```