### PR TITLE
Update the signature for difference

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -235,7 +235,7 @@ Others
 .. autofunction:: always_reversible
 .. autofunction:: side_effect
 .. autofunction:: iterate
-.. autofunction:: difference(iterable, func=operator.sub)
+.. autofunction:: difference(iterable, func=operator.sub, *, initial=None)
 .. autofunction:: make_decorator
 .. autoclass:: SequenceView
 .. autofunction:: time_limited


### PR DESCRIPTION
In https://github.com/erikrose/more-itertools/pull/290, I neglected to update the function signature for `difference` in the docs. This PR adds the `initial` keyword.