### PR TITLE
Change distinct_permutations implementation

### DIFF
--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -509,48 +509,41 @@ def one(iterable, too_short=None, too_long=None):
 
 def distinct_permutations(iterable):
     """Yield successive distinct permutations of the elements in *iterable*.
-
         >>> sorted(distinct_permutations([1, 0, 1]))
         [(0, 1, 1), (1, 0, 1), (1, 1, 0)]
-
     Equivalent to ``set(permutations(iterable))``, except duplicates are not
     generated and thrown away. For larger input sequences this is much more
     efficient.
-
     Duplicate permutations arise when there are duplicated elements in the
     input iterable. The number of items returned is
     `n! / (x_1! * x_2! * ... * x_n!)`, where `n` is the total number of
     items input, and each `x_i` is the count of a distinct item in the input
     sequence.
-
     """
-    def perm_unique_helper(item_counts, perm, i):
+    def distinct_permutations_generator(permutations_generator, e):
         """Internal helper function
+        :arg permutations_generator: The previous generator
+        :arg e: The next element from iterable
+        The output permutations are built up by adding the next element to the
+        previous permutations at every possible position. The key idea is to
+        keep identical elements ordered: if e1 == e2 and e1 is before e2 in
+        the iterable, then all permutations with e2 on the right of e1 are
+        ignored."""
+        for permutation in permutations_generator:
+            for j in range(len(permutation)):
+                yield permutation[:j] + [e] + permutation[j:]
+                if permutation[j] == e:
+                    break
+            else:
+                yield permutation + [e]
 
-        :arg item_counts: Stores the unique items in ``iterable`` and how many
-            times they are repeated
-        :arg perm: The permutation that is being built for output
-        :arg i: The index of the permutation being modified
 
-        The output permutations are built up recursively; the distinct items
-        are placed until their repetitions are exhausted.
-        """
-        if i < 0:
-            yield tuple(perm)
-        else:
-            for item in item_counts:
-                if item_counts[item] <= 0:
-                    continue
-                perm[i] = item
-                item_counts[item] -= 1
-                for x in perm_unique_helper(item_counts, perm, i - 1):
-                    yield x
-                item_counts[item] += 1
+    permutations_generator = [[]]
+    for e in iterable:
+        permutations_generator = distinct_permutations_generator(
+            permutations_generator, e)
 
-    item_counts = Counter(iterable)
-
-    return perm_unique_helper(item_counts, [None] * len(iterable),
-                              len(iterable) - 1)
+    return (tuple(t) for t in permutations_generator)
 
 
 def intersperse(e, iterable, n=1):


### PR DESCRIPTION
This PR is totally different from https://github.com/erikrose/more-itertools/pull/207: in https://github.com/erikrose/more-itertools/pull/207, I propose to fix an issue in `distinct_permutations`. Here, I propose another implementation of `distinct_permutations`. (I found the issue when making tests of the new implementation.)

The main and only reason is performance. I found an [interesting implementation of `distinct_permutations` on stackoverflow](https://stackoverflow.com/questions/6284396/permutations-with-unique-values/39014159#39014159) and after some refactoring, I made it faster, using generators.

Here's the full code of my benchmark:

```
import string
import random

def test_func(func, values):
    def test_func_closure():
        return list(func(values))
    return test_func_closure

times = {}
for _ in range(100):
    values = [random.choice(string.ascii_letters[:5]) for _ in range(10)]
    result = set(itertools.permutations(values))
    for func in [distinct_permutations_jferard, distinct_permutations_mi]:
        t = test_func(func, values)
        assert sorted(t()) == sorted(result), "expected: {}, actual: {}".format(result, t())
        times.setdefault(func, []).append(timeit.timeit(t, number=20))

for k,v in times.items():
    print (k, sum(v))
```

And here's the result:

```
<function distinct_permutations_jferard at 0x7f2eec375510> 46.91712202400777
<function distinct_permutations_mi at 0x7f2eec375c80> 248.31336366801224
```

Roughly five times faster.