### PR TITLE
Fix numeric range with step zero test

### DIFF
--- a/more_itertools/tests/test_more.py
+++ b/more_itertools/tests/test_more.py
@@ -1818,15 +1818,15 @@ class NumericRangeTests(TestCase):
         )
 
     def test_zero_step(self):
-        with self.assertRaises(ValueError):
-            for args in [
-                (1, 2, 0),
-                (
-                    datetime(2019, 3, 29, 12, 34, 56),
-                    datetime(2019, 3, 29, 12, 37, 55),
-                    timedelta(minutes=0)
-                ),
-            ]:
+        for args in [
+            (1, 2, 0),
+            (
+                datetime(2019, 3, 29, 12, 34, 56),
+                datetime(2019, 3, 29, 12, 37, 55),
+                timedelta(minutes=0)
+            ),
+        ]:
+            with self.assertRaises(ValueError):
                 list(mi.numeric_range(*args))
 
 


### PR DESCRIPTION
The order of the loop and with statement was wrong. The test did not execute the datetime test because the loop is inside the raises-context-manager and is thus exited when the previous test failed.