### PR TITLE
Upgrade PyPy versions in Travis testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-sudo: false
 dist: "xenial"
 language: "python"
 
@@ -8,8 +7,8 @@ python:
     - "3.5"
     - "3.6"
     - "3.7"
-    - "pypy2.7-5.10.0"
-    - "pypy3.5"
+    - "pypy2.7-6.0"
+    - "pypy3.5-6.0"
 
 install:
     - "pip install ."


### PR DESCRIPTION
This PR changes:
* The `sudo` keyword in `.travis.yml` - see [their blog post](https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration)
* The PyPy versions under test to 6.0 for both 2.7 and 3.5