### PR TITLE
Fix type annotation for sample

### DIFF
--- a/more_itertools/more.pyi
+++ b/more_itertools/more.pyi
@@ -365,5 +365,5 @@ def map_except(
 def sample(
     iterable: Iterable[_T],
     k: int,
-    weights: Iterable[_T],
+    weights: Optional[Iterable[_T]],
 ) -> List[_T]: ...


### PR DESCRIPTION
This got called out when using `mypy tests` (with #375).