### PR TITLE
Adds function `iterchunked` (like `chunked`, but yields iterables instead of lists)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -135,7 +135,7 @@ Several new recipes are available as well:
 
     >>> from more_itertools import chunked
     >>> iterable = [0, 1, 2, 3, 4, 5, 6, 7, 8]
-    >>> list(chunked(iterable, 3))
+    >>> list(list(chunk) for chunk in chunked(iterable, 3))
     [[0, 1, 2], [3, 4, 5], [6, 7, 8]]
 
     >>> from more_itertools import spy

--- a/README.rst
+++ b/README.rst
@@ -135,7 +135,7 @@ Several new recipes are available as well:
 
     >>> from more_itertools import chunked
     >>> iterable = [0, 1, 2, 3, 4, 5, 6, 7, 8]
-    >>> list(list(chunk) for chunk in chunked(iterable, 3))
+    >>> list(chunked(iterable, 3))
     [[0, 1, 2], [3, 4, 5], [6, 7, 8]]
 
     >>> from more_itertools import spy

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -1058,7 +1058,8 @@ def side_effect(func, iterable, chunk_size=None, before=None, after=None):
                 yield item
         else:
             for chunk in chunked(iterable, chunk_size):
-                func(list(chunk))
+                chunk = list(chunk)
+                func(chunk)
                 yield from chunk
     finally:
         if after is not None:

--- a/more_itertools/tests/test_more.py
+++ b/more_itertools/tests/test_more.py
@@ -93,7 +93,7 @@ class ChunkedTests(TestCase):
         )
 
 
-class ChunkedIterTests(TestCase):
+class IterchunkedTests(TestCase):
     """Tests for ``iterchunked()``"""
 
     def test_even(self):

--- a/more_itertools/tests/test_more.py
+++ b/more_itertools/tests/test_more.py
@@ -80,7 +80,7 @@ class ChunkedTests(TestCase):
     def test_even(self):
         """Test when ``n`` divides evenly into the length of the iterable."""
         self.assertEqual(
-            list(mi.chunked('ABCDEF', 3)), [['A', 'B', 'C'], ['D', 'E', 'F']]
+            list(list(chunk) for chunk in mi.chunked('ABCDEF', 3)), [['A', 'B', 'C'], ['D', 'E', 'F']]
         )
 
     def test_odd(self):
@@ -89,7 +89,7 @@ class ChunkedTests(TestCase):
 
         """
         self.assertEqual(
-            list(mi.chunked('ABCDE', 3)), [['A', 'B', 'C'], ['D', 'E']]
+            list(list(chunk) for chunk in mi.chunked('ABCDE', 3)), [['A', 'B', 'C'], ['D', 'E']]
         )
 
 

--- a/more_itertools/tests/test_more.py
+++ b/more_itertools/tests/test_more.py
@@ -80,7 +80,7 @@ class ChunkedTests(TestCase):
     def test_even(self):
         """Test when ``n`` divides evenly into the length of the iterable."""
         self.assertEqual(
-            list(list(chunk) for chunk in mi.chunked('ABCDEF', 3)), [['A', 'B', 'C'], ['D', 'E', 'F']]
+            list(mi.chunked('ABCDEF', 3)), [['A', 'B', 'C'], ['D', 'E', 'F']]
         )
 
     def test_odd(self):
@@ -89,7 +89,26 @@ class ChunkedTests(TestCase):
 
         """
         self.assertEqual(
-            list(list(chunk) for chunk in mi.chunked('ABCDE', 3)), [['A', 'B', 'C'], ['D', 'E']]
+            list(mi.chunked('ABCDE', 3)), [['A', 'B', 'C'], ['D', 'E']]
+        )
+
+
+class ChunkedIterTests(TestCase):
+    """Tests for ``iterchunked()``"""
+
+    def test_even(self):
+        """Test when ``n`` divides evenly into the length of the iterable."""
+        self.assertEqual(
+            list(list(chunk) for chunk in mi.iterchunked('ABCDEF', 3)), [['A', 'B', 'C'], ['D', 'E', 'F']]
+        )
+
+    def test_odd(self):
+        """Test when ``n`` does not divide evenly into the length of the
+        iterable.
+
+        """
+        self.assertEqual(
+            list(list(chunk) for chunk in mi.iterchunked('ABCDE', 3)), [['A', 'B', 'C'], ['D', 'E']]
         )
 
 


### PR DESCRIPTION
 I'm not sure if this will be of any value for other users, however when working with very large datasets I frequently want my "chunk" to be an iterator rather than a list, so I've been using this implementation for a while. It works exactly as `chunked` aside from yielding iterators instead of lists.