### PR TITLE
Fix typo in Version History for 6.0.0

### DIFF
--- a/docs/versions.rst
+++ b/docs/versions.rst
@@ -29,7 +29,7 @@ This aligns its behavior with :func:`always_iterable`.
 6.0.0
 -----
 
-* Major chances:
+* Major changes:
     * Python 2.7 is no longer supported. The 5.0.0 release will be the last
       version targeting Python 2.7.
     * All future releases will target the active versions of Python 3.


### PR DESCRIPTION
Hi, I found a mistake in the history of version 6.0.0.

```
Major chances
          ^
```

Maybe this meaning is "Major changes"?

Thanks to the continuous development of the maintainers and contributors.