### PR TITLE
New implementation of `set_partitions`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ dist: "xenial"
 language: "python"
 
 python:
-    - "3.4"
     - "3.5"
     - "3.6"
     - "3.7"

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -105,7 +105,6 @@ These tools combine multiple iterables.
 .. autofunction:: sort_together
 .. autofunction:: interleave
 .. autofunction:: interleave_longest
-.. autofunction:: collate(*iterables, key=lambda a: a, reverse=False)
 .. autofunction:: zip_offset(*iterables, offsets, longest=False, fillvalue=None)
 
 ----

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -2411,7 +2411,7 @@ def set_partitions(iterable, k=None):
             raise ValueError(
                 "Can't partition in a negative or zero number of groups")
         elif k > n:
-            return []
+            return
 
     def set_partitions_helper(L, k):
         n = len(L)

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -5,7 +5,6 @@ from collections.abc import Sequence
 from functools import partial, wraps
 from heapq import merge
 from itertools import (
-    combinations,
     chain,
     compress,
     count,
@@ -2409,7 +2408,8 @@ def set_partitions(iterable, k=None):
     n = len(L)
     if k is not None:
         if k < 1:
-            raise ValueError("Can't partition in a negative or zero number of groups")
+            raise ValueError(
+                "Can't partition in a negative or zero number of groups")
         elif k > n:
             return []
 

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -2389,8 +2389,8 @@ def set_partitions(iterable, k=None):
     >>> for part in set_partitions(iterable, 2):
     ...     print([''.join(p) for p in part])
     ['a', 'bc']
+    ['ab', 'c']
     ['b', 'ac']
-    ['c', 'ab']
 
 
     If *k* is not given, every set partition is generated.
@@ -2400,43 +2400,38 @@ def set_partitions(iterable, k=None):
     ...     print([''.join(p) for p in part])
     ['abc']
     ['a', 'bc']
+    ['ab', 'c']
     ['b', 'ac']
-    ['c', 'ab']
     ['a', 'b', 'c']
 
     """
-    iterable = tuple(iterable)
-    n = len(iterable)
+    L = list(iterable)
+    n = len(L)
+    if k is not None:
+        if k < 1:
+            raise ValueError("Can't partition in a negative or zero number of groups")
+        elif k > n:
+            return []
 
-    def less(a, b):
-        """Orders index tuples lexically"""
-        return (a < b) if (len(a) == len(b)) else (len(a) < len(b))
-
-    def part_inds(inds, k, prev):
-        """Generates set partitions by index"""
-        if (k <= 1) and (less(prev, inds)):
-            yield (inds,)
+    def set_partitions_helper(L, k):
+        n = len(L)
+        if k == 1:
+            yield [L]
+        elif n == k:
+            yield [[s] for s in L]
         else:
-            for curr_part_size in range(1, len(inds)):
-                for curr_part in combinations(inds, curr_part_size):
-                    nxt_part = tuple(i for i in inds if i not in curr_part)
-                    if less(prev, curr_part):
-                        for nxt_parts in part_inds(nxt_part, k - 1, curr_part):
-                            yield (curr_part,) + nxt_parts
-
-    def apply_selection(k):
-        """Creates partitions of iterable using index partitions"""
-        nonlocal iterable
-        nonlocal n
-
-        for ind_parts in part_inds(range(n), k, ()):
-            yield tuple(tuple(iterable[i] for i in inds) for inds in ind_parts)
+            e, *M = L
+            for p in set_partitions_helper(M, k - 1):
+                yield [[e], *p]
+            for p in set_partitions_helper(M, k):
+                for i in range(len(p)):
+                    yield p[:i] + [[e] + p[i]] + p[i + 1:]
 
     if k is None:
         for k in range(1, n + 1):
-            yield from apply_selection(k)
+            yield from set_partitions_helper(L, k)
     else:
-        yield from apply_selection(k)
+        yield from set_partitions_helper(L, k)
 
 
 def time_limited(limit_seconds, iterable):

--- a/more_itertools/tests/test_more.py
+++ b/more_itertools/tests/test_more.py
@@ -18,7 +18,7 @@ from itertools import (
     product,
     repeat,
 )
-from operator import add, mul, itemgetter, or_
+from operator import add, mul, itemgetter
 from sys import version_info
 from time import sleep
 from unittest import skipIf, TestCase
@@ -2500,23 +2500,27 @@ class _FrozenMultiset(Set):
         return hash(self._collection)
 
     def __repr__(self):
-        return "FrozenSet(["+", ".join(repr(x) for x in iter(self))+"])"
+        return "FrozenSet([{}]".format(
+               ", ".join(repr(x) for x in iter(self)))
 
 
 class SetPartitionsTests(TestCase):
     @staticmethod
     def _normalize_partition(p):
         """
-        Return a normalized, hashable, version of a partition using _FrozenMultiset
+        Return a normalized, hashable, version of a partition using
+        _FrozenMultiset
         """
         return _FrozenMultiset(_FrozenMultiset(g) for g in p)
 
     @staticmethod
     def _normalize_partitions(ps):
         """
-        Return a normalized set of all normalized partitions using _FrozenMultiset
+        Return a normalized set of all normalized partitions using
+        _FrozenMultiset
         """
-        return _FrozenMultiset(SetPartitionsTests._normalize_partition(p) for p in ps)
+        return _FrozenMultiset(
+            SetPartitionsTests._normalize_partition(p) for p in ps)
 
     def test_repeated(self):
         it = 'aaa'
@@ -2570,7 +2574,8 @@ class SetPartitionsTests(TestCase):
                          self._normalize_partitions(actual))
 
     def test_stirling_numbers(self):
-        """Check against https://en.wikipedia.org/wiki/Stirling_numbers_of_the_second_kind#Table_of_values"""
+        """Check against https://en.wikipedia.org/wiki/
+        Stirling_numbers_of_the_second_kind#Table_of_values"""
         cardinality_by_k_by_n = [
             [1],
             [1, 1],
@@ -2581,7 +2586,8 @@ class SetPartitionsTests(TestCase):
         ]
         for n, cardinality_by_k in enumerate(cardinality_by_k_by_n, 1):
             for k, cardinality in enumerate(cardinality_by_k, 1):
-                self.assertEqual(cardinality, len(list(mi.set_partitions(range(n), k))))
+                self.assertEqual(cardinality,
+                                 len(list(mi.set_partitions(range(n), k))))
 
 
 class TimeLimitedTests(TestCase):

--- a/more_itertools/tests/test_more.py
+++ b/more_itertools/tests/test_more.py
@@ -1,4 +1,5 @@
-from collections import OrderedDict
+from collections import OrderedDict, Counter
+from collections.abc import Set
 from datetime import datetime, timedelta
 from decimal import Decimal
 from doctest import DocTestSuite
@@ -2456,79 +2457,130 @@ class PartitionsTest(TestCase):
         ]
         self.assertEqual(actual, expected)
 
+class _FrozenMultiset(Set):
+    """
+    A helper class, useful to compare two lists without reference to the order
+    of elements.
+    
+    FrozenMultiset represents a hashable set that allows duplicate elements.
+    """
+    def __init__(self, iterable):
+        self._collection = frozenset(Counter(iterable).items())
+
+    def __contains__(self, y):
+        """
+        >>> (0, 1) in _FrozenMultiset([(0, 1), (2,), (0, 1)])
+        True
+        """
+        return any(y == x for x, _ in self._collection)
+
+    def __iter__(self):
+        """
+        >>> sorted(_FrozenMultiset([(0, 1), (2,), (0, 1)]))
+        [(0, 1), (0, 1), (2,)]
+        """
+        return (x for x, c in self._collection for _ in range(c))
+
+    def __len__(self):
+        """
+        >>> len(_FrozenMultiset([(0, 1), (2,), (0, 1)]))
+        3
+        """
+        return sum(c for x, c in self._collection)
+
+    def has_duplicates(self):
+        """
+        >>> _FrozenMultiset([(0, 1), (2,), (0, 1)]).has_duplicates()
+        True
+        """
+        return any(c != 1 for _, c in self._collection)
+
+    def __hash__(self):
+        return hash(self._collection)
+
+    def __repr__(self):
+        return "FrozenSet(["+", ".join(repr(x) for x in iter(self))+"])"
+
 
 class SetPartitionsTests(TestCase):
+    @staticmethod
+    def _normalize_partition(p):
+        """
+        Return a normalized, hashable, version of a partition using _FrozenMultiset
+        """
+        return _FrozenMultiset(_FrozenMultiset(g) for g in p)
+
+    @staticmethod
+    def _normalize_partitions(ps):
+        """
+        Return a normalized set of all normalized partitions using _FrozenMultiset
+        """
+        return _FrozenMultiset(SetPartitionsTests._normalize_partition(p) for p in ps)
+
     def test_repeated(self):
         it = 'aaa'
-        actual = []
-        for part in mi.set_partitions(it, 2):
-            actual.append([''.join(p) for p in part])
+        actual = mi.set_partitions(it, 2)
         expected = [['a', 'aa'], ['a', 'aa'], ['a', 'aa']]
-        self.assertEqual(actual, expected)
+        self.assertEqual(
+            self._normalize_partitions(expected),
+            self._normalize_partitions(actual)
+        )
 
     def test_each_correct(self):
-        a = frozenset(range(6))
-        for soln in mi.set_partitions(a):
-            soln = frozenset(frozenset(part) for part in soln)
-            total = reduce(or_, soln)
+        a = set(range(6))
+        for p in mi.set_partitions(a):
+            total = set(e for g in p for e in g)
             self.assertEqual(a, total)
 
     def test_duplicates(self):
-        a = list(range(6))  # unique values so set comparision will work
-        solns = list(mi.set_partitions(a))
-        unique_solns = frozenset(
-            frozenset(
-                frozenset(part) for part in soln)
-            for soln in solns)
-        self.assertEqual(len(solns), len(unique_solns))
-
-    def test_lexical_order(self):
-        def less(solnA, solnB):
-            """lexically orders solutions"""
-            if len(solnA) == len(solnB):
-                for partA, partB in zip(solnA, solnB):
-                    if len(partA) == len(partB):
-                        if partA == partB:
-                            continue
-                        else:
-                            return partA < partB
-                    else:
-                        return len(partA) < len(partB)
-            else:
-                return len(solnA) < len(solnB)
-        for curr, nxt in mi.windowed(mi.set_partitions(range(6)), 2):
-            self.assertTrue(less(curr, nxt))
+        a = set(range(6))
+        for p in mi.set_partitions(a):
+            self.assertFalse(self._normalize_partition(p).has_duplicates())
 
     def test_found_all(self):
         """small example, hand-checked"""
-        expected = [((0,), (1,), (2, 3, 4)),
-                    ((0,), (2,), (1, 3, 4)),
-                    ((0,), (3,), (1, 2, 4)),
-                    ((0,), (4,), (1, 2, 3)),
-                    ((0,), (1, 2), (3, 4)),
-                    ((0,), (1, 3), (2, 4)),
-                    ((0,), (1, 4), (2, 3)),
-                    ((1,), (2,), (0, 3, 4)),
-                    ((1,), (3,), (0, 2, 4)),
-                    ((1,), (4,), (0, 2, 3)),
-                    ((1,), (0, 2), (3, 4)),
-                    ((1,), (0, 3), (2, 4)),
-                    ((1,), (0, 4), (2, 3)),
-                    ((2,), (3,), (0, 1, 4)),
-                    ((2,), (4,), (0, 1, 3)),
-                    ((2,), (0, 1), (3, 4)),
-                    ((2,), (0, 3), (1, 4)),
-                    ((2,), (0, 4), (1, 3)),
-                    ((3,), (4,), (0, 1, 2)),
-                    ((3,), (0, 1), (2, 4)),
-                    ((3,), (0, 2), (1, 4)),
-                    ((3,), (0, 4), (1, 2)),
-                    ((4,), (0, 1), (2, 3)),
-                    ((4,), (0, 2), (1, 3)),
-                    ((4,), (0, 3), (1, 2))]
-        actual = list(mi.set_partitions(range(5), 3))
-        for e, a in zip(expected, actual):
-            self.assertEqual(e, a)
+        expected = [[[0], [1], [2, 3, 4]],
+                    [[0], [1, 2], [3, 4]],
+                    [[0], [2], [1, 3, 4]],
+                    [[0], [3], [1, 2, 4]],
+                    [[0], [4], [1, 2, 3]],
+                    [[0], [1, 3], [2, 4]],
+                    [[0], [1, 4], [2, 3]],
+                    [[1], [2], [0, 3, 4]],
+                    [[1], [3], [0, 2, 4]],
+                    [[1], [4], [0, 2, 3]],
+                    [[1], [0, 2], [3, 4]],
+                    [[1], [0, 3], [2, 4]],
+                    [[1], [0, 4], [2, 3]],
+                    [[2], [3], [0, 1, 4]],
+                    [[2], [4], [0, 1, 3]],
+                    [[2], [0, 1], [3, 4]],
+                    [[2], [0, 3], [1, 4]],
+                    [[2], [0, 4], [1, 3]],
+                    [[3], [4], [0, 1, 2]],
+                    [[3], [0, 1], [2, 4]],
+                    [[3], [0, 2], [1, 4]],
+                    [[3], [0, 4], [1, 2]],
+                    [[4], [0, 1], [2, 3]],
+                    [[4], [0, 2], [1, 3]],
+                    [[4], [0, 3], [1, 2]]]
+        actual = mi.set_partitions(range(5), 3)
+        self.assertEqual(self._normalize_partitions(expected),
+                         self._normalize_partitions(actual))
+
+    def test_stirling_numbers(self):
+        """Check against https://en.wikipedia.org/wiki/Stirling_numbers_of_the_second_kind#Table_of_values"""
+        cardinality_by_k_by_n = [
+            [1],
+            [1, 1],
+            [1, 3, 1],
+            [1, 7, 6, 1],
+            [1, 15, 25, 10, 1],
+            [1, 31, 90, 65, 15, 1]
+        ]
+        for n, cardinality_by_k in enumerate(cardinality_by_k_by_n, 1):
+            for k, cardinality in enumerate(cardinality_by_k, 1):
+                self.assertEqual(cardinality, len(list(mi.set_partitions(range(n), k))))
 
 
 class TimeLimitedTests(TestCase):

--- a/more_itertools/tests/test_more.py
+++ b/more_itertools/tests/test_more.py
@@ -2457,11 +2457,12 @@ class PartitionsTest(TestCase):
         ]
         self.assertEqual(actual, expected)
 
+
 class _FrozenMultiset(Set):
     """
     A helper class, useful to compare two lists without reference to the order
     of elements.
-    
+
     FrozenMultiset represents a hashable set that allows duplicate elements.
     """
     def __init__(self, iterable):

--- a/more_itertools/tests/test_more.py
+++ b/more_itertools/tests/test_more.py
@@ -2589,6 +2589,15 @@ class SetPartitionsTests(TestCase):
                 self.assertEqual(cardinality,
                                  len(list(mi.set_partitions(range(n), k))))
 
+    def test_no_group(self):
+        def helper():
+            list(mi.set_partitions(range(4), -1))
+
+        self.assertRaises(ValueError, helper)
+
+    def test_to_many_groups(self):
+        self.assertEquals([], list(mi.set_partitions(range(4), 5)))
+
 
 class TimeLimitedTests(TestCase):
     def test_basic(self):

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
     author_email='erikrose@grinchcentral.com',
     license='MIT',
     packages=find_packages(exclude=['ez_setup']),
-    python_requires='>=3.4',
+    python_requires='>=3.5',
     test_suite='more_itertools.tests',
     url='https://github.com/erikrose/more-itertools',
     include_package_data=True,

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py34, py35, py36, py37
+envlist = py35, py36, py37
 
 [testenv]
 commands = {envbindir}/python -m unittest discover -v


### PR DESCRIPTION
See https://github.com/erikrose/more-itertools/issues/300 for discussion.

Remark: the `FrozenMultiset` class could be used to make some other tests more robust. Typical use case: the theoretical output is a collections of elements 1. with possible duplicates and 2. order doesn't matter. Obviously, an implementation has to choose one of the possible orders, but the tests should be able to ignore this order.

Example: `powerset`.