### PR TITLE
Support datetimes in numeric_range

### DIFF
--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -1565,6 +1565,19 @@ def numeric_range(*args):
     Be aware of the limitations of floating point numbers; the representation
     of the yielded numbers may be surprising.
 
+    ``datetime.datetime`` objects can be used for *start* and *stop*, if *step*
+    is a ``datetime.timedelta`` object:
+
+        >>> import datetime
+        >>> start = datetime.datetime(2019, 1, 1)
+        >>> stop = datetime.datetime(2019, 1, 3)
+        >>> step = datetime.timedelta(days=1)
+        >>> items = numeric_range(start, stop, step)
+        >>> next(items)
+        datetime.datetime(2019, 1, 1, 0, 0)
+        >>> next(items)
+        datetime.datetime(2019, 1, 2, 0, 0)
+
     """
     argc = len(args)
     if argc == 1:

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -1581,9 +1581,10 @@ def numeric_range(*args):
         raise TypeError(err_msg.format(argc))
 
     values = (start + (step * n) for n in count())
-    if step > 0:
+    zero = type(step)(0)
+    if step > zero:
         return takewhile(partial(gt, stop), values)
-    elif step < 0:
+    elif step < zero:
         return takewhile(partial(lt, stop), values)
     else:
         raise ValueError('numeric_range arg 3 must not be zero')

--- a/more_itertools/tests/test_more.py
+++ b/more_itertools/tests/test_more.py
@@ -1,4 +1,5 @@
 from collections import OrderedDict
+from datetime import datetime, timedelta
 from decimal import Decimal
 from doctest import DocTestSuite
 from fractions import Fraction
@@ -1791,6 +1792,18 @@ class NumericRangeTests(TestCase):
             ((1.0, 0.0), []),
             ((Fraction(2, 1),), [Fraction(0, 1), Fraction(1, 1)]),
             ((Decimal('2.0'),), [Decimal('0.0'), Decimal('1.0')]),
+            (
+                (
+                    datetime(2019, 3, 29, 12, 34, 56),
+                    datetime(2019, 3, 29, 12, 37, 55),
+                    timedelta(minutes=1)
+                ),
+                [
+                    datetime(2019, 3, 29, 12, 34, 56),
+                    datetime(2019, 3, 29, 12, 35, 56),
+                    datetime(2019, 3, 29, 12, 36, 56),
+                ]
+            ),
         ]:
             actual = list(mi.numeric_range(*args))
             self.assertEqual(actual, expected)
@@ -1805,9 +1818,16 @@ class NumericRangeTests(TestCase):
         )
 
     def test_zero_step(self):
-        self.assertRaises(
-            ValueError, lambda: list(mi.numeric_range(1, 2, 0))
-        )
+        with self.assertRaises(ValueError):
+            for args in [
+                (1, 2, 0),
+                (
+                    datetime(2019, 3, 29, 12, 34, 56),
+                    datetime(2019, 3, 29, 12, 37, 55),
+                    timedelta(minutes=0)
+                ),
+            ]:
+                list(mi.numeric_range(*args))
 
 
 class CountCycleTests(TestCase):


### PR DESCRIPTION
This PR modifies `numeric_range` such that `start` and `stop` can be `datetime.datetime` objects, if `step` is a `datetime.timedelta` object.