### PR TITLE
Make numeric_range an iterable

### DIFF
--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -1687,6 +1687,12 @@ class numeric_range:
             raise ValueError('numeric_range() arg 3 must not be zero')
         self._growing = self._step > self._zero
 
+    def __bool__(self):
+        if self._growing:
+            return self._start < self._stop
+        else:
+            return self._start > self._stop
+
     def __contains__(self, elem):
         if self._growing:
             if self._start <= elem < self._stop:
@@ -1717,16 +1723,10 @@ class numeric_range:
                 "numeric range indices must be integers or slices, not str")
 
     def __hash__(self):
-        if self._growing:
-            if self._start >= self._stop:
-                return self._EMPTY_HASH
-            else:
-                return hash((self._start, self._get_by_index(-1), self._step))
+        if self:
+            return hash((self._start, self._get_by_index(-1), self._step))
         else:
-            if self._start <= self._stop:
-                return self._EMPTY_HASH
-            else:
-                return hash((self._start, self._get_by_index(-1), self._step))
+            return self._EMPTY_HASH
 
     def __iter__(self):
         elem = self._start + self._zero
@@ -1774,7 +1774,7 @@ class numeric_range:
                                   self._start - self._step, -self._step))
 
     def count(self, value):
-        return int(self.__contains__(value))
+        return int(value in self)
 
     def index(self, value):
         if self._growing:

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -1,6 +1,4 @@
 import warnings
-from collections import Counter, defaultdict, deque
-
 from collections import Counter, defaultdict, deque, abc
 from collections.abc import Sequence
 from functools import partial, wraps
@@ -20,9 +18,7 @@ from itertools import (
     zip_longest,
 )
 from math import exp, floor, log
-from operator import gt, itemgetter, lt, sub
 from random import random, randrange, uniform
-from operator import itemgetter, sub
 from operator import itemgetter, sub, gt, lt
 from sys import maxsize
 from time import monotonic

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -1770,7 +1770,7 @@ class numeric_range(abc.Sequence, abc.Hashable):
         distance = stop - start
         if distance <= self._zero:
             self._len = 0
-        else: # distance > 0 and step > 0: regular euclidean division
+        else:  # distance > 0 and step > 0: regular euclidean division
             q, r = divmod(distance, step)
             self._len = int(q) + int(r != self._zero)
 

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -1655,7 +1655,7 @@ class numeric_range:
         >>> start = datetime.datetime(2019, 1, 1)
         >>> stop = datetime.datetime(2019, 1, 3)
         >>> step = datetime.timedelta(days=1)
-        >>> items = numeric_range(start, stop, step)
+        >>> items = iter(numeric_range(start, stop, step))
         >>> next(items)
         datetime.datetime(2019, 1, 1, 0, 0)
         >>> next(items)

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -1662,6 +1662,8 @@ class numeric_range:
         datetime.datetime(2019, 1, 2, 0, 0)
 
     """
+    _EMPTY_HASH = hash(range(0, 0))
+
     def __init__(self, *args):
         argc = len(args)
         if argc == 1:
@@ -1715,7 +1717,16 @@ class numeric_range:
                 "numeric range indices must be integers or slices, not str")
 
     def __hash__(self):
-        return hash((self._start, self._stop, self._step))
+        if self._growing:
+            if self._start >= self._stop:
+                return self._EMPTY_HASH
+            else:
+                return hash((self._start, self._get_by_index(-1), self._step))
+        else:
+            if self._start <= self._stop:
+                return self._EMPTY_HASH
+            else:
+                return hash((self._start, self._get_by_index(-1), self._step))
 
     def __iter__(self):
         elem = self._start + self._zero

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -1678,12 +1678,12 @@ class numeric_range(abc.Sequence, abc.Hashable):
             self._step = 1
         elif argc == 3:
             self._start, self._stop, self._step = args
+        elif argc == 0:
+            raise TypeError('numeric_range expected at least '
+                            '1 argument, got {}'.format(argc))
         else:
-            if argc == 0:
-                err_msg = 'numeric_range expected at least 1 argument, got {}'
-            else:
-                err_msg = 'numeric_range expected at most 3 arguments, got {}'
-            raise TypeError(err_msg.format(argc))
+            raise TypeError('numeric_range expected at most '
+                            '3 arguments, got {}'.format(argc))
 
         self._zero = type(self._step)(0)
         if self._step == self._zero:
@@ -1753,7 +1753,7 @@ class numeric_range(abc.Sequence, abc.Hashable):
         if distance <= 0:
             return 0
 
-        assert distance > 0 and step > 0
+        # distance > 0 and step > 0: regular euclidean division
         q, r = divmod(distance, step)
         return int(q) + int(r != self._zero)
 

--- a/tests/test_more.py
+++ b/tests/test_more.py
@@ -2202,11 +2202,10 @@ class NumericRangeTests(TestCase):
             ((datetime(2019, 3, 29), datetime(2019, 3, 30),
               timedelta(hours=10)), 3)
         ]:
-            print(args)
             self.assertEqual(expected, len(mi.numeric_range(*args)))
 
     def test_repr(self):
-        for args, expected in [
+        for args, *expected in [
             ((7.0,), "numeric_range(0.0, 7.0)"),
             ((1.0, 7.0), "numeric_range(1.0, 7.0)"),
             ((7.0, 1.0, -1.5), "numeric_range(7.0, 1.0, -1.5)"),
@@ -2218,9 +2217,12 @@ class NumericRangeTests(TestCase):
               timedelta(hours=10)),
              "numeric_range(datetime.datetime(2019, 3, 29, 0, 0), "
              "datetime.datetime(2019, 3, 30, 0, 0), "
-             "datetime.timedelta(seconds=36000))")
+             "datetime.timedelta(seconds=36000))",
+             "numeric_range(datetime.datetime(2019, 3, 29, 0, 0), "
+             "datetime.datetime(2019, 3, 30, 0, 0), "
+             "datetime.timedelta(0, 36000))")
         ]:
-            self.assertEqual(expected, repr(mi.numeric_range(*args)))
+            self.assertIn(repr(mi.numeric_range(*args)), expected)
 
     def test_reversed(self):
         for args, expected in [

--- a/tests/test_more.py
+++ b/tests/test_more.py
@@ -2155,7 +2155,7 @@ class NumericRangeTests(TestCase):
               timedelta(hours=10)),
              slice(1, -1, None),
              (datetime(2019, 3, 29, 10), datetime(2019, 3, 29, 20),
-               timedelta(hours=10)))
+              timedelta(hours=10)))
         ]:
             self.assertEqual(mi.numeric_range(*expected_args),
                              mi.numeric_range(*args)[sl])

--- a/tests/test_more.py
+++ b/tests/test_more.py
@@ -2001,6 +2001,19 @@ class NumericRangeTests(TestCase):
             with self.assertRaises(ValueError):
                 list(mi.numeric_range(*args))
 
+    def test_bool(self):
+        for args, expected in [
+            ((1.0, 3.0, 1.5), True),
+            ((1.0, 2.0, 1.5), True),
+            ((1.0, 1.0, 1.5), False),
+            ((1.0, 0.0, 1.5), False),
+            ((3.0, 1.0, -1.5), True),
+            ((2.0, 1.0, -1.5), True),
+            ((1.0, 1.0, -1.5), False),
+            ((0.0, 1.0, -1.5), False),
+        ]:
+            self.assertEqual(expected, bool(mi.numeric_range(*args)))
+
     def test_contains(self):
         r1 = mi.numeric_range(1.0, 9.9, 1.5)
         r2 = mi.numeric_range(8.5, 0.0, -1.5)

--- a/tests/test_more.py
+++ b/tests/test_more.py
@@ -2058,7 +2058,12 @@ class NumericRangeTests(TestCase):
 
     def test_hash(self):
         for args, expected in [
-            ((1.0, 6.0, 1.5), -7847785522693970979),
+            ((1.0, 6.0, 1.5), hash((1.0, 5.5, 1.5))),
+            ((1.0, 7.0, 1.5), hash((1.0, 5.5, 1.5))),
+            ((1.0, 7.5, 1.5), hash((1.0, 7.0, 1.5))),
+            ((1.0, 1.5, 1.5), hash((1.0, 1.0, 1.5))),
+            ((1.5, 1.0, 1.5), hash(range(0, 0))),
+            ((1.5, 1.5, 1.5), hash(range(0, 0))),
         ]:
             self.assertEqual(expected, hash(mi.numeric_range(*args)))
 

--- a/tests/test_more.py
+++ b/tests/test_more.py
@@ -1,4 +1,4 @@
-from collections import OrderedDict, Counter
+from collections import OrderedDict, Counter, abc
 from collections.abc import Set
 from datetime import datetime, timedelta
 from decimal import Decimal
@@ -1984,10 +1984,12 @@ class NumericRangeTests(TestCase):
             )
 
     def test_arg_count(self):
-        self.assertRaises(TypeError, lambda: list(mi.numeric_range()))
-        self.assertRaises(
-            TypeError, lambda: list(mi.numeric_range(0, 1, 2, 3))
-        )
+        for args, message in [
+            ((), 'numeric_range expected at least 1 argument, got 0'),
+            ((0, 1, 2, 3), 'numeric_range expected at most 3 arguments, got 4')
+        ]:
+            with self.assertRaisesRegex(TypeError, message):
+                mi.numeric_range(*args)
 
     def test_zero_step(self):
         for args in [
@@ -2130,6 +2132,23 @@ class NumericRangeTests(TestCase):
         for v in (0.5, 7.0, 10.0):
             with self.assertRaises(ValueError):
                 r.index(v)
+
+    def test_parent_classes(self):
+        r = mi.numeric_range(7.0)
+        self.assertTrue(isinstance(r, abc.Iterable))
+        self.assertFalse(isinstance(r, abc.Iterator))
+        self.assertTrue(isinstance(r, abc.Sequence))
+        self.assertTrue(isinstance(r, abc.Hashable))
+
+    def test_bad_key(self):
+        r = mi.numeric_range(7.0)
+        for arg, message in [
+            ('a', 'numeric range indices must be integers or slices, not str'),
+            ((),
+             'numeric range indices must be integers or slices, not tuple'),
+        ]:
+            with self.assertRaisesRegex(TypeError, message):
+                r[arg]
 
 
 class CountCycleTests(TestCase):


### PR DESCRIPTION
The `numeric_range` function is meant to be

> An extension of the built-in ``range()`` function whose arguments can be any orderable numeric type.

But `range(...)` is an iterable, while `numeric_range(...)` is an iterator:

    >>> r = range(5)
    >>> list(r) + list(r)
    [0, 1, 2, 3, 4, 0, 1, 2, 3, 4]
    >>> from more_itertools import numeric_range
    >>> nr = numeric_range(5)
    >>> list(nr) + list(nr) # nr was exhausted
    [0, 1, 2, 3, 4]

I think that `numeric_range` should be an iterable. (Note that this semantic difference has some effects: `range` has an efficient implementation of `len`, `reversed`, `r[...]`, but those are features of an iterable, not an iterator. Hence we can't add these features to `numeric_range`.)

 This PR is a basic implementation. Main drawback: we need division and modulo. I don't know if there are numeric entities in Python that can't be divided (and would need a fallback).