### PR TITLE
Tidy up Travis configuration file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-dist: "xenial"
 language: "python"
 
 python:
@@ -6,7 +5,7 @@ python:
     - "3.6"
     - "3.7"
     - "3.8"
-    - "pypy3.5"
+    - "pypy3"
 
 install:
     - "pip install ."


### PR DESCRIPTION
Remove 'dist: "xenial"'. It is now the default and unnecesary.

Change to use pypy3 alias for testing against the latest PyPy3 release.