### PR TITLE
Ctrl+H

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -218,6 +218,7 @@ Others
 
 **New itertools**
 
+.. autofunction:: replace
 .. autofunction:: numeric_range(start, stop, step)
 .. autofunction:: always_reversible
 .. autofunction:: side_effect

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -2188,12 +2188,11 @@ def replace(iterable, pred, substitutes, count=None, window_size=1):
     # iterable
     it = chain(iterable, [_marker] * (window_size - 1))
     windows = windowed(it, window_size)
-    w = []
 
     n = 0
     for w in windows:
         # If the current window matches our predicate (and we haven't hit
-        # out maximum number of replacements), splice in the substitutes
+        # our maximum number of replacements), splice in the substitutes
         # and then consume the following windows that overlap with this one.
         # For example, if the iterable is (0, 1, 2, 3, 4...)
         # and the window size is 2, we have (0, 1), (1, 2), (2, 3)...

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -1488,10 +1488,6 @@ def locate(iterable, pred=bool, window_size=None):
         >>> list(locate(iterable, pred=pred, window_size=3))
         [1, 5, 9]
 
-    If the *window_size* is larger than *iterable*, *iterable* will be padded
-    with ``None`` such that *pred* is always called with *window_size*
-    arguments.
-
     Use with :func:`seekable` to find indexes and then retrieve the associated
     items:
 
@@ -1510,7 +1506,10 @@ def locate(iterable, pred=bool, window_size=None):
     if window_size is None:
         return compress(count(), map(pred, iterable))
 
-    it = windowed(iterable, window_size)
+    if window_size < 1:
+        raise ValueError('window size must be at least 1')
+
+    it = windowed(iterable, window_size, fillvalue=_marker)
     return compress(count(), starmap(pred, it))
 
 
@@ -2179,6 +2178,9 @@ def replace(iterable, pred, substitutes, count=None, window_size=1):
         [3, 4, 5, 3, 4, 5]
 
     """
+    if window_size < 1:
+        raise ValueError('window_size must be at least 1')
+
     # Save the substitutes iterable, since it's used more than once
     substitutes = tuple(substitutes)
 
@@ -2211,7 +2213,7 @@ def replace(iterable, pred, substitutes, count=None, window_size=1):
 
         # If there was no match (or we've reached the replacement limit),
         # yield the first item from the window.
-        if w[0] is not _marker:
+        if w and (w[0] is not _marker):
             yield w[0]
 
     # If the last window wasn't a match, we have leftover items. Yield them.

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -12,6 +12,7 @@ from itertools import (
     groupby,
     islice,
     repeat,
+    starmap,
     takewhile,
     tee
 )
@@ -1463,7 +1464,7 @@ def count_cycle(iterable, n=None):
     return ((i, item) for i in counter for item in iterable)
 
 
-def locate(iterable, pred=bool, n=None):
+def locate(iterable, pred=bool, window_size=None):
     """Yield the index of each item in *iterable* for which *pred* returns
     ``True``.
 
@@ -1478,12 +1479,12 @@ def locate(iterable, pred=bool, n=None):
         >>> list(locate(['a', 'b', 'c', 'b'], lambda x: x == 'b'))
         [1, 3]
 
-    If *n* is given, the argument given to the *pred* function will be a tuple
-    with containing *n* items. This enables searching for sub-sequences:
+    If *window_size* is given, then the *pred* function will be called with
+    that many items. This enables searching for sub-sequences:
 
         >>> iterable = [0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3]
-        >>> pred = lambda sub: sub == (1, 2, 3)
-        >>> list(locate(iterable, pred=pred, n=3))
+        >>> pred = lambda *args: args == (1, 2, 3)
+        >>> list(locate(iterable, pred=pred, window_size=3))
         [1, 5, 9]
 
     Use with :func:`seekable` to find indexes and then retrieve the associated
@@ -1501,11 +1502,11 @@ def locate(iterable, pred=bool, n=None):
         106
 
     """
-    if n is None:
+    if window_size is None:
         return compress(count(), map(pred, iterable))
 
-    it = windowed(iterable, n)
-    return compress(count(), map(pred, it))
+    it = windowed(iterable, window_size)
+    return compress(count(), starmap(pred, it))
 
 
 def lstrip(iterable, pred):
@@ -2099,7 +2100,7 @@ def map_reduce(iterable, keyfunc, valuefunc=None, reducefunc=None):
     return ret
 
 
-def rlocate(iterable, pred=bool, n=None):
+def rlocate(iterable, pred=bool, window_size=None):
     """Yield the index of each item in *iterable* for which *pred* returns
     ``True``, starting from the right and moving left.
 
@@ -2116,12 +2117,12 @@ def rlocate(iterable, pred=bool, n=None):
         >>> list(rlocate(iterable, pred))
         [3, 1]
 
-    If *n* is given, the argument given to the *pred* function will be a tuple
-    with containing *n* items. This enables searching for sub-sequences:
+    If *window_size* is given, then the *pred* function will be called with
+    that many items. This enables searching for sub-sequences:
 
         >>> iterable = [0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3]
-        >>> pred = lambda sub: sub == (1, 2, 3)
-        >>> list(rlocate(iterable, pred=pred, n=3))
+        >>> pred = lambda *args: args == (1, 2, 3)
+        >>> list(rlocate(iterable, pred=pred, window_size=3))
         [9, 5, 1]
 
     Beware, this function won't return anything for infinite iterables.
@@ -2132,16 +2133,16 @@ def rlocate(iterable, pred=bool, n=None):
     See :func:`locate` to for other example applications.
 
     """
-    if n is None:
+    if window_size is None:
         try:
             len_iter = len(iterable)
             return (
-                len_iter - i - 1 for i in locate(reversed(iterable), pred, n)
+                len_iter - i - 1 for i in locate(reversed(iterable), pred)
             )
         except TypeError:
             pass
 
-    return reversed(list(locate(iterable, pred, n)))
+    return reversed(list(locate(iterable, pred, window_size)))
 
 
 def replace(iterable, pred, substitutes, count=None, window_size=1):

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -2191,11 +2191,7 @@ def replace(iterable, pred, substitutes, count=None, window_size=1):
     w = []
 
     n = 0
-    last_replaced = False
-
     for w in windows:
-        last_replaced = False
-
         # If the current window matches our predicate (and we haven't hit
         # out maximum number of replacements), splice in the substitutes
         # and then consume the following windows that overlap with this one.
@@ -2204,7 +2200,6 @@ def replace(iterable, pred, substitutes, count=None, window_size=1):
         # If the predicate matches on (0, 1), we need to zap (0, 1) and (1, 2)
         if pred(*w):
             if (count is None) or (n < count):
-                last_replaced = True
                 n += 1
                 for s in substitutes:
                     yield s
@@ -2215,10 +2210,3 @@ def replace(iterable, pred, substitutes, count=None, window_size=1):
         # yield the first item from the window.
         if w and (w[0] is not _marker):
             yield w[0]
-
-    # If the last window wasn't a match, we have leftover items. Yield them.
-    if not last_replaced:
-        for item in w[1:]:
-            if item is _marker:
-                break
-            yield item

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -2099,7 +2099,7 @@ def map_reduce(iterable, keyfunc, valuefunc=None, reducefunc=None):
     return ret
 
 
-def rlocate(iterable, pred=bool):
+def rlocate(iterable, pred=bool, n=None):
     """Yield the index of each item in *iterable* for which *pred* returns
     ``True``, starting from the right and moving left.
 
@@ -2116,6 +2116,14 @@ def rlocate(iterable, pred=bool):
         >>> list(rlocate(iterable, pred))
         [3, 1]
 
+    If *n* is given, the argument given to the *pred* function will be a tuple
+    with containing *n* items. This enables searching for sub-sequences:
+
+        >>> iterable = [0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3]
+        >>> pred = lambda sub: sub == (1, 2, 3)
+        >>> list(rlocate(iterable, pred=pred, n=3))
+        [9, 5, 1]
+
     Beware, this function won't return anything for infinite iterables.
     If *iterable* is reversible, ``rlocate`` will reverse it and search from
     the right. Otherwise, it will search from the left and return the results
@@ -2124,11 +2132,16 @@ def rlocate(iterable, pred=bool):
     See :func:`locate` to for other example applications.
 
     """
-    try:
-        len_iter = len(iterable)
-        return (len_iter - i - 1 for i in locate(reversed(iterable), pred))
-    except TypeError:
-        return reversed(list(locate(iterable, pred)))
+    if n is None:
+        try:
+            len_iter = len(iterable)
+            return (
+                len_iter - i - 1 for i in locate(reversed(iterable), pred, n)
+            )
+        except TypeError:
+            pass
+
+    return reversed(list(locate(iterable, pred, n)))
 
 
 def replace(iterable, select_func, substitute_func, count=None):

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -1463,7 +1463,7 @@ def count_cycle(iterable, n=None):
     return ((i, item) for i in counter for item in iterable)
 
 
-def locate(iterable, pred=bool):
+def locate(iterable, pred=bool, n=None):
     """Yield the index of each item in *iterable* for which *pred* returns
     ``True``.
 
@@ -1473,18 +1473,17 @@ def locate(iterable, pred=bool):
         [1, 2, 4]
 
     Set *pred* to a custom function to, e.g., find the indexes for a particular
-    item:
+    item.
 
         >>> list(locate(['a', 'b', 'c', 'b'], lambda x: x == 'b'))
         [1, 3]
 
-    Use with :func:`windowed` to find the indexes of a sub-sequence:
+    If *n* is given, the argument given to the *pred* function will be a tuple
+    with containing *n* items. This enables searching for sub-sequences:
 
-        >>> from more_itertools import windowed
         >>> iterable = [0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3]
-        >>> sub = [1, 2, 3]
-        >>> pred = lambda w: w == tuple(sub)  # windowed() returns tuples
-        >>> list(locate(windowed(iterable, len(sub)), pred=pred))
+        >>> pred = lambda sub: sub == (1, 2, 3)
+        >>> list(locate(iterable, pred=pred, n=3))
         [1, 5, 9]
 
     Use with :func:`seekable` to find indexes and then retrieve the associated
@@ -1502,22 +1501,11 @@ def locate(iterable, pred=bool):
         106
 
     """
-    return compress(count(), map(pred, iterable))
+    if n is None:
+        return compress(count(), map(pred, iterable))
 
-
-def locate_seq(iterable, seq):
-    """Yield each index in *iterable* where the sequence *seq* begins.
-
-        >>> iterable = [0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3]
-        >>> seq = [1, 2, 3]
-        >>> list(locate_seq(iterable, seq))
-        [1, 5, 9]
-
-    """
-    seq = tuple(seq)
-    it = windowed(iterable, len(seq))
-    pred = lambda w: w == seq
-    return locate(it, pred=pred)
+    it = windowed(iterable, n)
+    return compress(count(), map(pred, it))
 
 
 def lstrip(iterable, pred):

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -62,6 +62,7 @@ __all__ = [
     'one',
     'padded',
     'peekable',
+    'replace',
     'rlocate',
     'rstrip',
     'run_length',
@@ -1487,6 +1488,10 @@ def locate(iterable, pred=bool, window_size=None):
         >>> list(locate(iterable, pred=pred, window_size=3))
         [1, 5, 9]
 
+    If the *window_size* is larger than *iterable*, *iterable* will be padded
+    with ``None`` such that *pred* is always called with *window_size*
+    arguments.
+
     Use with :func:`seekable` to find indexes and then retrieve the associated
     items:
 
@@ -2180,7 +2185,7 @@ def replace(iterable, pred, substitutes, count=None, window_size=1):
     # Add padding such that the number of windows matches the length of the
     # iterable
     it = chain(iterable, [_marker] * (window_size - 1))
-    windows = windowed(it, window_size, fillvalue=_marker)
+    windows = windowed(it, window_size)
     w = []
 
     n = 0

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -2144,89 +2144,68 @@ def rlocate(iterable, pred=bool, n=None):
     return reversed(list(locate(iterable, pred, n)))
 
 
-def replace(iterable, select_func, substitute_func, count=None):
-    """Yield the items in *iterable*, replacing ones for which
-    *select_func* returns ``True`` with the value given by *substitute_func*.
-    The optional argument *count* limits the number of replacements that are
-    made.
+def replace(iterable, pred, substitutes, count=None, window_size=None):
+    """Yield the items from *iterable*, replacing the items for which *pred*
+    returns ``True`` with the items from the iterable *substitutes*.
 
-        >>> iterable = iter('aBCDeFGHi')
-        >>> select_func = lambda x: x == x.lower()
-        >>> substitute_func = lambda x: x.upper()
-        >>> list(replace(iterable, select_func, substitute_func, 2))
-        ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'i']
+        >>> iterable = [0, 1, 2, 5, 0, 1, 2, 5]
+        >>> pred = lambda x: x == 2
+        >>> substitutes = (2, 3, 4)
+        >>> list(replace(iterable, pred, substitutes))
+        [0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5]
 
-    To select and replace multiple items, see :func:`replace_seq`.
+    If *count* is given, the number of replacements will be limited:
 
-    """
-    n = 0
-    for item in iterable:
-        if select_func(item):
-            if (count is None) or (n < count):
-                n += 1
-                yield substitute_func(item)
-                continue
-        yield item
+        >>> iterable = [0, 1, 2, 5, 0, 1, 2, 5]
+        >>> pred = lambda x: x == 2
+        >>> substitutes = (2, 3, 4)
+        >>> list(replace(iterable, pred, substitutes, count=1))
+        [0, 1, 2, 3, 4, 5, 0, 1, 2, 5]
 
+    If *window_size* is given, the argument passed to *pred* will be a tuple
+    of items from the iterable. This allows for locating and replacing
+    subsequences.
 
-def replace_seq(iterable, old_seq, new_seq, count=None):
-    """Yield the items in *iterable*, replacing sub-sequences that match
-    *old_seq* with the items from new_seq, up to *count* times.
-
-        >>> iterable = [0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3]
-        >>> old_seq = [1, 2, 3]
-        >>> new_seq = [-1, -2, -3]
-        >>> list(replace_seq(iterable, old_seq, new_seq, 2))
-        [0, -1, -2, -3, 0, -1, -2, -3, 0, 1, 2, 3]
-
-        >>> iterable = []
-        >>> old_seq = [1, 2, 3]
-        >>> new_seq = [-1, -2, -3]
-        >>> list(replace_seq(iterable, old_seq, new_seq, 2))
-        []
-
-        >>> iterable = [1, 2]
-        >>> old_seq = [1, 2, 3]
-        >>> new_seq = [-1, -2, -3]
-        >>> list(replace_seq(iterable, old_seq, new_seq, 2))
-        [1, 2]
-
-        >>> iterable = [0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3]
-        >>> old_seq = [1, 2, 3]
-        >>> new_seq = [-1, -2, -3]
-        >>> list(replace_seq(iterable, old_seq, new_seq))
-        [0, -1, -2, -3, 0, -1, -2, -3, 0, -1, -2, -3]
-
-        >>> iterable = [0, 1, 2, 3]
-        >>> old_seq = [1, 2, 3]
-        >>> new_seq = [-1, -2, -3]
-        >>> list(replace_seq(iterable, old_seq, new_seq))
-        [0, -1, -2, -3]
+        >>> iterable = [0, 1, 2, 5, 0, 1, 2, 5]
+        >>> window_size = 3
+        >>> pred = lambda x: x == (0, 1, 2)  # Three items passed to pred
+        >>> substitutes = [3, 4]
+        >>> list(replace(iterable, pred, substitutes, window_size=window_size))
+        [3, 4, 5, 3, 4, 5]
 
     """
-    old_seq = tuple(old_seq)
-    new_seq = tuple(new_seq)
+    if window_size is None:
+        n = 0
+        for item in iterable:
+            if pred(item):
+                if (count is None) or (n < count):
+                    n += 1
+                    for s in substitutes:
+                        yield s
+                    continue
+            yield item
+    else:
+        it = chain(iterable, [_marker] * (window_size - 1))
+        windows = windowed(it, window_size, fillvalue=_marker)
+        w = []
 
-    windows = windowed(iterable, len(old_seq), fillvalue=_marker)
-    w = []
-
-    n = 0
-    last_replaced = False
-    for w in windows:
+        n = 0
         last_replaced = False
-        if w == old_seq:
-            if (count is None) or (n < count):
-                last_replaced = True
-                n += 1
-                for item in new_seq:
+        for w in windows:
+            last_replaced = False
+            if pred(w):
+                if (count is None) or (n < count):
+                    last_replaced = True
+                    n += 1
+                    for s in substitutes:
+                        yield s
+                    consume(windows, window_size - 1)
+                    continue
+
+            if w[0] is not _marker:
+                yield w[0]
+
+        if not last_replaced:
+            for item in w[1:]:
+                if item is not _marker:
                     yield item
-                consume(windows, len(old_seq) - 1)
-                continue
-
-        if w[0] is not _marker:
-            yield w[0]
-
-    if not last_replaced:
-        for item in w[1:]:
-            if item is not _marker:
-                yield item

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -2161,11 +2161,11 @@ def replace(iterable, pred, substitutes, count=None, window_size=1):
 
     If *count* is given, the number of replacements will be limited:
 
-        >>> iterable = [1, 1, 0, 1, 1, 0, 1, 1]
+        >>> iterable = [1, 1, 0, 1, 1, 0, 1, 1, 0]
         >>> pred = lambda x: x == 0
         >>> substitutes = [None]
         >>> list(replace(iterable, pred, substitutes, count=2))
-        [1, 1, None, 1, 1, None, 1, 1]
+        [1, 1, None, 1, 1, None, 1, 1, 0]
 
     Use *window_size* to control the number of items passed as arguments to
     *pred*. This allows for locating and replacing subsequences.

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -2126,3 +2126,28 @@ def rlocate(iterable, pred=bool):
         return (len_iter - i - 1 for i in locate(reversed(iterable), pred))
     except TypeError:
         return reversed(list(locate(iterable, pred)))
+
+
+def replace(iterable, select_func, substitute_func, count=None):
+    """Yield the items in *iterable*, replacing ones for which
+    *select_func* returns ``True`` with the value given by *substitute_func*.
+    The optional argument *count* limits the number of replacements that are
+    made.
+
+        >>> iterable = iter('aBCDeFGHi')
+        >>> select_func = lambda x: x == x.lower()
+        >>> substitute_func = lambda x: x.upper()
+        >>> list(replace(iterable, select_func, substitute_func, 2))
+        ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'i']
+
+    To select and replace multiple items, see :func:`replace_seq`.
+
+    """
+    n = 0
+    for item in iterable:
+        if select_func(item):
+            if (count is None) or (n < count):
+                n += 1
+                yield substitute_func(item)
+                continue
+        yield item

--- a/more_itertools/tests/test_more.py
+++ b/more_itertools/tests/test_more.py
@@ -1547,6 +1547,27 @@ class LocateTests(TestCase):
         expected = [0, 3, 5, 6]
         self.assertEqual(actual, expected)
 
+    def test_window_size(self):
+        iterable = ['0', 1, 1, '0', 1, '0', '0']
+        pred = lambda *args: args == ('0', 1)
+        actual = list(mi.locate(iterable, pred, window_size=2))
+        expected = [0, 3]
+        self.assertEqual(actual, expected)
+
+    def test_window_size_large(self):
+        iterable = [1, 2, 3, 4]
+        pred = lambda a, b, c, d, e: e is None
+        actual = list(mi.locate(iterable, pred, window_size=5))
+        expected = [0]
+        self.assertEqual(actual, expected)
+
+    def test_window_size_zero(self):
+        iterable = [1, 2, 3, 4]
+        pred = lambda: True
+        actual = list(mi.locate(iterable, pred, window_size=0))
+        expected = [0]
+        self.assertEqual(actual, expected)
+
 
 class StripFunctionTests(TestCase):
     def test_hashable(self):
@@ -1962,3 +1983,72 @@ class RlocateTests(TestCase):
         pred = lambda x: x == target  # Find-able from the right
         actual = next(mi.rlocate(iterable, pred))
         self.assertEqual(actual, target)
+
+    def test_window_size(self):
+        iterable = ['0', 1, 1, '0', 1, '0', '0']
+        pred = lambda *args: args == ('0', 1)
+        for it in (iterable, iter(iterable)):
+            actual = list(mi.rlocate(it, pred, window_size=2))
+            expected = [3, 0]
+            self.assertEqual(actual, expected)
+
+    def test_window_size_large(self):
+        iterable = [1, 2, 3, 4]
+        pred = lambda a, b, c, d, e: e is None
+        for it in (iterable, iter(iterable)):
+            actual = list(mi.rlocate(iterable, pred, window_size=5))
+            expected = [0]
+            self.assertEqual(actual, expected)
+
+    def test_window_size_zero(self):
+        iterable = [1, 2, 3, 4]
+        pred = lambda: True
+        for it in (iterable, iter(iterable)):
+            actual = list(mi.locate(iterable, pred, window_size=0))
+            expected = [0]
+            self.assertEqual(actual, expected)
+
+
+class ReplaceTests(TestCase):
+    def test_basic(self):
+        iterable = range(10)
+        pred = lambda x: x % 2 == 0
+        substitutes = []
+        actual = list(mi.replace(iterable, pred, substitutes))
+        expected = [1, 3, 5, 7, 9]
+        self.assertEqual(actual, expected)
+
+    def test_count(self):
+        iterable = range(10)
+        pred = lambda x: x % 2 == 0
+        substitutes = []
+        actual = list(mi.replace(iterable, pred, substitutes, count=4))
+        expected = [1, 3, 5, 7, 8, 9]
+        self.assertEqual(actual, expected)
+
+    def test_window_size(self):
+        iterable = range(10)
+        pred = lambda *args: (args == (0, 1, 2)) or (args == (7, 8, 9))
+        substitutes = []
+        actual = list(mi.replace(iterable, pred, substitutes, window_size=3))
+        expected = [3, 4, 5, 6]
+        self.assertEqual(actual, expected)
+
+    def test_window_size_count(self):
+        iterable = range(10)
+        pred = lambda *args: (args == (0, 1, 2)) or (args == (7, 8, 9))
+        substitutes = []
+        actual = list(
+            mi.replace(iterable, pred, substitutes, count=1, window_size=3)
+        )
+        expected = [3, 4, 5, 6, 7, 8, 9]
+        self.assertEqual(actual, expected)
+
+    def test_window_size_large(self):
+        self.fail()
+
+    def test_window_size_zero(self):
+        self.fail()
+
+    def test_iterable_substitutes(self):
+        self.fail()

--- a/more_itertools/tests/test_more.py
+++ b/more_itertools/tests/test_more.py
@@ -2026,10 +2026,18 @@ class ReplaceTests(TestCase):
 
     def test_window_size(self):
         iterable = range(10)
-        pred = lambda *args: (args == (0, 1, 2)) or (args == (7, 8, 9))
+        pred = lambda *args: args == (0, 1, 2)
         substitutes = []
         actual = list(mi.replace(iterable, pred, substitutes, window_size=3))
-        expected = [3, 4, 5, 6]
+        expected = [3, 4, 5, 6, 7, 8, 9]
+        self.assertEqual(actual, expected)
+
+    def test_window_size_end(self):
+        iterable = range(10)
+        pred = lambda *args: args == (7, 8, 9)
+        substitutes = []
+        actual = list(mi.replace(iterable, pred, substitutes, window_size=3))
+        expected = [0, 1, 2, 3, 4, 5, 6]
         self.assertEqual(actual, expected)
 
     def test_window_size_count(self):

--- a/more_itertools/tests/test_more.py
+++ b/more_itertools/tests/test_more.py
@@ -1556,7 +1556,7 @@ class LocateTests(TestCase):
 
     def test_window_size_large(self):
         iterable = [1, 2, 3, 4]
-        pred = lambda a, b, c, d, e: e is None
+        pred = lambda a, b, c, d, e: True
         actual = list(mi.locate(iterable, pred, window_size=5))
         expected = [0]
         self.assertEqual(actual, expected)
@@ -1564,9 +1564,8 @@ class LocateTests(TestCase):
     def test_window_size_zero(self):
         iterable = [1, 2, 3, 4]
         pred = lambda: True
-        actual = list(mi.locate(iterable, pred, window_size=0))
-        expected = [0]
-        self.assertEqual(actual, expected)
+        with self.assertRaises(ValueError):
+            list(mi.locate(iterable, pred, window_size=0))
 
 
 class StripFunctionTests(TestCase):
@@ -1994,7 +1993,7 @@ class RlocateTests(TestCase):
 
     def test_window_size_large(self):
         iterable = [1, 2, 3, 4]
-        pred = lambda a, b, c, d, e: e is None
+        pred = lambda a, b, c, d, e: True
         for it in (iterable, iter(iterable)):
             actual = list(mi.rlocate(iterable, pred, window_size=5))
             expected = [0]
@@ -2004,9 +2003,8 @@ class RlocateTests(TestCase):
         iterable = [1, 2, 3, 4]
         pred = lambda: True
         for it in (iterable, iter(iterable)):
-            actual = list(mi.locate(iterable, pred, window_size=0))
-            expected = [0]
-            self.assertEqual(actual, expected)
+            with self.assertRaises(ValueError):
+                list(mi.locate(iterable, pred, window_size=0))
 
 
 class ReplaceTests(TestCase):
@@ -2045,10 +2043,24 @@ class ReplaceTests(TestCase):
         self.assertEqual(actual, expected)
 
     def test_window_size_large(self):
-        self.fail()
+        iterable = range(4)
+        pred = lambda a, b, c, d, e: True
+        substitutes = [5, 6, 7]
+        actual = list(mi.replace(iterable, pred, substitutes, window_size=5))
+        expected = [5, 6, 7]
+        self.assertEqual(actual, expected)
 
     def test_window_size_zero(self):
-        self.fail()
+        iterable = range(10)
+        pred = lambda *args: True
+        substitutes = []
+        with self.assertRaises(ValueError):
+            list(mi.replace(iterable, pred, substitutes, window_size=0))
 
     def test_iterable_substitutes(self):
-        self.fail()
+        iterable = range(5)
+        pred = lambda x: x % 2 == 0
+        substitutes = iter('__')
+        actual = list(mi.replace(iterable, pred, substitutes))
+        expected = ['_', '_', 1, '_', '_', 3, '_', '_']
+        self.assertEqual(actual, expected)


### PR DESCRIPTION
Re: issue #220, this PR:
* Adds `replace()`, which can cut out sequences of items and splice others in their place
* Adds a *window_size* argument to `locate()` and `rlocate()` that enable them to search for multiple items instead of single items

These additions are intended to bring the functionality of `str.index()` and `str.replace()` to generic iterables.

---

I originally wrote the issue with three (or maybe four) new tools, but I've cut that down to one by unifying `replace()` and `replace_seq()` and adding sub-sequence support to the existing `locate()` and `rlocate()`.

I'll leave some additional comments in the diff.
