### PR TITLE
Cleanup and improve tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -2,4 +2,4 @@
 envlist = py{35,36,37,38}
 
 [testenv]
-commands = {envbindir}/python -m unittest discover -v
+commands = {envpython} -m unittest -v {posargs}


### PR DESCRIPTION
Replace '{envbindir}/python' with '{envpython}'
See: https://tox.readthedocs.io/en/latest/config.html#substitutions-for-virtualenv-related-sections

---

Drop "discover" argument. It is now the default for unittest.

https://docs.python.org/3/library/unittest.html#command-line-interface

> When executed without arguments Test Discovery is started:

---

Add the '{posargs}' placeholder to allow passing arguments to unittest
from the tox command line.

https://tox.readthedocs.io/en/latest/config.html#substitutions-for-positional-arguments-in-commands