### PR TITLE
Implement last()

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -124,6 +124,7 @@ These tools return summarized or aggregated data from an iterable.
 
 .. autofunction:: ilen
 .. autofunction:: first(iterable[, default])
+.. autofunction:: last(iterable[, default])
 .. autofunction:: one
 .. autofunction:: unique_to_each
 .. autofunction:: locate(iterable, pred=bool)

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -150,11 +150,14 @@ def last(iterable, default=_marker):
     If *default* is not provided and there are no items in the iterable,
     raise ``ValueError``.
     """
-    if not isinstance(iterable, (list, deque)):
-        iterable = deque(iterable, maxlen=1)
     try:
-        return iterable[-1]
-    except IndexError:
+        try:
+            # Try to access the last item directly
+            return iterable[-1]
+        except (TypeError, AttributeError, KeyError):
+            # If not slice-able, iterate entirely using length-1 deque
+            return deque(iterable, maxlen=1)[0]
+    except IndexError:  # If the iterable was empty
         if default is _marker:
             raise ValueError('last() was called on an empty iterable, and no '
                              'default value was provided.')

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -52,6 +52,7 @@ __all__ = [
     'intersperse',
     'islice_extended',
     'iterate',
+    'last',
     'locate',
     'lstrip',
     'make_decorator',
@@ -133,6 +134,29 @@ def first(iterable, default=_marker):
         # exception, and it's weird to explicitly catch StopIteration.
         if default is _marker:
             raise ValueError('first() was called on an empty iterable, and no '
+                             'default value was provided.')
+        return default
+
+
+def last(iterable, default=_marker):
+    """Return the last item of *iterable*, or *default* if *iterable* is
+    empty.
+
+        >>> last([0, 1, 2, 3])
+        3
+        >>> last([], 'some default')
+        'some default'
+
+    If *default* is not provided and there are no items in the iterable,
+    raise ``ValueError``.
+    """
+    if not isinstance(iterable, (list, deque)):
+        iterable = deque(iterable, maxlen=1)
+    try:
+        return iterable[-1]
+    except IndexError:
+        if default is _marker:
+            raise ValueError('last() was called on an empty iterable, and no '
                              'default value was provided.')
         return default
 

--- a/more_itertools/tests/test_more.py
+++ b/more_itertools/tests/test_more.py
@@ -114,6 +114,28 @@ class FirstTests(TestCase):
         self.assertEqual(mi.first([], 'boo'), 'boo')
 
 
+class LastTests(TestCase):
+    """Tests for ``last()``"""
+
+    def test_many(self):
+        """Test that it works on many-item iterables."""
+        # Also try it on a generator expression to make sure it works on
+        # whatever those return, across Python versions.
+        self.assertEqual(mi.last(x for x in range(4)), 3)
+
+    def test_one(self):
+        """Test that it doesn't raise StopIteration prematurely."""
+        self.assertEqual(mi.last([3]), 3)
+
+    def test_empty_stop_iteration(self):
+        """It should raise StopIteration for empty iterables."""
+        self.assertRaises(ValueError, lambda: mi.last([]))
+
+    def test_default(self):
+        """It should return the provided default arg for empty iterables."""
+        self.assertEqual(mi.last([], 'boo'), 'boo')
+
+
 class PeekableTests(TestCase):
     """Tests for ``peekable()`` behavor not incidentally covered by testing
     ``collate()``

--- a/more_itertools/tests/test_more.py
+++ b/more_itertools/tests/test_more.py
@@ -117,22 +117,42 @@ class FirstTests(TestCase):
 class LastTests(TestCase):
     """Tests for ``last()``"""
 
-    def test_many(self):
-        """Test that it works on many-item iterables."""
+    def test_many_nonsliceable(self):
+        """Test that it works on many-item non-slice-able iterables."""
         # Also try it on a generator expression to make sure it works on
         # whatever those return, across Python versions.
         self.assertEqual(mi.last(x for x in range(4)), 3)
 
-    def test_one(self):
+    def test_one_nonsliceable(self):
+        """Test that it doesn't raise StopIteration prematurely."""
+        self.assertEqual(mi.last(x for x in range(1)), 0)
+
+    def test_empty_stop_iteration_nonsliceable(self):
+        """It should raise ValueError for empty non-slice-able iterables."""
+        self.assertRaises(ValueError, lambda: mi.last(x for x in range(0)))
+
+    def test_default_nonsliceable(self):
+        """It should return the provided default arg for empty non-slice-able
+        iterables.
+        """
+        self.assertEqual(mi.last((x for x in range(0)), 'boo'), 'boo')
+
+    def test_many_sliceable(self):
+        """Test that it works on many-item slice-able iterables."""
+        self.assertEqual(mi.last([0, 1, 2, 3]), 3)
+
+    def test_one_sliceable(self):
         """Test that it doesn't raise StopIteration prematurely."""
         self.assertEqual(mi.last([3]), 3)
 
-    def test_empty_stop_iteration(self):
-        """It should raise StopIteration for empty iterables."""
+    def test_empty_stop_iteration_sliceable(self):
+        """It should raise ValueError for empty slice-able iterables."""
         self.assertRaises(ValueError, lambda: mi.last([]))
 
-    def test_default(self):
-        """It should return the provided default arg for empty iterables."""
+    def test_default_sliceable(self):
+        """It should return the provided default arg for empty slice-able
+        iterables.
+        """
         self.assertEqual(mi.last([], 'boo'), 'boo')
 
 

--- a/more_itertools/tests/test_more.py
+++ b/more_itertools/tests/test_more.py
@@ -1,5 +1,6 @@
 from __future__ import division, print_function, unicode_literals
 
+from collections import OrderedDict
 from decimal import Decimal
 from doctest import DocTestSuite
 from fractions import Fraction
@@ -114,6 +115,31 @@ class FirstTests(TestCase):
         self.assertEqual(mi.first([], 'boo'), 'boo')
 
 
+class IterOnlyRange:
+    """User-defined iterable class which only support __iter__.
+
+    It is not specified to inherit ``object``, so indexing on a instance will
+    raise an ``AttributeError`` rather than ``TypeError`` in Python 2.
+
+    >>> r = IterOnlyRange(5)
+    >>> r[0]
+    AttributeError: IterOnlyRange instance has no attribute '__getitem__'
+
+    Note: In Python 3, ``TypeError`` will be raised because ``object`` is
+    inherited implicitly by default.
+
+    >>> r[0]
+    TypeError: 'IterOnlyRange' object does not support indexing
+    """
+    def __init__(self, n):
+        """Set the length of the range."""
+        self.n = n
+
+    def __iter__(self):
+        """Works same as range()."""
+        return iter(range(self.n))
+
+
 class LastTests(TestCase):
     """Tests for ``last()``"""
 
@@ -154,6 +180,23 @@ class LastTests(TestCase):
         iterables.
         """
         self.assertEqual(mi.last([], 'boo'), 'boo')
+
+    def test_dict(self):
+        """last(dic) and last(dic.keys()) should return same result."""
+        dic = {'a': 1, 'b': 2, 'c': 3}
+        self.assertEqual(mi.last(dic), mi.last(dic.keys()))
+
+    def test_ordereddict(self):
+        """last(dic) should return the last key."""
+        od = OrderedDict()
+        od['a'] = 1
+        od['b'] = 2
+        od['c'] = 3
+        self.assertEqual(mi.last(od), 'c')
+
+    def test_customrange(self):
+        """It should work on custom class where [] raises AttributeError."""
+        self.assertEqual(mi.last(IterOnlyRange(5)), 4)
 
 
 class PeekableTests(TestCase):


### PR DESCRIPTION
Implement `last()` method, which gets last element of the iterable.

Works same as `first(tail(iterable, n=1)[, default])`, but

- More concise and descriptive
- No iteration for random-accessible container