### PR TITLE
Add split_into

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -20,6 +20,7 @@ These tools yield groups of items from a source iterable.
 .. autofunction:: split_at
 .. autofunction:: split_before
 .. autofunction:: split_after
+.. autofunction:: split_into
 .. autofunction:: bucket
 .. autofunction:: unzip
 

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -74,6 +74,7 @@ __all__ = [
     'split_at',
     'split_after',
     'split_before',
+    'split_into',
     'spy',
     'stagger',
     'strip',
@@ -1068,6 +1069,53 @@ def split_after(iterable, pred):
             buf = []
     if buf:
         yield buf
+
+
+def split_into(iterable, sizes):
+    """Yield a list of sequential items from *iterable* of length 'n' for each
+    integer 'n' in *sizes*.
+
+        >>> list(split_into([1,2,3,4,5,6], [1,2,3]))
+        [[1], [2, 3], [4, 5, 6]]
+
+    If the sum of *sizes* is smaller than the length of *iterable*, then the
+    remaining items of *iterable* will not be returned.
+
+        >>> list(split_into([1,2,3,4,5,6], [2,3]))
+        [[1, 2], [3, 4, 5]]
+
+    If the sum of *sizes* is larger than the length of *iterable*, fewer items
+    will be returned in the iteration that overruns *iterable* and further
+    lists will be empty:
+
+        >>> list(split_into([1,2,3,4], [1,2,3,4]))
+        [[1], [2, 3], [4], []]
+
+    When a ``None`` object is encountered in *sizes*, the returned list will
+    contain items up to the end of *iterable* the same way that itertools.slice
+    does:
+
+        >>> list(split_into([1,2,3,4,5,6,7,8,9,0], [2,3,None]))
+        [[1, 2], [3, 4, 5], [6, 7, 8, 9, 0]]
+
+    :func:`split_into` can be useful for grouping a series of items where the
+    sizes of the groups are not uniform. An example would be where in a row
+    from a table, multiple columns represent elements of the same feature
+    (e.g. a point represented by x,y,z) but, the format is not the same for
+    all columns.
+    """
+    # convert the iterable argument into an iterator so its contents can
+    # be consumed by islice in case it is a generator
+    it = iter(iterable)
+
+    for size in sizes:
+        if isinstance(size, int):
+            yield list(islice(it, size))
+        elif size is None:
+            yield list(it)
+            return
+        else:
+            raise TypeError("each item in 'sizes' must be an integer or None")
 
 
 def padded(iterable, fillvalue=None, n=None, next_multiple=False):

--- a/more_itertools/tests/test_more.py
+++ b/more_itertools/tests/test_more.py
@@ -1013,167 +1013,167 @@ class SplitIntoTests(TestCase):
     """Tests for ``split_into()``"""
 
     def test_iterable_just_right(self):
-        """Size of ``iterable`` equals the sum of ``lengths``."""
+        """Size of ``iterable`` equals the sum of ``sizes``."""
         iterable = [1, 2, 3, 4, 5, 6, 7, 8, 9]
-        lengths = [2, 3, 4]
+        sizes = [2, 3, 4]
         expected = [[1, 2], [3, 4, 5], [6, 7, 8, 9]]
-        actual = list(mi.split_into(iterable, lengths))
+        actual = list(mi.split_into(iterable, sizes))
         self.assertEqual(actual, expected)
 
     def test_iterable_too_small(self):
-        """Size of ``iterable`` is smaller than sum of ``lengths``. Last return
+        """Size of ``iterable`` is smaller than sum of ``sizes``. Last return
         list is shorter as a result."""
         iterable = [1, 2, 3, 4, 5, 6, 7]
-        lengths = [2, 3, 4]
+        sizes = [2, 3, 4]
         expected = [[1, 2], [3, 4, 5], [6, 7]]
-        actual = list(mi.split_into(iterable, lengths))
+        actual = list(mi.split_into(iterable, sizes))
         self.assertEqual(actual, expected)
 
     def test_iterable_too_small_extra(self):
-        """Size of ``iterable`` is smaller than sum of ``lengths``. Second last
+        """Size of ``iterable`` is smaller than sum of ``sizes``. Second last
         return list is shorter and last return list is empty as a result."""
         iterable = [1, 2, 3, 4, 5, 6, 7]
-        lengths = [2, 3, 4, 5]
+        sizes = [2, 3, 4, 5]
         expected = [[1, 2], [3, 4, 5], [6, 7], []]
-        actual = list(mi.split_into(iterable, lengths))
+        actual = list(mi.split_into(iterable, sizes))
         self.assertEqual(actual, expected)
 
     def test_iterable_too_large(self):
-        """Size of ``iterable`` is larger than sum of ``lengths``. Not all
+        """Size of ``iterable`` is larger than sum of ``sizes``. Not all
         items of iterable are returned."""
         iterable = [1, 2, 3, 4, 5, 6, 7, 8, 9]
-        lengths = [2, 3, 2]
+        sizes = [2, 3, 2]
         expected = [[1, 2], [3, 4, 5], [6, 7]]
-        actual = list(mi.split_into(iterable, lengths))
+        actual = list(mi.split_into(iterable, sizes))
         self.assertEqual(actual, expected)
 
     def test_using_none_with_leftover(self):
-        """Last item of ``lengths`` is None when items still remain in
+        """Last item of ``sizes`` is None when items still remain in
         ``iterable``. Last list returned stretches to fit all remaining items
         of ``iterable``."""
         iterable = [1, 2, 3, 4, 5, 6, 7, 8, 9]
-        lengths = [2, 3, None]
+        sizes = [2, 3, None]
         expected = [[1, 2], [3, 4, 5], [6, 7, 8, 9]]
-        actual = list(mi.split_into(iterable, lengths))
+        actual = list(mi.split_into(iterable, sizes))
         self.assertEqual(actual, expected)
 
     def test_using_none_without_leftover(self):
-        """Last item of ``lengths`` is None when no items remain in
+        """Last item of ``sizes`` is None when no items remain in
         ``iterable``. Last list returned is empty."""
         iterable = [1, 2, 3, 4, 5, 6, 7, 8, 9]
-        lengths = [2, 3, 4, None]
+        sizes = [2, 3, 4, None]
         expected = [[1, 2], [3, 4, 5], [6, 7, 8, 9], []]
-        actual = list(mi.split_into(iterable, lengths))
+        actual = list(mi.split_into(iterable, sizes))
         self.assertEqual(actual, expected)
 
-    def test_using_none_mid_lengths(self):
-        """None is present in ``lengths`` but is not the last item. Last list
+    def test_using_none_mid_sizes(self):
+        """None is present in ``sizes`` but is not the last item. Last list
         returned stretches to fit all remaining items of ``iterable`` but
-        all items in ``lengths`` after None are ignored."""
+        all items in ``sizes`` after None are ignored."""
         iterable = [1, 2, 3, 4, 5, 6, 7, 8, 9]
-        lengths = [2, 3, None, 4]
+        sizes = [2, 3, None, 4]
         expected = [[1, 2], [3, 4, 5], [6, 7, 8, 9]]
-        actual = list(mi.split_into(iterable, lengths))
+        actual = list(mi.split_into(iterable, sizes))
         self.assertEqual(actual, expected)
 
     def test_iterable_empty(self):
-        """``iterable`` argument is empty but ``lengths`` is not. An empty
-        list is returned for each item in ``lengths``."""
+        """``iterable`` argument is empty but ``sizes`` is not. An empty
+        list is returned for each item in ``sizes``."""
         iterable = []
-        lengths = [2, 4, 2]
+        sizes = [2, 4, 2]
         expected = [[], [], []]
-        actual = list(mi.split_into(iterable, lengths))
+        actual = list(mi.split_into(iterable, sizes))
         self.assertEqual(actual, expected)
 
     def test_iterable_empty_using_none(self):
-        """``iterable`` argument is empty but ``lengths`` is not. An empty
-        list is returned for each item in ``lengths`` that is not after a
+        """``iterable`` argument is empty but ``sizes`` is not. An empty
+        list is returned for each item in ``sizes`` that is not after a
         None item."""
         iterable = []
-        lengths = [2, 4, None, 2]
+        sizes = [2, 4, None, 2]
         expected = [[], [], []]
-        actual = list(mi.split_into(iterable, lengths))
+        actual = list(mi.split_into(iterable, sizes))
         self.assertEqual(actual, expected)
 
-    def test_lengths_empty(self):
-        """``lengths`` argument is empty but ``iterable`` is not. An empty
+    def test_sizes_empty(self):
+        """``sizes`` argument is empty but ``iterable`` is not. An empty
         generator is returned."""
         iterable = [1, 2, 3, 4, 5, 6, 7, 8, 9]
-        lengths = []
+        sizes = []
         expected = []
-        actual = list(mi.split_into(iterable, lengths))
+        actual = list(mi.split_into(iterable, sizes))
         self.assertEqual(actual, expected)
 
     def test_both_empty(self):
-        """Both ``lengths`` and ``iterable`` arguments are empty. An empty
+        """Both ``sizes`` and ``iterable`` arguments are empty. An empty
         generator is returned."""
         iterable = []
-        lengths = []
+        sizes = []
         expected = []
-        actual = list(mi.split_into(iterable, lengths))
+        actual = list(mi.split_into(iterable, sizes))
         self.assertEqual(actual, expected)
 
-    def test_float_in_lengths(self):
-        """A float object is present in ``lengths`` and raises a TypeError
+    def test_float_in_sizes(self):
+        """A float object is present in ``sizes`` and raises a TypeError
         when reached."""
         iterable = [1, 2, 3, 4, 5, 6, 7, 8, 9]
-        lengths = [1, 2.0]
+        sizes = [1, 2.0]
         with self.assertRaises(TypeError):
-            list(mi.split_into(iterable, lengths))
+            list(mi.split_into(iterable, sizes))
 
-    def test_bool_in_lengths(self):
-        """A bool object is present in ``lengths`` is treated as a 1 or 0 for
+    def test_bool_in_sizes(self):
+        """A bool object is present in ``sizes`` is treated as a 1 or 0 for
         True or False due to bool being an instance of int."""
         iterable = [1, 2, 3, 4, 5, 6, 7, 8, 9]
-        lengths = [3, True, 2, False]
+        sizes = [3, True, 2, False]
         expected = [[1, 2, 3], [4], [5, 6], []]
-        actual = list(mi.split_into(iterable, lengths))
+        actual = list(mi.split_into(iterable, sizes))
         self.assertEqual(actual, expected)
 
-    def test_non_numeric_in_lengths(self):
-        """A non-numeric object in lengths will raise a TypeError if it is not
+    def test_non_numeric_in_sizes(self):
+        """A non-numeric object in sizes will raise a TypeError if it is not
         and instance of int."""
         iterable = [1, 2, 3, 4, 5, 6, 7, 8, 9]
-        lengths = [1, [], 3]
+        sizes = [1, [], 3]
         with self.assertRaises(TypeError):
-            list(mi.split_into(iterable, lengths))
+            list(mi.split_into(iterable, sizes))
 
-    def test_invalid_in_lengths_after_none(self):
-        """A item in lengths that is invalid will not raise a TypeError if it
+    def test_invalid_in_sizes_after_none(self):
+        """A item in sizes that is invalid will not raise a TypeError if it
         comes after a None item."""
         iterable = [1, 2, 3, 4, 5, 6, 7, 8, 9]
-        lengths = [3, 4, None, []]
+        sizes = [3, 4, None, []]
         expected = [[1, 2, 3], [4, 5, 6, 7], [8, 9]]
-        actual = list(mi.split_into(iterable, lengths))
+        actual = list(mi.split_into(iterable, sizes))
         self.assertEqual(actual, expected)
 
     def test_generator_iterable_integrity(self):
         """Check that if ``iterable`` is an iterator, it is consumed only by as
-        many items as the sum of ``lengths``."""
+        many items as the sum of ``sizes``."""
         iterable = (i for i in range(10))
-        lengths = [2, 3]
+        sizes = [2, 3]
 
         expected = [[0, 1], [2, 3, 4]]
-        actual = list(mi.split_into(iterable, lengths))
+        actual = list(mi.split_into(iterable, sizes))
         self.assertEqual(actual, expected)
 
         iterable_expected = [5, 6, 7, 8, 9]
         iterable_actual = list(iterable)
         self.assertEqual(iterable_actual, iterable_expected)
 
-    def test_generator_lengths_integrity(self):
-        """Check that if ``lengths`` is an iterator, it is consumed only until a
+    def test_generator_sizes_integrity(self):
+        """Check that if ``sizes`` is an iterator, it is consumed only until a
         None item is reached"""
         iterable = [1, 2, 3, 4, 5, 6, 7, 8, 9]
-        lengths = (i for i in [1, 2, None, 3, 4])
+        sizes = (i for i in [1, 2, None, 3, 4])
 
         expected = [[1], [2, 3], [4, 5, 6, 7, 8, 9]]
-        actual = list(mi.split_into(iterable, lengths))
+        actual = list(mi.split_into(iterable, sizes))
         self.assertEqual(actual, expected)
 
-        lengths_expected = [3, 4]
-        lengths_actual = list(lengths)
-        self.assertEqual(lengths_actual, lengths_expected)
+        sizes_expected = [3, 4]
+        sizes_actual = list(sizes)
+        self.assertEqual(sizes_actual, sizes_expected)
 
 
 class PaddedTest(TestCase):

--- a/more_itertools/tests/test_more.py
+++ b/more_itertools/tests/test_more.py
@@ -1009,6 +1009,173 @@ class SplitAfterTest(TestCase):
         self.assertEqual(actual, expected)
 
 
+class SplitIntoTests(TestCase):
+    """Tests for ``split_into()``"""
+
+    def test_iterable_just_right(self):
+        """Size of ``iterable`` equals the sum of ``lengths``."""
+        iterable = [1, 2, 3, 4, 5, 6, 7, 8, 9]
+        lengths = [2, 3, 4]
+        expected = [[1, 2], [3, 4, 5], [6, 7, 8, 9]]
+        actual = list(mi.split_into(iterable, lengths))
+        self.assertEqual(actual, expected)
+
+    def test_iterable_too_small(self):
+        """Size of ``iterable`` is smaller than sum of ``lengths``. Last return
+        list is shorter as a result."""
+        iterable = [1, 2, 3, 4, 5, 6, 7]
+        lengths = [2, 3, 4]
+        expected = [[1, 2], [3, 4, 5], [6, 7]]
+        actual = list(mi.split_into(iterable, lengths))
+        self.assertEqual(actual, expected)
+
+    def test_iterable_too_small_extra(self):
+        """Size of ``iterable`` is smaller than sum of ``lengths``. Second last
+        return list is shorter and last return list is empty as a result."""
+        iterable = [1, 2, 3, 4, 5, 6, 7]
+        lengths = [2, 3, 4, 5]
+        expected = [[1, 2], [3, 4, 5], [6, 7], []]
+        actual = list(mi.split_into(iterable, lengths))
+        self.assertEqual(actual, expected)
+
+    def test_iterable_too_large(self):
+        """Size of ``iterable`` is larger than sum of ``lengths``. Not all
+        items of iterable are returned."""
+        iterable = [1, 2, 3, 4, 5, 6, 7, 8, 9]
+        lengths = [2, 3, 2]
+        expected = [[1, 2], [3, 4, 5], [6, 7]]
+        actual = list(mi.split_into(iterable, lengths))
+        self.assertEqual(actual, expected)
+
+    def test_using_none_with_leftover(self):
+        """Last item of ``lengths`` is None when items still remain in
+        ``iterable``. Last list returned stretches to fit all remaining items
+        of ``iterable``."""
+        iterable = [1, 2, 3, 4, 5, 6, 7, 8, 9]
+        lengths = [2, 3, None]
+        expected = [[1, 2], [3, 4, 5], [6, 7, 8, 9]]
+        actual = list(mi.split_into(iterable, lengths))
+        self.assertEqual(actual, expected)
+
+    def test_using_none_without_leftover(self):
+        """Last item of ``lengths`` is None when no items remain in
+        ``iterable``. Last list returned is empty."""
+        iterable = [1, 2, 3, 4, 5, 6, 7, 8, 9]
+        lengths = [2, 3, 4, None]
+        expected = [[1, 2], [3, 4, 5], [6, 7, 8, 9], []]
+        actual = list(mi.split_into(iterable, lengths))
+        self.assertEqual(actual, expected)
+
+    def test_using_none_mid_lengths(self):
+        """None is present in ``lengths`` but is not the last item. Last list
+        returned stretches to fit all remaining items of ``iterable`` but
+        all items in ``lengths`` after None are ignored."""
+        iterable = [1, 2, 3, 4, 5, 6, 7, 8, 9]
+        lengths = [2, 3, None, 4]
+        expected = [[1, 2], [3, 4, 5], [6, 7, 8, 9]]
+        actual = list(mi.split_into(iterable, lengths))
+        self.assertEqual(actual, expected)
+
+    def test_iterable_empty(self):
+        """``iterable`` argument is empty but ``lengths`` is not. An empty
+        list is returned for each item in ``lengths``."""
+        iterable = []
+        lengths = [2, 4, 2]
+        expected = [[], [], []]
+        actual = list(mi.split_into(iterable, lengths))
+        self.assertEqual(actual, expected)
+
+    def test_iterable_empty_using_none(self):
+        """``iterable`` argument is empty but ``lengths`` is not. An empty
+        list is returned for each item in ``lengths`` that is not after a
+        None item."""
+        iterable = []
+        lengths = [2, 4, None, 2]
+        expected = [[], [], []]
+        actual = list(mi.split_into(iterable, lengths))
+        self.assertEqual(actual, expected)
+
+    def test_lengths_empty(self):
+        """``lengths`` argument is empty but ``iterable`` is not. An empty
+        generator is returned."""
+        iterable = [1, 2, 3, 4, 5, 6, 7, 8, 9]
+        lengths = []
+        expected = []
+        actual = list(mi.split_into(iterable, lengths))
+        self.assertEqual(actual, expected)
+
+    def test_both_empty(self):
+        """Both ``lengths`` and ``iterable`` arguments are empty. An empty
+        generator is returned."""
+        iterable = []
+        lengths = []
+        expected = []
+        actual = list(mi.split_into(iterable, lengths))
+        self.assertEqual(actual, expected)
+
+    def test_float_in_lengths(self):
+        """A float object is present in ``lengths`` and raises a TypeError
+        when reached."""
+        iterable = [1, 2, 3, 4, 5, 6, 7, 8, 9]
+        lengths = [1, 2.0]
+        with self.assertRaises(TypeError):
+            list(mi.split_into(iterable, lengths))
+
+    def test_bool_in_lengths(self):
+        """A bool object is present in ``lengths`` is treated as a 1 or 0 for
+        True or False due to bool being an instance of int."""
+        iterable = [1, 2, 3, 4, 5, 6, 7, 8, 9]
+        lengths = [3, True, 2, False]
+        expected = [[1, 2, 3], [4], [5, 6], []]
+        actual = list(mi.split_into(iterable, lengths))
+        self.assertEqual(actual, expected)
+
+    def test_non_numeric_in_lengths(self):
+        """A non-numeric object in lengths will raise a TypeError if it is not
+        and instance of int."""
+        iterable = [1, 2, 3, 4, 5, 6, 7, 8, 9]
+        lengths = [1, [], 3]
+        with self.assertRaises(TypeError):
+            list(mi.split_into(iterable, lengths))
+
+    def test_invalid_in_lengths_after_none(self):
+        """A item in lengths that is invalid will not raise a TypeError if it
+        comes after a None item."""
+        iterable = [1, 2, 3, 4, 5, 6, 7, 8, 9]
+        lengths = [3, 4, None, []]
+        expected = [[1, 2, 3], [4, 5, 6, 7], [8, 9]]
+        actual = list(mi.split_into(iterable, lengths))
+        self.assertEqual(actual, expected)
+
+    def test_generator_iterable_integrity(self):
+        """Check that if ``iterable`` is an iterator, it is consumed only by as
+        many items as the sum of ``lengths``."""
+        iterable = (i for i in range(10))
+        lengths = [2, 3]
+
+        expected = [[0, 1], [2, 3, 4]]
+        actual = list(mi.split_into(iterable, lengths))
+        self.assertEqual(actual, expected)
+
+        iterable_expected = [5, 6, 7, 8, 9]
+        iterable_actual = list(iterable)
+        self.assertEqual(iterable_actual, iterable_expected)
+
+    def test_generator_lengths_integrity(self):
+        """Check that if ``lengths`` is an iterator, it is consumed only until a
+        None item is reached"""
+        iterable = [1, 2, 3, 4, 5, 6, 7, 8, 9]
+        lengths = (i for i in [1, 2, None, 3, 4])
+
+        expected = [[1], [2, 3], [4, 5, 6, 7, 8, 9]]
+        actual = list(mi.split_into(iterable, lengths))
+        self.assertEqual(actual, expected)
+
+        lengths_expected = [3, 4]
+        lengths_actual = list(lengths)
+        self.assertEqual(lengths_actual, lengths_expected)
+
+
 class PaddedTest(TestCase):
     """Tests for ``padded()``"""
 


### PR DESCRIPTION
Re: [Issue #246](https://github.com/erikrose/more-itertools/issues/246)

An addition to the `grouping` tools that splits an iterable into uneven groups based on a list of sizes. Given `split_into(iterable, sizes)`, a list of length _n_ is yielded containing the next _n_ items in `iterable` for each integer _n_ in `sizes`. 

When a `None` item is encountered in `sizes`, then the rest of `iterable` is returned. This follows from the functionality of `islice` which will yield until the end of the iterator if a `None` is passed to `end`.

`split_into` can take an iterator argument for both `iterable` and `sizes`. `iterable` will be consumed up to the sum of the integers encountered in `sizes` or will be fully consumed if a `None` value in `sizes` is encountered. `sizes` will be consumed up to and including any `None` values. A `TypeError` is thrown if an item in `sizes` is neither an instance of `int` or `None` unless the item comes after a `None` value.

All implementations, tests and references to `split_into` were inserted after `split_after` as it was the last item in the `grouping` section.

