### PR TITLE
Note about order in groupy_transform

### DIFF
--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -1346,8 +1346,8 @@ def groupby_transform(iterable, keyfunc=None, valuefunc=None):
         [(0, 'ab'), (1, 'cde'), (2, 'fgh'), (3, 'i')]
 
     Note that the order of items in the iterable is significant.
-    Only adjacent items are grouped together, so if you don't want any duplicate
-    groups, you should sort the iterable by the key function.
+    Only adjacent items are grouped together, so if you don't want any
+    duplicate groups, you should sort the iterable by the key function.
 
     """
     valuefunc = (lambda x: x) if valuefunc is None else valuefunc

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -1345,6 +1345,10 @@ def groupby_transform(iterable, keyfunc=None, valuefunc=None):
         >>> [(k, ''.join(g)) for k, g in grouper]
         [(0, 'ab'), (1, 'cde'), (2, 'fgh'), (3, 'i')]
 
+    Note that the order of items in the iterable is significant.
+    Only adjacent items are grouped together, so if you don't want any duplicate
+    groups, you should sort the iterable by the key function.
+
     """
     valuefunc = (lambda x: x) if valuefunc is None else valuefunc
     return ((k, map(valuefunc, g)) for k, g in groupby(iterable, keyfunc))


### PR DESCRIPTION
Re: issue #203, this PR adds a note to the docs about `groupby_transform` and how you should be careful with the order of items in the iterable.