### PR TITLE
Expand sliced to allow sliceable objects that don't use `bool` for emptiness

### DIFF
--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -1051,7 +1051,7 @@ def sliced(seq, n):
     For non-sliceable iterables, see :func:`chunked`.
 
     """
-    return takewhile(bool, (seq[i : i + n] for i in count(0, n)))
+    return takewhile(len, (seq[i : i + n] for i in count(0, n)))
 
 
 def split_at(iterable, pred):

--- a/tests/test_more.py
+++ b/tests/test_more.py
@@ -25,6 +25,8 @@ from sys import version_info
 from time import sleep
 from unittest import skipIf, TestCase
 
+import numpy as np
+
 import more_itertools as mi
 
 
@@ -1058,6 +1060,13 @@ class SlicedTests(TestCase):
 
         with self.assertRaises(TypeError):
             list(mi.sliced(seq, 3))
+
+    def test_numpy_array(self):
+        """Test that it works on numpy arrays"""
+        seq = np.arange(10)
+        result = list(mi.sliced(seq, 5))
+        assert np.allclose(result[0], np.arange(5))
+        assert np.allclose(result[1], np.arange(5, 10))
 
 
 class SplitAtTests(TestCase):


### PR DESCRIPTION
I was surprised when I tried to use `sliced` with a numpy array, and it failed.  The issue turned out to be that `sliced` calls `bool` on each slice to check if it's empty or not, so it knows when to stop.  By changing it to call `len` instead, we can use `sliced` with numpy arrays and other objects that don't use `bool` to indicate emptiness.

I've also added a test for `sliced` that uses a numpy array.  However this does add a dependency on numpy for our tests, so maybe we shouldn't keep this new test.