### PR TITLE
Use explicit keyword argument in some functions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ dist: "xenial"
 language: "python"
 
 python:
-    - "2.7"
     - "3.4"
     - "3.5"
     - "3.6"

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -339,14 +339,11 @@ class peekable(object):
         return self._cache[index]
 
 
-def _collate(*iterables, **kwargs):
+def _collate(*iterables,key=lambda a: a, reverse = False):
     """Helper for ``collate()``, called when the user is using the ``reverse``
     or ``key`` keyword arguments on Python versions below 3.5.
 
     """
-    key = kwargs.pop('key', lambda a: a)
-    reverse = kwargs.pop('reverse', False)
-
     min_or_max = partial(max if reverse else min, key=itemgetter(0))
     peekables = [peekable(it) for it in iterables]
     peekables = [p for p in peekables if p]  # Kill empties.

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -1207,7 +1207,7 @@ def stagger(iterable, offsets=(-1, 0, 1), longest=False, fillvalue=None):
     )
 
 
-def zip_offset(*iterables, **kwargs):
+def zip_offset(*iterables,offsets,longest=False,fillvalue=None):
     """``zip`` the input *iterables* together, but offset the `i`-th iterable
     by the `i`-th item in *offsets*.
 
@@ -1228,9 +1228,6 @@ def zip_offset(*iterables, **kwargs):
     sequence. Specify *fillvalue* to use some other value.
 
     """
-    offsets = kwargs['offsets']
-    longest = kwargs.get('longest', False)
-    fillvalue = kwargs.get('fillvalue', None)
 
     if len(iterables) != len(offsets):
         raise ValueError("Number of iterables and offsets didn't match")

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -339,7 +339,7 @@ class peekable(object):
         return self._cache[index]
 
 
-def _collate(*iterables,key=lambda a: a, reverse = False):
+def _collate(*iterables, key=lambda a: a, reverse=False):
     """Helper for ``collate()``, called when the user is using the ``reverse``
     or ``key`` keyword arguments on Python versions below 3.5.
 
@@ -1204,7 +1204,7 @@ def stagger(iterable, offsets=(-1, 0, 1), longest=False, fillvalue=None):
     )
 
 
-def zip_offset(*iterables,offsets,longest=False,fillvalue=None):
+def zip_offset(*iterables, offsets, longest=False, fillvalue=None):
     """``zip`` the input *iterables* together, but offset the `i`-th iterable
     by the `i`-th item in *offsets*.
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py34, py35, py36, py37
+envlist = py34, py35, py36, py37
 
 [testenv]
 commands = {envbindir}/python -m unittest discover -v


### PR DESCRIPTION
Part of #253
Makes writing stubs for #262 much easier for some methods
Not py2 (and probably some of py3) compatible