### PR TITLE
ichunked, now more than ever

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -14,6 +14,7 @@ These tools yield groups of items from a source iterable.
 **New itertools**
 
 .. autofunction:: chunked
+.. autofunction:: ichunked
 .. autofunction:: sliced
 .. autofunction:: distribute
 .. autofunction:: divide

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -2489,14 +2489,8 @@ def ichunked(iterable, n):
 
     """
     source = iter(iterable)
-    i = 0
 
     while True:
-        # Don't advance the iterator on the first loop, but skip past
-        # n elements on subsequent loops.
-        consume(source, i)
-        i = n
-
         # Check to see whether we're at the end of the source iterable
         item = next(source, _marker)
         if item is _marker:
@@ -2505,3 +2499,6 @@ def ichunked(iterable, n):
         # Clone the source and yield an n-length slice
         source, it = tee(chain([item], source))
         yield islice(it, n)
+
+        # Advance the source iterable
+        consume(source, n)

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -47,7 +47,7 @@ __all__ = [
     'intersperse',
     'islice_extended',
     'iterate',
-    'iterchunked',
+    'ichunked',
     'last',
     'locate',
     'lstrip',
@@ -2467,9 +2467,9 @@ def only(iterable, default=None, too_long=None):
     return value
 
 
-def iterchunked(iterable, n):
+def ichunked(iterable, n):
     """Break *iterable* into sub-iterables with *n* elements each.
-    :func:`iterchunked` is like :func:`chunked`, but it yields iterables
+    :func:`ichunked` is like :func:`chunked`, but it yields iterables
     instead of lists.
 
     If the sub-iterables are read in order, the elements of *iterable*
@@ -2478,7 +2478,7 @@ def iterchunked(iterable, n):
     elements as necessary.
 
     >>> from itertools import count
-    >>> all_chunks = iterchunked(count(), 4)
+    >>> all_chunks = ichunked(count(), 4)
     >>> c_1, c_2, c_3 = next(all_chunks), next(all_chunks), next(all_chunks)
     >>> list(c_2)  # c_1's elements have been cached; c_3's haven't been
     [4, 5, 6, 7]


### PR DESCRIPTION
Re: issue #72 - this PR was inspired by @davebelais in PR #291.

As the issue states, a few people have tried to do a chunked-that-emits-iterators.

The version from PR #58, my version called `ichunked_new` in the issue, and the version from PR #291 all exhibit strange behavior when reading the chunks out of order.

This version handles that (previous chunks' elements are cached until they are needed), as well as 0-length iterables, iterables with `None` elements, etc.

I think I'm happy with this, 3 years after having given up. @davebelais, your thoughts? Re: @pylang's comment, I don't think this needs to merged with `chunked`; and I don't think the other "Grouping" itertools (except `grouper`) are really candidates for lazy versions?