### PR TITLE
Make pred=None work in partition again

### DIFF
--- a/more_itertools/recipes.py
+++ b/more_itertools/recipes.py
@@ -313,8 +313,17 @@ def partition(pred, iterable):
         >>> list(even_items), list(odd_items)
         ([0, 2, 4, 6, 8], [1, 3, 5, 7, 9])
 
+    If *pred* is None, :func:`bool` is used.
+
+        >>> iterable = [0, 1, False, True, '', ' ']
+        >>> false_items, true_items = partition(None, iterable)
+        >>> list(false_items), list(true_items)
+        ([0, False, ''], [1, True, ' '])
+
     """
-    # partition(is_odd, range(10)) --> 0 2 4 6 8   and  1 3 5 7 9
+    if pred is None:
+        pred = bool
+
     evaluations = ((pred(x), x) for x in iterable)
     t1, t2 = tee(evaluations)
     return (

--- a/tests/test_recipes.py
+++ b/tests/test_recipes.py
@@ -319,16 +319,19 @@ class PartitionTests(TestCase):
     """Tests for ``partition()``"""
 
     def test_bool(self):
-        """Test when pred() returns a boolean"""
         lesser, greater = mi.partition(lambda x: x > 5, range(10))
         self.assertEqual(list(lesser), [0, 1, 2, 3, 4, 5])
         self.assertEqual(list(greater), [6, 7, 8, 9])
 
     def test_arbitrary(self):
-        """Test when pred() returns an integer"""
         divisibles, remainders = mi.partition(lambda x: x % 3, range(10))
         self.assertEqual(list(divisibles), [0, 3, 6, 9])
         self.assertEqual(list(remainders), [1, 2, 4, 5, 7, 8])
+
+    def test_pred_is_none(self):
+        falses, trues = mi.partition(None, range(3))
+        self.assertEqual(list(falses), [0])
+        self.assertEqual(list(trues), [1, 2])
 
 
 class PowersetTests(TestCase):


### PR DESCRIPTION
Re: https://github.com/erikrose/more-itertools/issues/366, this PR restores the previous `pred=None` behavior for `partition`.