### PR TITLE
Make default return for first_true be None

### DIFF
--- a/more_itertools/recipes.py
+++ b/more_itertools/recipes.py
@@ -436,7 +436,7 @@ def iter_except(func, exception, first=None):
         pass
 
 
-def first_true(iterable, default=False, pred=None):
+def first_true(iterable, default=None, pred=None):
     """
     Returns the first true value in the iterable.
 

--- a/more_itertools/tests/test_recipes.py
+++ b/more_itertools/tests/test_recipes.py
@@ -436,7 +436,7 @@ class FirstTrueTests(TestCase):
 
     def test_nothing_true(self):
         """Test default return value."""
-        self.assertEqual(mi.first_true([0, 0, 0]), False)
+        self.assertIsNone(mi.first_true([0, 0, 0]))
 
     def test_default(self):
         """Test with a default keyword"""


### PR DESCRIPTION
Re: Issue #231, this PR changes the "default" return value for `first_true()` to be `None`. That is, the return value for when none of the values in the iterable are truthy. Previously it was `False`.

---

__Before__:

```python
>>> from more_itertools import first_true
... iterable = [0, 0.0, '', complex(0, 0), False, bool(), [], (), set()]
... first_true(iterable)
False
>>>
```

__After__:

```python
>>> from more_itertools import first_true
... iterable = [0, 0.0, '', complex(0, 0), False, bool(), [], (), set()]
... first_true(iterable)
>>> 
```