### PR TITLE
Test version 3.7 in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 sudo: false
-
+dist: "xenial"
 language: "python"
 
 python:
@@ -7,7 +7,7 @@ python:
     - "3.4"
     - "3.5"
     - "3.6"
-    - "3.7-dev"
+    - "3.7"
     - "pypy-5.4.1"
     - "pypy3"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,8 @@ python:
     - "3.4"
     - "3.5"
     - "3.6"
-    - "3.7-dev"
-    - "pypy2.7"
+    - "3.7"
+    - "pypy2.7-5.10.0"
     - "pypy3.5"
 
 install:
@@ -21,7 +21,7 @@ script:
     - "sphinx-build -W -b html docs docs/_build/html"
 
 notifications:
-  email: false
+    - email: false
 
 after_success:
     - "coveralls"

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,9 @@ python:
     - "3.4"
     - "3.5"
     - "3.6"
-    - "3.7"
-    - "pypy-5.4.1"
-    - "pypy3"
+    - "3.7-dev"
+    - "pypy2.7"
+    - "pypy3.5"
 
 install:
     - "pip install ."

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,3 @@
 [flake8]
 exclude = ./docs/conf.py, .eggs/
-ignore = E731, E741, F999
+ignore = E731, E741, F999, W504


### PR DESCRIPTION
3.7 proper is now available in Travis, using the `xenial` image. This PR adds in that testing, and squelches a warning from the new version of `flake8`.