### PR TITLE
Add map_accumulate

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -138,6 +138,7 @@ These tools return summarized or aggregated data from an iterable.
 .. autofunction:: exactly_n(iterable, n, predicate=bool)
 .. autoclass:: run_length
 .. autofunction:: map_reduce
+.. autofunction:: map_accumulate
 
 ----
 

--- a/more_itertools/tests/test_more.py
+++ b/more_itertools/tests/test_more.py
@@ -2277,6 +2277,30 @@ class MapReduceTests(TestCase):
         self.assertRaises(KeyError, lambda: d[None].append(1))
 
 
+class MapAccumulateTests(TestCase):
+    def test_basic(self):
+        iterable = (str(x) for x in range(5))
+        keyfunc = lambda item: int(item) // 2
+        initfunc = lambda: 0
+        updatefunc = lambda value, item: max(value, int(item))
+        actual = mi.map_accumulate(iterable, keyfunc, initfunc, updatefunc)
+        expected = {0: 1, 1: 3, 2: 4}
+        self.assertEqual(actual, expected)
+
+    def test_side_effects(self):
+        iterable = 'abbccc'
+        keyfunc = lambda item: item.upper()
+        initfunc = lambda: []
+
+        def updatefunc(value, item):
+            value.append(item)
+            return value
+
+        actual = mi.map_accumulate(iterable, keyfunc, initfunc, updatefunc)
+        expected = {'A': ['a'], 'B': ['b', 'b'], 'C': ['c', 'c', 'c']}
+        self.assertEqual(actual, expected)
+
+
 class RlocateTests(TestCase):
     def test_default_pred(self):
         iterable = [0, 1, 1, 0, 1, 0, 0]


### PR DESCRIPTION
This PR adds `map_accumulate()`, a function similar to `map_reduce()`. Instead of gathering all items into memory and then reducing them, this function applies the reduction as each item is encountered.

A simple demonstration is emulating `collections.Counter`: https://github.com/erikrose/more-itertools/blob/a23188dc0a3f0be513023bf5b529bbe01c1410b4/more_itertools/more.py#L2267-L2273

A better one is keeping track of parts of a complicated data structure:
https://github.com/erikrose/more-itertools/blob/a23188dc0a3f0be513023bf5b529bbe01c1410b4/more_itertools/more.py#L2277-L2297

[Here](https://github.com/obsrvbl/flowlogs-reader/blob/63977dc787f289f8f62582a079efc67701cd9c8b/flowlogs_reader/aggregation.py) is a real-world example of this process in action. [Here](https://stackoverflow.com/a/2937417/353839) is another.