### PR TITLE
Improve difference

### DIFF
--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -1966,7 +1966,7 @@ def consecutive_groups(iterable, ordering=lambda x: x):
         yield map(itemgetter(1), g)
 
 
-def difference(iterable, func=sub, *, initial=None):
+def difference(iterable, func=sub, *, initial=_marker):
     """By default, compute the first difference of *iterable* using
     :func:`operator.sub`.
 
@@ -2011,10 +2011,10 @@ def difference(iterable, func=sub, *, initial=None):
     except StopIteration:
         return iter([])
 
-    if initial is not None:
+    if initial is not _marker:
         first = []
 
-    return chain(first, map(lambda x: func(x[1], x[0]), zip(a, b)))
+    return chain(first, starmap(func, zip(b,a)))
 
 
 class SequenceView(Sequence):
@@ -2415,7 +2415,9 @@ def replace(iterable, pred, substitutes, count=None, window_size=1):
 
     # Add padding such that the number of windows matches the length of the
     # iterable
-    it = chain(iterable, [_marker] * (window_size - 1))
+    it = chain(iterable, [
+    
+] * (window_size - 1))
     windows = windowed(it, window_size)
 
     n = 0

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -2415,9 +2415,7 @@ def replace(iterable, pred, substitutes, count=None, window_size=1):
 
     # Add padding such that the number of windows matches the length of the
     # iterable
-    it = chain(iterable, [
-    
-] * (window_size - 1))
+    it = chain(iterable, [_marker] * (window_size - 1))
     windows = windowed(it, window_size)
 
     n = 0

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -2014,7 +2014,7 @@ def difference(iterable, func=sub, *, initial=None):
     if initial is not None:
         first = []
 
-    return chain(first, starmap(func, zip(b,a)))
+    return chain(first, starmap(func, zip(b, a)))
 
 
 class SequenceView(Sequence):

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -1966,7 +1966,7 @@ def consecutive_groups(iterable, ordering=lambda x: x):
         yield map(itemgetter(1), g)
 
 
-def difference(iterable, func=sub, *, initial=_marker):
+def difference(iterable, func=sub, *, initial=None):
     """By default, compute the first difference of *iterable* using
     :func:`operator.sub`.
 
@@ -2011,7 +2011,7 @@ def difference(iterable, func=sub, *, initial=_marker):
     except StopIteration:
         return iter([])
 
-    if initial is not _marker:
+    if initial is not None:
         first = []
 
     return chain(first, starmap(func, zip(b,a)))


### PR DESCRIPTION
Initial issue: https://github.com/erikrose/more-itertools/issues/342

Changed use of `lambda` to `starmap`&`zip` for performance. (also improves code readability)

Changed `initial` parameter to `_marker` as not to limit `None` as initial value.