### PR TITLE
Drop support for Python 3.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ dist: "xenial"
 language: "python"
 
 python:
-    - "3.4"
     - "3.5"
     - "3.6"
     - "3.7"

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
     author_email='erikrose@grinchcentral.com',
     license='MIT',
     packages=find_packages(exclude=['ez_setup']),
-    python_requires='>=3.4',
+    python_requires='>=3.5',
     test_suite='more_itertools.tests',
     url='https://github.com/erikrose/more-itertools',
     include_package_data=True,

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py34, py35, py36, py37
+envlist = py35, py36, py37
 
 [testenv]
 commands = {envbindir}/python -m unittest discover -v


### PR DESCRIPTION
Python 3.4 reached its EOL on 2019-03-18, see https://www.python.org/dev/peps/pep-0429/#release-schedule

This allows to make full use of PEP 484, see https://docs.python.org/3/whatsnew/3.5.html#pep-484-type-hints