### PR TITLE
Maxsplit parameter for "split_" functions

### DIFF
--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -1081,10 +1081,18 @@ def split_at(iterable, pred, maxsplit=-1):
         >>> list(split_at(range(10), lambda n: n % 2 == 1, maxsplit=2))
         [[0], [2], [4, 5, 6, 7, 8, 9]]
     """
+    if maxsplit == 0:
+        yield list(iterable)
+        return
+
     buf = []
-    for item in iterable:
-        if pred(item) and maxsplit != 0:
+    it = iter(iterable)
+    for item in it:
+        if pred(item):
             yield buf
+            if maxsplit == 1:
+                yield list(it)
+                return
             buf = []
             maxsplit -= 1
         else:
@@ -1108,10 +1116,18 @@ def split_before(iterable, pred, maxsplit=-1):
         >>> list(split_before(range(10), lambda n: n % 3 == 0, maxsplit=2))
         [[0, 1, 2], [3, 4, 5], [6, 7, 8, 9]]
     """
+    if maxsplit == 0:
+        yield list(iterable)
+        return
+
     buf = []
-    for item in iterable:
-        if pred(item) and maxsplit != 0 and buf:
+    it = iter(iterable)
+    for item in it:
+        if pred(item) and buf:
             yield buf
+            if maxsplit == 1:
+                yield [item] + list(it)
+                return
             buf = []
             maxsplit -= 1
         buf.append(item)
@@ -1135,11 +1151,19 @@ def split_after(iterable, pred, maxsplit=-1):
         [[0], [1, 2, 3], [4, 5, 6, 7, 8, 9]]
 
     """
+    if maxsplit == 0:
+        yield list(iterable)
+        return
+
     buf = []
-    for item in iterable:
+    it = iter(iterable)
+    for item in it:
         buf.append(item)
-        if pred(item) and maxsplit != 0 and buf:
+        if pred(item) and buf:
             yield buf
+            if maxsplit == 1:
+                yield list(it)
+                return
             buf = []
             maxsplit -= 1
     if buf:
@@ -1165,6 +1189,10 @@ def split_when(iterable, pred, maxsplit=-1):
         [[1, 2, 3, 3], [2, 5], [2, 4, 2]]
 
     """
+    if maxsplit == 0:
+        yield list(iterable)
+        return
+
     it = iter(iterable)
     try:
         cur_item = next(it)
@@ -1173,8 +1201,11 @@ def split_when(iterable, pred, maxsplit=-1):
 
     buf = [cur_item]
     for next_item in it:
-        if pred(cur_item, next_item) and maxsplit != 0:
+        if pred(cur_item, next_item):
             yield buf
+            if maxsplit == 1:
+                yield [next_item] + list(it)
+                return
             buf = []
             maxsplit -= 1
 

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -1091,9 +1091,11 @@ def split_at(iterable, pred, maxsplit=-1):
     yield buf
 
 
-def split_before(iterable, pred):
+def split_before(iterable, pred, maxsplit=-1):
     """Yield lists of items from *iterable*, where each list ends just before
-    an item for which callable *pred* returns ``True``:
+    an item for which callable *pred* returns ``True``.
+    If *maxsplit* is given, at most *maxsplit* splits are done. If *maxsplit*
+    is not specified or -1, then there is no limit on the number of splits:
 
         >>> list(split_before('OneTwo', lambda s: s.isupper()))
         [['O', 'n', 'e'], ['T', 'w', 'o']]
@@ -1104,16 +1106,19 @@ def split_before(iterable, pred):
     """
     buf = []
     for item in iterable:
-        if pred(item) and buf:
+        if pred(item) and maxsplit != 0 and buf:
             yield buf
             buf = []
+            maxsplit -= 1
         buf.append(item)
     yield buf
 
 
-def split_after(iterable, pred):
+def split_after(iterable, pred, maxsplit=-1):
     """Yield lists of items from *iterable*, where each list ends with an
-    item where callable *pred* returns ``True``:
+    item where callable *pred* returns ``True``.
+    if *maxsplit* is given, at most *maxsplit* splits are done. If *maxsplit*
+    is not specified or -1, then there is no limit on the number of splits:
 
         >>> list(split_after('one1two2', lambda s: s.isdigit()))
         [['o', 'n', 'e', '1'], ['t', 'w', 'o', '2']]
@@ -1125,9 +1130,10 @@ def split_after(iterable, pred):
     buf = []
     for item in iterable:
         buf.append(item)
-        if pred(item) and buf:
+        if pred(item) and maxsplit != 0 and buf:
             yield buf
             buf = []
+            maxsplit -= 1
     if buf:
         yield buf
 

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -1066,16 +1066,17 @@ def sliced(seq, n):
 
 def split_at(iterable, pred, maxsplit=-1):
     """Yield lists of items from *iterable*, where each list is delimited by
-    an item where callable *pred* returns ``True``. As ``str.split``,
-    if *maxsplit* is given, at most *maxsplit* splits are done. If *maxsplit*
-    is not specified or -1, then there is no limit on the number of splits.
-    The lists do not include the delimiting items.
+    an item where callable *pred* returns ``True``.
+    The lists do not include the delimiting items:
 
         >>> list(split_at('abcdcba', lambda x: x == 'b'))
         [['a'], ['c', 'd', 'c'], ['a']]
 
         >>> list(split_at(range(10), lambda n: n % 2 == 1))
         [[0], [2], [4], [6], [8], []]
+
+    At most *maxsplit* splits are done. If *maxsplit* is not specified or -1,
+    then there is no limit on the number of splits:
 
         >>> list(split_at(range(10), lambda n: n % 2 == 1, maxsplit=2))
         [[0], [2], [4, 5, 6, 7, 8, 9]]
@@ -1093,9 +1094,7 @@ def split_at(iterable, pred, maxsplit=-1):
 
 def split_before(iterable, pred, maxsplit=-1):
     """Yield lists of items from *iterable*, where each list ends just before
-    an item for which callable *pred* returns ``True``.
-    If *maxsplit* is given, at most *maxsplit* splits are done. If *maxsplit*
-    is not specified or -1, then there is no limit on the number of splits:
+    an item for which callable *pred* returns ``True``:
 
         >>> list(split_before('OneTwo', lambda s: s.isupper()))
         [['O', 'n', 'e'], ['T', 'w', 'o']]
@@ -1103,6 +1102,11 @@ def split_before(iterable, pred, maxsplit=-1):
         >>> list(split_before(range(10), lambda n: n % 3 == 0))
         [[0, 1, 2], [3, 4, 5], [6, 7, 8], [9]]
 
+    At most *maxsplit* splits are done. If *maxsplit* is not specified or -1,
+    then there is no limit on the number of splits:
+
+        >>> list(split_before(range(10), lambda n: n % 3 == 0, maxsplit=2))
+        [[0, 1, 2], [3, 4, 5], [6, 7, 8, 9]]
     """
     buf = []
     for item in iterable:
@@ -1116,15 +1120,19 @@ def split_before(iterable, pred, maxsplit=-1):
 
 def split_after(iterable, pred, maxsplit=-1):
     """Yield lists of items from *iterable*, where each list ends with an
-    item where callable *pred* returns ``True``.
-    if *maxsplit* is given, at most *maxsplit* splits are done. If *maxsplit*
-    is not specified or -1, then there is no limit on the number of splits:
+    item where callable *pred* returns ``True``:
 
         >>> list(split_after('one1two2', lambda s: s.isdigit()))
         [['o', 'n', 'e', '1'], ['t', 'w', 'o', '2']]
 
         >>> list(split_after(range(10), lambda n: n % 3 == 0))
         [[0], [1, 2, 3], [4, 5, 6], [7, 8, 9]]
+
+    At most *maxsplit* splits are done. If *maxsplit* is not specified or -1,
+    then there is no limit on the number of splits:
+
+        >>> list(split_after(range(10), lambda n: n % 3 == 0, maxsplit=2))
+        [[0], [1, 2, 3], [4, 5, 6, 7, 8, 9]]
 
     """
     buf = []
@@ -1138,7 +1146,7 @@ def split_after(iterable, pred, maxsplit=-1):
         yield buf
 
 
-def split_when(iterable, pred):
+def split_when(iterable, pred, maxsplit=-1):
     """Split *iterable* into pieces based on the output of *pred*.
     *pred* should be a function that takes successive pairs of items and
     returns ``True`` if the iterable should be split in between them.
@@ -1148,6 +1156,14 @@ def split_when(iterable, pred):
 
         >>> list(split_when([1, 2, 3, 3, 2, 5, 2, 4, 2], lambda x, y: x > y))
         [[1, 2, 3, 3], [2, 5], [2, 4], [2]]
+
+    At most *maxsplit* splits are done. If *maxsplit* is not specified or -1,
+    then there is no limit on the number of splits:
+
+        >>> list(split_when([1, 2, 3, 3, 2, 5, 2, 4, 2],
+        ...                 lambda x, y: x > y, maxsplit=2))
+        [[1, 2, 3, 3], [2, 5], [2, 4, 2]]
+
     """
     it = iter(iterable)
     try:
@@ -1157,9 +1173,10 @@ def split_when(iterable, pred):
 
     buf = [cur_item]
     for next_item in it:
-        if pred(cur_item, next_item):
+        if pred(cur_item, next_item) and maxsplit != 0:
             yield buf
             buf = []
+            maxsplit -= 1
 
         buf.append(next_item)
         cur_item = next_item

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -1064,22 +1064,28 @@ def sliced(seq, n):
     return takewhile(len, (seq[i : i + n] for i in count(0, n)))
 
 
-def split_at(iterable, pred):
+def split_at(iterable, pred, maxsplit=-1):
     """Yield lists of items from *iterable*, where each list is delimited by
-    an item where callable *pred* returns ``True``. The lists do not include
-    the delimiting items.
+    an item where callable *pred* returns ``True``. As ``str.split``,
+    if *maxsplit* is given, at most *maxsplit* splits are done. If *maxsplit*
+    is not specified or -1, then there is no limit on the number of splits.
+    The lists do not include the delimiting items.
 
         >>> list(split_at('abcdcba', lambda x: x == 'b'))
         [['a'], ['c', 'd', 'c'], ['a']]
 
         >>> list(split_at(range(10), lambda n: n % 2 == 1))
         [[0], [2], [4], [6], [8], []]
+
+        >>> list(split_at(range(10), lambda n: n % 2 == 1, maxsplit=2))
+        [[0], [2], [4, 5, 6, 7, 8, 9]]
     """
     buf = []
     for item in iterable:
-        if pred(item):
+        if pred(item) and maxsplit != 0:
             yield buf
             buf = []
+            maxsplit -= 1
         else:
             buf.append(item)
     yield buf

--- a/tests/test_more.py
+++ b/tests/test_more.py
@@ -1277,7 +1277,6 @@ class SplitWhenTests(TestCase):
             self.assertEqual(expected, actual, str(args))
 
 
-
 class SplitIntoTests(TestCase):
     """Tests for ``split_into()``"""
 

--- a/tests/test_more.py
+++ b/tests/test_more.py
@@ -1100,16 +1100,16 @@ class SlicedTests(TestCase):
 class SplitAtTests(TestCase):
     """Tests for ``split()``"""
 
-    def comp_with_str_split(self, str_to_split, delim):
+    def comp_with_str_split(self, str_to_split, delim, maxsplit):
         pred = lambda c: c == delim
-        actual = list(map(''.join, mi.split_at(str_to_split, pred)))
-        expected = str_to_split.split(delim)
+        actual = list(map(''.join, mi.split_at(str_to_split, pred, maxsplit)))
+        expected = str_to_split.split(delim, maxsplit)
         self.assertEqual(actual, expected)
 
     def test_seperators(self):
         test_strs = ['', 'abcba', 'aaabbbcccddd', 'e']
-        for s, delim in product(test_strs, 'abcd'):
-            self.comp_with_str_split(s, delim)
+        for s, delim, maxsplit in product(test_strs, 'abcd', range(-1, 4)):
+            self.comp_with_str_split(s, delim, maxsplit)
 
 
 class SplitBeforeTest(TestCase):

--- a/tests/test_more.py
+++ b/tests/test_more.py
@@ -1130,6 +1130,26 @@ class SplitBeforeTest(TestCase):
         expected = [['o', 'o', 'o']]
         self.assertEqual(actual, expected)
 
+    def test_max_split(self):
+        for args, expected in [
+            (('a,b,c,d', lambda c: c == ',', -1),
+             [['a'], [',', 'b'], [',', 'c'], [',', 'd']]),
+            (('a,b,c,d', lambda c: c == ',', 0),
+             [['a', ',', 'b', ',', 'c', ',', 'd']]),
+            (('a,b,c,d', lambda c: c == ',', 1),
+             [['a'], [',', 'b', ',', 'c', ',', 'd']]),
+            (('a,b,c,d', lambda c: c == ',', 2),
+             [['a'], [',', 'b'], [',', 'c', ',', 'd']]),
+            (('a,b,c,d', lambda c: c == ',', 10),
+             [['a'], [',', 'b'], [',', 'c'], [',', 'd']]),
+            (('a,b,c,d', lambda c: c == '@', 2),
+             [['a', ',', 'b', ',', 'c', ',', 'd']]),
+            (('a,b,c,d', lambda c: c != ',', 2),
+             [['a', ','], ['b', ','], ['c', ',', 'd']]),
+        ]:
+            actual = list(mi.split_before(*args))
+            self.assertEqual(expected, actual)
+
 
 class SplitAfterTest(TestCase):
     """Tests for ``split_after()``"""
@@ -1148,6 +1168,26 @@ class SplitAfterTest(TestCase):
         actual = list(mi.split_after('ooo', lambda c: c == 'x'))
         expected = [['o', 'o', 'o']]
         self.assertEqual(actual, expected)
+
+    def test_max_split(self):
+        for args, expected in [
+            (('a,b,c,d', lambda c: c == ',', -1),
+             [['a', ','], ['b', ','], ['c', ','], ['d']]),
+            (('a,b,c,d', lambda c: c == ',', 0),
+             [['a', ',', 'b', ',', 'c', ',', 'd']]),
+            (('a,b,c,d', lambda c: c == ',', 1),
+             [['a', ','], ['b', ',', 'c', ',', 'd']]),
+            (('a,b,c,d', lambda c: c == ',', 2),
+             [['a', ','], ['b', ','], ['c', ',', 'd']]),
+            (('a,b,c,d', lambda c: c == ',', 10),
+             [['a', ','], ['b', ','], ['c', ','], ['d']]),
+            (('a,b,c,d', lambda c: c == '@', 2),
+             [['a', ',', 'b', ',', 'c', ',', 'd']]),
+            (('a,b,c,d', lambda c: c != ',', 2),
+             [['a'], [',', 'b'], [',', 'c', ',', 'd']]),
+        ]:
+            actual = list(mi.split_after(*args))
+            self.assertEqual(expected, actual)
 
 
 class SplitWhenTests(TestCase):

--- a/tests/test_more.py
+++ b/tests/test_more.py
@@ -1254,6 +1254,29 @@ class SplitWhenTests(TestCase):
         expected = [['x']]
         self.assertEqual(actual, expected)
 
+    def test_max_split(self):
+        for args, expected in [
+            (('a,b,c,d', lambda a, _: a == ',', -1),
+             [['a', ','], ['b', ','], ['c', ','], ['d']]),
+            (('a,b,c,d', lambda a, _: a == ',', 0),
+             [['a', ',', 'b', ',', 'c', ',', 'd']]),
+            (('a,b,c,d', lambda _, b: b == ',', 1),
+             [['a'], [',', 'b', ',', 'c', ',', 'd']]),
+            (('a,b,c,d', lambda a, _: a == ',', 2),
+             [['a', ','], ['b', ','], ['c', ',', 'd']]),
+            (('0124376', lambda a, b: a > b, -1),
+             [['0', '1', '2', '4'], ['3', '7'], ['6']]),
+            (('0124376', lambda a, b: a > b, 0),
+             [['0', '1', '2', '4', '3', '7', '6']]),
+            (('0124376', lambda a, b: a > b, 1),
+             [['0', '1', '2', '4'], ['3', '7', '6']]),
+            (('0124376', lambda a, b: a > b, 2),
+             [['0', '1', '2', '4'], ['3', '7'], ['6']]),
+        ]:
+            actual = list(mi.split_when(*args))
+            self.assertEqual(expected, actual, str(args))
+
+
 
 class SplitIntoTests(TestCase):
     """Tests for ``split_into()``"""

--- a/tests/test_more.py
+++ b/tests/test_more.py
@@ -1148,7 +1148,7 @@ class SplitBeforeTest(TestCase):
              [['a', ','], ['b', ','], ['c', ',', 'd']]),
         ]:
             actual = list(mi.split_before(*args))
-            self.assertEqual(expected, actual)
+            self.assertEqual(actual, expected)
 
 
 class SplitAfterTest(TestCase):
@@ -1187,7 +1187,7 @@ class SplitAfterTest(TestCase):
              [['a'], [',', 'b'], [',', 'c', ',', 'd']]),
         ]:
             actual = list(mi.split_after(*args))
-            self.assertEqual(expected, actual)
+            self.assertEqual(actual, expected)
 
 
 class SplitWhenTests(TestCase):
@@ -1274,7 +1274,7 @@ class SplitWhenTests(TestCase):
              [['0', '1', '2', '4'], ['3', '7'], ['6']]),
         ]:
             actual = list(mi.split_when(*args))
-            self.assertEqual(expected, actual, str(args))
+            self.assertEqual(actual, expected, str(args))
 
 
 class SplitIntoTests(TestCase):


### PR DESCRIPTION
See #381. 

The implementation is *very* straightforward, but may not be optimal: when maxplit reaches `0`, we could return a `list(...)` with the iterator. E.g.:

```
def split_at(iterable, pred, maxsplit=-1):
    if maxsplit == 0:
        yield list(iterable)
        return

    buf = []
    it = iter(iterable)
    for item in it:
        if pred(item) and maxsplit != 0:
            yield buf
            if maxsplit == 1: # we want a last chunk.
                yield list(it)
                return
            buf = []
            maxsplit -= 1
        else:
            buf.append(item)
    yield buf
```

It should be faster for very long iterators, but I didn't `timeit`. (All tests pass with this implementation.)