### PR TITLE
`filter_except()` and `map_except()`

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -215,6 +215,7 @@ consume iterables.
 .. autofunction:: consumer
 .. autofunction:: with_iter
 .. autofunction:: filter_except
+.. autofunction:: map_except
 
 ----
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -214,6 +214,7 @@ consume iterables.
 .. autofunction:: always_iterable
 .. autofunction:: consumer
 .. autofunction:: with_iter
+.. autofunction:: filter_except
 
 ----
 

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -55,6 +55,7 @@ __all__ = [
     'locate',
     'lstrip',
     'make_decorator',
+    'map_except',
     'map_reduce',
     'numeric_range',
     'one',
@@ -2605,3 +2606,25 @@ def filter_except(validator, iterable, *exceptions):
             pass
         else:
             yield item
+
+
+def map_except(function, iterable, *exceptions):
+    """Transform each item from *iterable* with *function* and yield the
+    result, unless *function* raises one of the specified *exceptions*.
+
+    *function* is called to transform each item in *iterable*.
+    It should be a accept one argument.
+
+    >>> iterable = ['1', '2', 'three', '4', None]
+    >>> list(map_except(int, iterable, ValueError, TypeError))
+    [1, 2, 4]
+
+    If an exception other than one given by *exceptions* is raised by
+    *function*, it is raised like normal.
+    """
+    exceptions = tuple(exceptions)
+    for item in iterable:
+        try:
+            yield function(item)
+        except exceptions:
+            pass

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -41,6 +41,7 @@ __all__ = [
     'distribute',
     'divide',
     'exactly_n',
+    'filter_except',
     'first',
     'groupby_transform',
     'ilen',
@@ -2579,3 +2580,28 @@ def distinct_combinations(iterable, r):
         for i, prefix in unique_everseen(enumerate(pool), key=itemgetter(1)):
             for suffix in distinct_combinations(pool[i + 1:], r - 1):
                 yield (prefix,) + suffix
+
+
+def filter_except(validator, iterable, *exceptions):
+    """Yield the items from *iterable* for which the *validator* function does
+    not raise one of the specified *exceptions*.
+
+    *validator* is called for each item in *iterable*.
+    It should be a function that accepts one argument and raises an exception
+    if that item is not valid.
+
+    >>> iterable = ['1', '2', 'three', '4', None]
+    >>> list(filter_except(int, iterable, ValueError, TypeError))
+    ['1', '2', '4']
+
+    If an exception other than one given by *exceptions* is raised by
+    *validator*, it is raised like normal.
+    """
+    exceptions = tuple(exceptions)
+    for item in iterable:
+        try:
+            validator(item)
+        except exceptions:
+            pass
+        else:
+            yield item

--- a/more_itertools/tests/test_more.py
+++ b/more_itertools/tests/test_more.py
@@ -2641,3 +2641,35 @@ class DistinctCombinationsTests(TestCase):
 
     def test_empty(self):
         self.assertEqual(list(mi.distinct_combinations([], 2)), [])
+
+
+class FilterExceptTests(TestCase):
+    def test_no_exceptions_pass(self):
+        iterable = '0123'
+        actual = list(mi.filter_except(int, iterable))
+        expected = ['0', '1', '2', '3']
+        self.assertEqual(actual, expected)
+
+    def test_no_exceptions_raise(self):
+        iterable = ['0', '1', 'two', '3']
+        with self.assertRaises(ValueError):
+            list(mi.filter_except(int, iterable))
+
+    def test_raise(self):
+        iterable = ['0', '1' '2', 'three', None]
+        with self.assertRaises(TypeError):
+            list(mi.filter_except(int, iterable, ValueError))
+
+    def test_false(self):
+        # Even if the validator returns false, we pass through
+        validator = lambda x: False
+        iterable = ['0', '1', '2', 'three', None]
+        actual = list(mi.filter_except(validator, iterable, Exception))
+        expected = ['0', '1', '2', 'three', None]
+        self.assertEqual(actual, expected)
+
+    def test_multiple(self):
+        iterable = ['0', '1', '2', 'three', None, '4']
+        actual = list(mi.filter_except(int, iterable, ValueError, TypeError))
+        expected = ['0', '1', '2', '4']
+        self.assertEqual(actual, expected)

--- a/more_itertools/tests/test_more.py
+++ b/more_itertools/tests/test_more.py
@@ -2673,3 +2673,27 @@ class FilterExceptTests(TestCase):
         actual = list(mi.filter_except(int, iterable, ValueError, TypeError))
         expected = ['0', '1', '2', '4']
         self.assertEqual(actual, expected)
+
+
+class MapExceptTests(TestCase):
+    def test_no_exceptions_pass(self):
+        iterable = '0123'
+        actual = list(mi.map_except(int, iterable))
+        expected = [0, 1, 2, 3]
+        self.assertEqual(actual, expected)
+
+    def test_no_exceptions_raise(self):
+        iterable = ['0', '1', 'two', '3']
+        with self.assertRaises(ValueError):
+            list(mi.map_except(int, iterable))
+
+    def test_raise(self):
+        iterable = ['0', '1' '2', 'three', None]
+        with self.assertRaises(TypeError):
+            list(mi.map_except(int, iterable, ValueError))
+
+    def test_multiple(self):
+        iterable = ['0', '1', '2', 'three', None, '4']
+        actual = list(mi.map_except(int, iterable, ValueError, TypeError))
+        expected = [0, 1, 2, 4]
+        self.assertEqual(actual, expected)


### PR DESCRIPTION
This PR adds `filter_except()` and `map_except()`.

`filter_except()` is like the built-in `filter`, but instead of skipping items that evaluate to `False`, it skips over items that raise a specific set of exceptions when validated. Here's an example using [Django validators](https://docs.djangoproject.com/en/2.2/ref/validators/), which follow this pattern:

```python
>>> from django.core.exceptions import ValidationError
... from django.core.validators import EmailValidator
... 
... from more_itertools import filter_except
... 
... 
... validator = EmailValidator()
... iterable = [
...     'good@example.com',
...     'good@localhost',
...     'bad',
...     'bad@bad_doman.com',
... ]
... list(filter_except(validator, iterable, ValidationError))
['good@example.com', 'good@localhost']
```

`map_except()` is like the built-in `map()`, but it skips over items that raise a specific set of exceptions when transformed.

```python
>>> from django.core.exceptions import ValidationError
... from django.core.validators import EmailValidator
... 
... from more_itertools import map_except
... 
... 
... def extract_domains(address, validator=EmailValidator()):
...     validator(address)  # Raises if the address is invalid
...     return address.split('@')[1]
...     
... 
... iterable = [
...     'good@example.com',
...     'good@localhost',
...     'bad',
...     'bad@bad_doman.com',
... ]
... list(map_except(extract_domains, iterable, ValidationError))
['example.com', 'localhost']
```
