### PR TITLE
Deprecate collate

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -105,7 +105,6 @@ These tools combine multiple iterables.
 .. autofunction:: sort_together
 .. autofunction:: interleave
 .. autofunction:: interleave_longest
-.. autofunction:: collate(*iterables, key=lambda a: a, reverse=False)
 .. autofunction:: zip_offset(*iterables, offsets, longest=False, fillvalue=None)
 
 ----

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -374,7 +374,7 @@ def collate(*iterables, **kwargs):
         "collate is no longer part of more_itertools, use heapq.merge",
         DeprecationWarning,
     )
-    return merge(*iterables)
+    return merge(*iterables, **kwargs)
 
 
 def consumer(func):

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -1,3 +1,5 @@
+import warnings
+
 from collections import Counter, defaultdict, deque
 from collections.abc import Sequence
 from functools import partial, wraps
@@ -18,7 +20,7 @@ from itertools import (
     zip_longest,
 )
 from operator import itemgetter, lt, gt, sub
-from sys import maxsize, version_info
+from sys import maxsize
 from time import monotonic
 
 from .recipes import consume, flatten, powerset, take, unique_everseen
@@ -337,20 +339,6 @@ class peekable:
         return self._cache[index]
 
 
-def _collate(*iterables, key=lambda a: a, reverse=False):
-    """Helper for ``collate()``, called when the user is using the ``reverse``
-    or ``key`` keyword arguments on Python versions below 3.5.
-
-    """
-    min_or_max = partial(max if reverse else min, key=itemgetter(0))
-    peekables = [peekable(it) for it in iterables]
-    peekables = [p for p in peekables if p]  # Kill empties.
-    while peekables:
-        _, p = min_or_max((key(p.peek()), p) for p in peekables)
-        yield next(p)
-        peekables = [x for x in peekables if x]
-
-
 def collate(*iterables, **kwargs):
     """Return a sorted merge of the items from each of several already-sorted
     *iterables*.
@@ -382,18 +370,11 @@ def collate(*iterables, **kwargs):
     On Python 3.5+, this function is an alias for :func:`heapq.merge`.
 
     """
-    if not kwargs:
-        return merge(*iterables)
-
-    return _collate(*iterables, **kwargs)
-
-
-# If using Python version 3.5 or greater, heapq.merge() will be faster than
-# collate - use that instead.
-if version_info >= (3, 5, 0):
-    _collate_docstring = collate.__doc__
-    collate = partial(merge)
-    collate.__doc__ = _collate_docstring
+    warnings.warn(
+        "collate is no longer part of more_itertools, use heapq.merge",
+        DeprecationWarning,
+    )
+    return merge(*iterables)
 
 
 def consumer(func):


### PR DESCRIPTION
This PR removes `collate()` from the API reference. It will be removed from the library in a future version - Python 3.5's `heapq.merge()` does the same task. In the meantime it raises a `DeprecationWarning`.