### PR TITLE
Allow line breaks after binary operators

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,3 @@
 [flake8]
 exclude = ./docs/conf.py, .eggs/
-ignore = E731, E741, F999
+ignore = E731, E741, F999, W504


### PR DESCRIPTION
This PR fixes the test failures on `master`. It seems the `flake8` dependencies updated.