### PR TITLE
Update take() docstring

### DIFF
--- a/more_itertools/recipes.py
+++ b/more_itertools/recipes.py
@@ -61,11 +61,12 @@ def take(n, iterable):
 
         >>> take(3, range(10))
         [0, 1, 2]
-        >>> take(5, range(3))
-        [0, 1, 2]
 
-    Effectively a short replacement for ``next`` based iterator consumption
-    when you want more than one item, but less than the whole iterator.
+    If there are fewer than *n* items in the iterable, all of them are
+    returned.
+
+        >>> take(10, range(3))
+        [0, 1, 2]
 
     """
     return list(islice(iterable, n))


### PR DESCRIPTION
Re: https://github.com/erikrose/more-itertools/issues/314, this PR updates the `take()` docstring to highlight the "fewer than n items in the iterable" example.