### PR TITLE
gitignore: ignore more venvs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,7 +26,10 @@ pip-log.txt
 _build
 
 # Environment
-.env
+.env/
+.venv/
+env/
+venv/
 
 # IDE files
 .idea


### PR DESCRIPTION
not everyone uses env/ as their venv folder.
Also, I used venv/ instead of /venv/ because some may want a separate venv for docs