### PR TITLE
more.py: document ilen

### DIFF
--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -409,7 +409,11 @@ def ilen(iterable):
     This consumes the iterable, so handle with care.
 
     """
+    # maxlen=1 only stores the last item in the deque
     d = deque(enumerate(iterable, 1), maxlen=1)
+    # since we started enumerate at 1,
+    # the first item of the last pair will be the length of the iterable
+    # (assuming there were items)
     return d[0][0] if d else 0
 
 


### PR DESCRIPTION
I found the implementation of ilen to be confusing, so I documented it.
It's still unclear to me why this is better than
```py
length = 0
for _ in iterable:
    length += 1
return length
```
Some basic testing shows that the `deque` method is a bit faster, so that could be why.