### PR TITLE
Faster divide

### DIFF
--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -1445,9 +1445,10 @@ def divide(n, iterable):
     q, r = divmod(len(seq), n)
 
     ret = []
-    for i in range(n):
-        start = (i * q) + (i if i < r else r)
-        stop = ((i + 1) * q) + (i + 1 if i + 1 < r else r)
+    stop = 0
+    for i in range(1, n + 1):
+        start = stop
+        stop = (i * q) + (i if i < r else r)
         ret.append(iter(seq[start:stop]))
 
     return ret

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -1441,14 +1441,20 @@ def divide(n, iterable):
     if n < 1:
         raise ValueError('n must be at least 1')
 
-    seq = tuple(iterable)
+    try:
+        iterable[:0]
+    except TypeError:
+        seq = tuple(iterable)
+    else:
+        seq = iterable
+
     q, r = divmod(len(seq), n)
 
     ret = []
     stop = 0
     for i in range(1, n + 1):
         start = stop
-        stop = (i * q) + (i if i < r else r)
+        stop += q + 1 if i <= r else q
         ret.append(iter(seq[start:stop]))
 
     return ret


### PR DESCRIPTION
This PR is meant to increase speed of the `divide` function. I feel that the code is clearer too, because the step is explicit.

My tests are (`divide2` is my implementation, `divide` is the original implementation):

* Check if the proposed implementation has the same behavior as the existing implementation:
```
for i in range(100):
    for j in range(1,150):
        L = list(range(i))
        assert [list(c) for c in divide(j, L)] == [list(c) for c in divide2(j, L)]
```

* Benchmark:
```
import timeit

# small list (the gain comes from the start/stop computation)
print(timeit.timeit(lambda: divide(3, [1, 2, 3, 4, 5, 6, 7])))
# 1.2612955110016628
print(timeit.timeit(lambda: divide2(3, [1, 2, 3, 4, 5, 6, 7])))
# 1.0805485130003945

# medium list
L = list(range(1000))
print(timeit.timeit(lambda: divide(9, L)))
# 7.553474797998206
print(timeit.timeit(lambda: divide2(9, L)))
# 4.713630324997212

# range (sliceable but long to copy)
print(timeit.timeit(lambda: divide(9, range(1000))))
# 15.157971905999148
print(timeit.timeit(lambda: divide2(9, range(1000))))
# 3.915666782999324

# medium non sliceable object (no difference!)
print(timeit.timeit(lambda: divide(9, enumerate(L))))
# 34.57155330800015
print(timeit.timeit(lambda: divide2(9, enumerate(L))))
# 34.57311550000304

# a lot of start/stop computations
print(timeit.timeit(lambda: divide(999, enumerate([1, 2, 3, 4, 5, 6, 7])), number=10000))
# 2.583204354999907
print(timeit.timeit(lambda: divide2(999, enumerate([1, 2, 3, 4, 5, 6, 7])), number=10000))
# 1.6604377519979607
```